### PR TITLE
Fixed link union/sealed classes in the documentation

### DIFF
--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -196,7 +196,7 @@ abstract class Union<T> with _$Union<T> {
 }
 ```
 
-See [unions/Sealed classes](#unions/sealed-classes) for more information.
+See [unions/Sealed classes](#unionssealed-classes) for more information.
 
 ### Non-nullable
 


### PR DESCRIPTION
This pull request fixed link for union/sealed classes in the documentation.