### PR TITLE
Replace dynamic type for nested generics

### DIFF
--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -485,6 +485,34 @@ String parseTypeSource(VariableElement element) {
       final match = RegExp(r'(\w+<.+?>)\s+$').firstMatch(source);
       type = match?.group(1);
     }
+  } else if (type.contains('dynamic')) {
+    type = _parseNestedTypeSource(type, element);
   }
   return type;
+}
+
+String _parseNestedTypeSource(String fallbakcType, VariableElement element) {
+  const delimiter = ' ';
+  final enclosingElementList =
+      element.enclosingElement.toString().split(RegExp(delimiter));
+  if (enclosingElementList.length < 2) {
+    return fallbakcType;
+  }
+
+  final pattern = RegExp.escape(enclosingElementList
+          .sublist(1, enclosingElementList.length)
+          .join(delimiter))
+      .replaceAll('dynamic', '.*');
+  final source = element.source.contents.data;
+  final lineMatch = RegExp(pattern).firstMatch(source);
+  if (lineMatch == null) {
+    return fallbakcType;
+  }
+
+  final typeMatch = RegExp(r'\((.+)\s+\w+\)').firstMatch(lineMatch.group(0));
+  if (typeMatch == null) {
+    return fallbakcType;
+  }
+
+  return typeMatch.group(1);
 }

--- a/packages/freezed/test/integration/multiple_constructors.dart
+++ b/packages/freezed/test/integration/multiple_constructors.dart
@@ -44,3 +44,32 @@ abstract class RequiredParams with _$RequiredParams {
   const factory RequiredParams({@required String a}) = RequiredParams0;
   const factory RequiredParams.second({@required String a}) = RequiredParams1;
 }
+
+@freezed
+abstract class NestedList with _$NestedList {
+  factory NestedList.shallow(List<LeafNestedListItem> children) =
+      ShallowNestedList;
+  factory NestedList.deep(List<InnerNestedListItem> children) = DeepNestedList;
+}
+
+@freezed
+abstract class NestedListItem with _$NestedListItem {
+  factory NestedListItem.leaf() = LeafNestedListItem;
+  factory NestedListItem.inner(List<LeafNestedListItem> children) =
+      InnerNestedListItem;
+}
+
+@freezed
+abstract class NestedMap with _$NestedMap {
+  factory NestedMap.shallow(Map<String, LeafNestedMapItem> children) =
+      ShallowNestedMap;
+  factory NestedMap.deep(Map<String, InnerNestedMapItem> children) =
+      DeepNestedMap;
+}
+
+@freezed
+abstract class NestedMapItem with _$NestedMapItem {
+  factory NestedMapItem.leaf() = LeafNestedMapItem;
+  factory NestedMapItem.inner(Map<String, LeafNestedMapItem> children) =
+      InnerNestedMapItem;
+}

--- a/packages/freezed/test/multiple_constructors_test.dart
+++ b/packages/freezed/test/multiple_constructors_test.dart
@@ -19,17 +19,7 @@ typedef NoCommonParamNamedTearOff = NoCommonParam1 Function(
 
 void main() {
   test('recursive class does not generate dynamic', () async {
-    final sources = await resolveSources(
-      {'freezed|test/integration/multiple_constructors.dart': useAssetReader},
-      (r) {
-        return r.libraries.firstWhere((element) =>
-            element.source.toString().contains('multiple_constructors'));
-      },
-    );
-
-    final recursiveClass = sources.topLevelElements
-        .whereType<ClassElement>()
-        .firstWhere((element) => element.name == '_RecursiveNext');
+    final recursiveClass = await _getClassElement('_RecursiveNext');
 
     expect(recursiveClass.getField('value').type.isDynamic, isFalse);
   });
@@ -289,4 +279,57 @@ void main() {
       error,
     );
   });
+  group('NestedList', () {
+    test('does not generate dynamic', () async {
+      final nestedListClass = await _getClassElement('ShallowNestedList');
+
+      expect(nestedListClass.getField('children').type.getDisplayString(),
+          'List<LeafNestedListItem>');
+    });
+
+    test('does not generate dynamic for deep nested case', () async {
+      final nestedListClass = await _getClassElement('DeepNestedList');
+
+      expect(nestedListClass.getField('children').type.getDisplayString(),
+          'List<InnerNestedListItem>');
+
+      final nestedListItemClass = await _getClassElement('InnerNestedListItem');
+
+      expect(nestedListItemClass.getField('children').type.getDisplayString(),
+          'List<LeafNestedListItem>');
+    });
+  });
+  group('NestedMap', () {
+    test('does not generate dynamic', () async {
+      final nestedMapClass = await _getClassElement('ShallowNestedMap');
+
+      expect(nestedMapClass.getField('children').type.getDisplayString(),
+          'Map<String, LeafNestedMapItem>');
+    });
+
+    test('does not generate dynamic for deep nested case', () async {
+      final nestedMapClass = await _getClassElement('DeepNestedMap');
+
+      expect(nestedMapClass.getField('children').type.getDisplayString(),
+          'Map<String, InnerNestedMapItem>');
+
+      final nestedMapItemClass = await _getClassElement('InnerNestedMapItem');
+
+      expect(nestedMapItemClass.getField('children').type.getDisplayString(),
+          'Map<String, LeafNestedMapItem>');
+    });
+  });
+}
+
+Future<ClassElement> _getClassElement(String elementName) async {
+  final sources = await resolveSources(
+    {'freezed|test/integration/multiple_constructors.dart': useAssetReader},
+    (r) {
+      return r.libraries.firstWhere((element) =>
+          element.source.toString().contains('multiple_constructors'));
+    },
+  );
+  return sources.topLevelElements
+      .whereType<ClassElement>()
+      .firstWhere((element) => element.name == elementName);
 }


### PR DESCRIPTION
Following code generates `dynamic`. This changes replace `dynamic` types to expected classes.

```
@freezed
abstract class NestedList with _$NestedList {
  factory NestedList.shallow(List<LeafNestedListItem> children) =
      ShallowNestedList;
  factory NestedList.deep(List<InnerNestedListItem> children) = DeepNestedList;
}

@freezed
abstract class NestedListItem with _$NestedListItem {
  factory NestedListItem.leaf() = LeafNestedListItem;
  factory NestedListItem.inner(List<LeafNestedListItem> children) =
      InnerNestedListItem;
}
```

## Before this change

```
class _$ShallowNestedList implements ShallowNestedList {
  _$ShallowNestedList(this.children) : assert(children != null);

  @override
  final List<dynamic> children;

...
```

## After this change

```
class _$ShallowNestedList implements ShallowNestedList {
  _$ShallowNestedList(this.children) : assert(children != null);

  @override
  final List<LeafNestedListItem> children;

...
```

Similar with https://github.com/rrousselGit/freezed/pull/196