### PR TITLE
naive regex for generics referencing codegen types

### DIFF
--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -471,7 +471,7 @@ extension DefaultValue on ParameterElement {
 String parseTypeSource(VariableElement element) {
   var type = element.type?.getDisplayString();
 
-  if (type == null || type.contains('dynamic')) {
+  if (type == null || type == 'dynamic') {
     if (element.type?.element != null &&
         element.type.isDynamic &&
         element.type.element.isSynthetic) {
@@ -482,7 +482,7 @@ String parseTypeSource(VariableElement element) {
     } else if (element.type?.element != null) {
       final source =
           element.source.contents.data.substring(0, element.nameOffset);
-      final match = RegExp(r'(\w+<\w+>)\s+$').firstMatch(source);
+      final match = RegExp(r'(\w+<.+?>)\s+$').firstMatch(source);
       type = match?.group(1);
     }
   }

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -447,13 +447,18 @@ extension DefaultValue on ParameterElement {
 String parseTypeSource(VariableElement element) {
   var type = element.type?.getDisplayString();
 
-  if (type == null || type == 'dynamic') {
+  if (type == null || type.contains('dynamic')) {
     if (element.type?.element != null &&
         element.type.isDynamic &&
         element.type.element.isSynthetic) {
       final source =
           element.source.contents.data.substring(0, element.nameOffset);
       final match = RegExp(r'(\w+)\s+$').firstMatch(source);
+      type = match?.group(1);
+    } else if (element.type?.element != null) {
+      final source =
+          element.source.contents.data.substring(0, element.nameOffset);
+      final match = RegExp(r'(\w+<\w+>)\s+$').firstMatch(source);
       type = match?.group(1);
     }
   }

--- a/packages/freezed/test/generics_refs_test.dart
+++ b/packages/freezed/test/generics_refs_test.dart
@@ -1,6 +1,7 @@
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
+import 'common.dart';
 import 'integration/generics_refs.dart';
 
 void main() {
@@ -19,20 +20,46 @@ void main() {
     expect(errorResult.errors, isEmpty);
   });
 
-  test('correct generic type generated for constructor and copyWith', () {
-    final header = const Header(title: 'test');
+  test('handles lists', () async {
     final page = const Page();
-    expect(header is Header, true);
-    var fapp = FApp(head: header, pages: []);
-    expect(
-      fapp.pages is List<Page>,
-      true,
-    );
 
-    fapp = fapp.copyWith(pages: [page]);
-    expect(
-      fapp.pages is List<Page>,
-      true,
-    );
+    expect(PageList([page]).pages, [page]);
+
+    await expectLater(compile(r'''
+import 'generics_refs.dart';
+
+void main() {
+  const page = Page();
+  PageList([page]);
+}
+'''), completes);
+    await expectLater(compile(r'''
+import 'generics_refs.dart';
+
+void main() {
+  PageList([42]);
+}
+'''), throwsCompileError);
+  });
+  test('handles maps', () async {
+    final page = const Page();
+
+    expect(PageMap({'foo': page}).pages, {'foo': page});
+
+    await expectLater(compile(r'''
+import 'generics_refs.dart';
+
+void main() {
+  const page = Page();
+  PageMap({'foo': page});
+}
+'''), completes);
+    await expectLater(compile(r'''
+import 'generics_refs.dart';
+
+void main() {
+  PageMap({'foo': 42});
+}
+'''), throwsCompileError);
   });
 }

--- a/packages/freezed/test/generics_refs_test.dart
+++ b/packages/freezed/test/generics_refs_test.dart
@@ -1,0 +1,38 @@
+import 'package:build_test/build_test.dart';
+import 'package:test/test.dart';
+
+import 'integration/generics_refs.dart';
+
+void main() {
+  test('has no issue', () async {
+    final main = await resolveSources(
+      {
+        'freezed|test/integration/generics_refs.dart': useAssetReader,
+      },
+      (r) => r.libraries.firstWhere(
+          (element) => element.source.toString().contains('generics_refs')),
+    );
+
+    final errorResult = await main.session
+        .getErrors('/freezed/test/integration/generics_refs.freezed.dart');
+
+    expect(errorResult.errors, isEmpty);
+  });
+
+  test('correct generic type generated for constructor and copyWith', () {
+    final header = const WidgetType.header(title: 'test');
+    final page = const WidgetType.page();
+    expect(header is Header, true);
+    var fapp = FApp(head: header as Header, pages: []);
+    expect(
+      fapp.pages is List<Page>,
+      true,
+    );
+
+    fapp = fapp.copyWith(pages: [page as Page]);
+    expect(
+      fapp.pages is List<Page>,
+      true,
+    );
+  });
+}

--- a/packages/freezed/test/generics_refs_test.dart
+++ b/packages/freezed/test/generics_refs_test.dart
@@ -20,16 +20,16 @@ void main() {
   });
 
   test('correct generic type generated for constructor and copyWith', () {
-    final header = const WidgetType.header(title: 'test');
-    final page = const WidgetType.page();
+    final header = const Header(title: 'test');
+    final page = const Page();
     expect(header is Header, true);
-    var fapp = FApp(head: header as Header, pages: []);
+    var fapp = FApp(head: header, pages: []);
     expect(
       fapp.pages is List<Page>,
       true,
     );
 
-    fapp = fapp.copyWith(pages: [page as Page]);
+    fapp = fapp.copyWith(pages: [page]);
     expect(
       fapp.pages is List<Page>,
       true,

--- a/packages/freezed/test/integration/generics_refs.dart
+++ b/packages/freezed/test/integration/generics_refs.dart
@@ -3,13 +3,16 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'generics_refs.freezed.dart';
 
 @freezed
-abstract class FApp with _$FApp {
-  factory FApp({Header head, List<Page> pages}) = _FApp;
+abstract class PageList with _$PageList {
+  factory PageList(List<Page> pages) = _PageList;
+}
+
+@freezed
+abstract class PageMap with _$PageMap {
+  factory PageMap(Map<String, Page> pages) = _PageMap;
 }
 
 @freezed
 abstract class WidgetType with _$WidgetType {
-  const factory WidgetType.page({Body body, Header header}) = Page;
-  const factory WidgetType.body() = Body;
-  const factory WidgetType.header({String title}) = Header;
+  const factory WidgetType.page() = Page;
 }

--- a/packages/freezed/test/integration/generics_refs.dart
+++ b/packages/freezed/test/integration/generics_refs.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'generics_refs.freezed.dart';
+
+@freezed
+abstract class FApp with _$FApp {
+  factory FApp({Header head, List<Page> pages}) = _FApp;
+}
+
+@freezed
+abstract class WidgetType with _$WidgetType {
+  const factory WidgetType.page({Body body, Header header}) = Page;
+  const factory WidgetType.body() = Body;
+  const factory WidgetType.header({String title}) = Header;
+}


### PR DESCRIPTION
This expands a little the extra processing for types that the analyzer has incorrectly classified as `dynamic` because they are defined in code generated files to include single level generics, primarily intended to handle the use case of `Maps` and `Lists` of freezed generated union types.