### PR TITLE
Fix == returning false for classes with other prop

### DIFF
--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -299,7 +299,7 @@ String toString($parameters) {
 
   String get _operatorEqualMethod {
     final properties = constructor.impliedProperties.map((p) {
-      return '(identical(other.${p.name}, ${p.name}) || const DeepCollectionEquality().equals(other.${p.name}, ${p.name}))';
+      return '(identical(other.${p.name}, this.${p.name}) || const DeepCollectionEquality().equals(other.${p.name}, this.${p.name}))';
     });
 
     return '''

--- a/packages/freezed/test/equal_test.dart
+++ b/packages/freezed/test/equal_test.dart
@@ -139,4 +139,8 @@ void main() {
       GenericIterable([1]),
     );
   });
+  test('ObjectWithOtherProperty', () {
+    expect(ObjectWithOtherProperty(1), ObjectWithOtherProperty(1));
+    expect(ObjectWithOtherProperty(1), isNot(ObjectWithOtherProperty(2)));
+  });
 }

--- a/packages/freezed/test/equal_test.dart
+++ b/packages/freezed/test/equal_test.dart
@@ -140,7 +140,12 @@ void main() {
     );
   });
   test('ObjectWithOtherProperty', () {
-    expect(ObjectWithOtherProperty(1), ObjectWithOtherProperty(1));
-    expect(ObjectWithOtherProperty(1), isNot(ObjectWithOtherProperty(2)));
+    expect(ObjectWithOtherProperty(const [2, 3]),
+        ObjectWithOtherProperty(const [2, 3]));
+    expect(ObjectWithOtherProperty(const [2, 3]),
+        isNot(ObjectWithOtherProperty(const [2, 4])));
+    expect(ObjectWithOtherProperty([1, 2]), ObjectWithOtherProperty([1, 2]));
+    expect(
+        ObjectWithOtherProperty([1, 2]), isNot(ObjectWithOtherProperty([1])));
   });
 }

--- a/packages/freezed/test/integration/equal.dart
+++ b/packages/freezed/test/integration/equal.dart
@@ -62,3 +62,8 @@ abstract class GenericIterable<T extends Iterable<dynamic>>
     with _$GenericIterable<T> {
   factory GenericIterable(T value) = _GenericIterable<T>;
 }
+
+@freezed
+abstract class ObjectWithOtherProperty with _$ObjectWithOtherProperty {
+  factory ObjectWithOtherProperty(int other) = _ObjectWithOtherProperty;
+}

--- a/packages/freezed/test/integration/equal.dart
+++ b/packages/freezed/test/integration/equal.dart
@@ -65,5 +65,5 @@ abstract class GenericIterable<T extends Iterable<dynamic>>
 
 @freezed
 abstract class ObjectWithOtherProperty with _$ObjectWithOtherProperty {
-  factory ObjectWithOtherProperty(int other) = _ObjectWithOtherProperty;
+  factory ObjectWithOtherProperty(List<int> other) = _ObjectWithOtherProperty;
 }


### PR DESCRIPTION
Fixes #138.

By the way, one of the tests is failing mysteriously on my machine, specifically this one:
```
00:46 +127 -1: test/multiple_constructors_test.dart: tear off [E]
  Expected: Type:<(String, {int b}) => NoCommonParam0>
    Actual: Type:<(String, {int b}) => NoCommonParam0>

  package:test_api                           expect
  test/multiple_constructors_test.dart 41:5  main.<fn>
```
This test fails even on `master`. Is it only happening with me, or are others also having this issue?