### PR TITLE
do not create @required annotation for positional arguments #130

### DIFF
--- a/packages/freezed/lib/src/templates/parameter_template.dart
+++ b/packages/freezed/lib/src/templates/parameter_template.dart
@@ -157,11 +157,7 @@ class ParametersTemplate {
 
   @override
   String toString() {
-    final buffer = StringBuffer()
-      ..writeAll(
-          requiredPositionalParameters
-              .map<String>((p) => p.toString(skipRequired: true)),
-          ', ');
+    final buffer = StringBuffer()..writeAll(requiredPositionalParameters, ', ');
 
     if (buffer.isNotEmpty &&
         (optionalPositionalParameters.isNotEmpty ||
@@ -239,13 +235,32 @@ class Parameter {
   final List<String> decorators;
   final bool showDefaultValue;
 
+  Parameter copyWith({
+    String type,
+    String name,
+    String defaultValueSource,
+    bool isRequired,
+    bool nullable,
+    List<String> decorators,
+    bool showDefaultValue,
+  }) =>
+      Parameter(
+        type: type ?? this.type,
+        name: name ?? this.name,
+        defaultValueSource: defaultValueSource ?? this.defaultValueSource,
+        isRequired: isRequired ?? this.isRequired,
+        nullable: nullable ?? this.nullable,
+        decorators: decorators ?? this.decorators,
+        showDefaultValue: showDefaultValue ?? this.showDefaultValue,
+      );
+
   @override
-  String toString({bool skipRequired = false}) {
+  String toString() {
     var res = '${decorators.join()}  ${type ?? 'dynamic'} $name';
     if (showDefaultValue && defaultValueSource != null) {
       res = '$res = $defaultValueSource';
     }
-    return isRequired && !skipRequired ? '@required $res' : res;
+    return isRequired ? '@required $res' : res;
   }
 }
 
@@ -268,12 +283,12 @@ class LocalParameter extends Parameter {
         );
 
   @override
-  String toString({bool skipRequired = false}) {
+  String toString() {
     var res = '${decorators.join()} this.$name';
     if (showDefaultValue && defaultValueSource != null) {
       res = '$res = $defaultValueSource';
     }
-    return isRequired && !skipRequired ? '@required $res' : res;
+    return isRequired ? '@required $res' : res;
   }
 }
 
@@ -299,8 +314,8 @@ class CallbackParameter extends Parameter {
   final ParametersTemplate parameters;
 
   @override
-  String toString({bool skipRequired = false}) {
+  String toString() {
     var res = '${decorators.join()} $type $name($parameters)';
-    return isRequired && !skipRequired ? '@required $res' : res;
+    return isRequired ? '@required $res' : res;
   }
 }

--- a/packages/freezed/lib/src/templates/parameter_template.dart
+++ b/packages/freezed/lib/src/templates/parameter_template.dart
@@ -157,7 +157,11 @@ class ParametersTemplate {
 
   @override
   String toString() {
-    final buffer = StringBuffer()..writeAll(requiredPositionalParameters, ', ');
+    final buffer = StringBuffer()
+      ..writeAll(
+          requiredPositionalParameters
+              .map<String>((p) => p.toString(skipRequired: true)),
+          ', ');
 
     if (buffer.isNotEmpty &&
         (optionalPositionalParameters.isNotEmpty ||
@@ -236,12 +240,12 @@ class Parameter {
   final bool showDefaultValue;
 
   @override
-  String toString() {
+  String toString({bool skipRequired = false}) {
     var res = '${decorators.join()}  ${type ?? 'dynamic'} $name';
     if (showDefaultValue && defaultValueSource != null) {
       res = '$res = $defaultValueSource';
     }
-    return isRequired ? '@required $res' : res;
+    return isRequired && !skipRequired ? '@required $res' : res;
   }
 }
 
@@ -264,12 +268,12 @@ class LocalParameter extends Parameter {
         );
 
   @override
-  String toString() {
+  String toString({bool skipRequired = false}) {
     var res = '${decorators.join()} this.$name';
     if (showDefaultValue && defaultValueSource != null) {
       res = '$res = $defaultValueSource';
     }
-    return isRequired ? '@required $res' : res;
+    return isRequired && !skipRequired ? '@required $res' : res;
   }
 }
 
@@ -295,8 +299,8 @@ class CallbackParameter extends Parameter {
   final ParametersTemplate parameters;
 
   @override
-  String toString() {
+  String toString({bool skipRequired = false}) {
     var res = '${decorators.join()} $type $name($parameters)';
-    return isRequired ? '@required $res' : res;
+    return isRequired && !skipRequired ? '@required $res' : res;
   }
 }

--- a/packages/freezed/lib/src/templates/prototypes.dart
+++ b/packages/freezed/lib/src/templates/prototypes.dart
@@ -109,7 +109,8 @@ String _whenPrototype(
       return ParametersTemplate([
         ...constructor.parameters.requiredPositionalParameters,
         ...constructor.parameters.optionalPositionalParameters,
-        ...constructor.parameters.namedParameters,
+        ...constructor.parameters.namedParameters
+            .map((e) => e.copyWith(isRequired: false)),
       ]);
     },
   );

--- a/packages/freezed/test/integration/multiple_constructors.dart
+++ b/packages/freezed/test/integration/multiple_constructors.dart
@@ -38,3 +38,10 @@ abstract class Recursive with _$Recursive {
   factory Recursive() = RecursiveImpl;
   factory Recursive.next(RecursiveImpl value) = _RecursiveNext;
 }
+
+@freezed
+abstract class RequiredParams with _$RequiredParams {
+  const factory RequiredParams({@required String a}) = RequiredParams0;
+  const factory RequiredParams.second({@required String a}) = RequiredParams1;
+  const factory RequiredParams.third({@required String b}) = RequiredParams2;
+}

--- a/packages/freezed/test/integration/multiple_constructors.dart
+++ b/packages/freezed/test/integration/multiple_constructors.dart
@@ -43,5 +43,4 @@ abstract class Recursive with _$Recursive {
 abstract class RequiredParams with _$RequiredParams {
   const factory RequiredParams({@required String a}) = RequiredParams0;
   const factory RequiredParams.second({@required String a}) = RequiredParams1;
-  const factory RequiredParams.third({@required String b}) = RequiredParams2;
 }

--- a/packages/freezed/test/map_test.dart
+++ b/packages/freezed/test/map_test.dart
@@ -312,7 +312,7 @@ import 'multiple_constructors.dart';
 void main() {
   final value = RequiredParams(a: 'a');
 
-  value.when((a) => a, second: (b) => b, third: (c) => c);
+  value.when((a) => a, second: (b) => b);
 }
 
 void redundant(@required String test) {


### PR DESCRIPTION
Hi,
I have a possible fix for #130 - this creates:

for:
```
@freezed
abstract class RequiredParams with _$RequiredParams {
  const factory RequiredParams({@required String a}) = RequiredParams0;
  const factory RequiredParams.second({@required String a}) = RequiredParams1;
  const factory RequiredParams.third({@required String b}) = RequiredParams2;
}
```

now:
```
  @override
  @optionalTypeArgs
  Result when<Result extends Object>(
    Result $default(String a), {
    @required Result second(String a),
    @required Result third(String b),
  }) {
    assert($default != null);
    assert(second != null);
    assert(third != null);
    return second(a);
  }
```

instead of:
```
  @override
  @optionalTypeArgs
  Result when<Result extends Object>(
    Result $default(@required String a), {
    @required Result second(@required String a),
    @required Result third(@required String b),
  }) {
    assert($default != null);
    assert(second != null);
    assert(third != null);
    return second(a);
  }
```

I have simply passed an option into the `toString` method of whether `isRequired` should be appended. I guess another option would be to implement it similarly to `showDefaultValue` as a property for the Parameter - but i did not quite understand what the `asExpanded` means - which seems to be the method which modifies the `showDefaultValue` property. And I felt it a bit cleaner to make this as a "render" argument.. because the Parameter is still required, it's just rendered as position argument instead of and named argument?