### PR TITLE
Do not add const modifier if user already explicitly added const modifier in @Default() annotations

### DIFF
--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -430,7 +430,7 @@ extension DefaultValue on ParameterElement {
         final source = meta.toSource();
         final res = source.substring('@Default('.length, source.length - 1);
 
-        var needsConstModifier = true;
+        var needsConstModifier = !res.trimLeft().startsWith('const');
         final defaultValue =
             meta.computeConstantValue()?.getField('defaultValue');
         final type = defaultValue?.type;

--- a/packages/freezed/test/integration/single_class_constructor.dart
+++ b/packages/freezed/test/integration/single_class_constructor.dart
@@ -157,5 +157,6 @@ abstract class NullDefault with _$NullDefault {
 @freezed
 abstract class ExplicitConstDefault with _$ExplicitConstDefault {
   //ignore: unnecessary_const
-  factory ExplicitConstDefault([@Default(const <Object>[]) List<Object> value]) = _ExplicitConstDefault;
+  factory ExplicitConstDefault(
+      [@Default(const <Object>[]) List<Object> value]) = _ExplicitConstDefault;
 }

--- a/packages/freezed/test/integration/single_class_constructor.dart
+++ b/packages/freezed/test/integration/single_class_constructor.dart
@@ -153,3 +153,8 @@ abstract class BoolDefault with _$BoolDefault {
 abstract class NullDefault with _$NullDefault {
   factory NullDefault([@Default(null) bool value]) = _NullDefault;
 }
+
+@freezed
+abstract class ExplicitConstDefault with _$ExplicitConstDefault {
+  factory ExplicitConstDefault([@Default(const <Object>[]) List<Object> value]) = _ExplicitConstDefault;
+}

--- a/packages/freezed/test/integration/single_class_constructor.dart
+++ b/packages/freezed/test/integration/single_class_constructor.dart
@@ -156,5 +156,6 @@ abstract class NullDefault with _$NullDefault {
 
 @freezed
 abstract class ExplicitConstDefault with _$ExplicitConstDefault {
+  //ignore: unnecessary_const
   factory ExplicitConstDefault([@Default(const <Object>[]) List<Object> value]) = _ExplicitConstDefault;
 }

--- a/packages/freezed/test/integration/single_class_constructor.dart
+++ b/packages/freezed/test/integration/single_class_constructor.dart
@@ -156,7 +156,7 @@ abstract class NullDefault with _$NullDefault {
 
 @freezed
 abstract class ExplicitConstDefault with _$ExplicitConstDefault {
-  //ignore: unnecessary_const
   factory ExplicitConstDefault(
+      //ignore: unnecessary_const
       [@Default(const <Object>[]) List<Object> value]) = _ExplicitConstDefault;
 }


### PR DESCRIPTION
Sorry for bringing this topic up again, but there's another issue with const modifiers - the current implementation does not check if the user already added the const modifier explicitly, it always adds it, no matter if it's already there or not.

This fixes this (hopefully). I'm not really happy with this code, seems fragile, feel free to improve upon it if you know a better way.