### PR TITLE
Sync @JsonKey options with freezed decorators

### DIFF
--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -312,7 +312,7 @@ class FreezedGenerator extends ParserGenerator<_GlobalData, Data, Freezed> {
                 nullable: p.nullable,
                 defaultValueSource: p.defaultValueSource,
                 // TODO: support hasJsonKey
-                hasJsonKey: false,
+                // hasJsonKey: false,
               ))
           .toList(),
       needsJsonSerializable: globalData.hasJson &&


### PR DESCRIPTION
Hi @rrousselGit , 

Our team has run into some issues where the freezed annotations that we define sometimes either clash with the default `@JsonKey` settings we get, or we're forced to duplicate some semantics around how we want our models to operate.

For example:
```dart
class User with _$User {
 	factory User({
		@required @JsonKey(required: true, disallowNullValues: true) name,
		@nullable @JsonKey(disallowNullValues: false) phoneNumber,
	}) = _User;
}
```

It would be great if we could look at the `@required` and `@nullable` annotations and make sure that the options set on `@JsonKey` also reflect those settings.

I took a stab at this, would love to know your thoughts!