### PR TITLE
Ignore always_specify_types

### DIFF
--- a/packages/freezed/lib/builder.dart
+++ b/packages/freezed/lib/builder.dart
@@ -8,6 +8,6 @@ Builder freezed(BuilderOptions options) {
   return PartBuilder([FreezedGenerator()], '.freezed.dart',
       header: '''
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
+// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, always_specify_types
     ''');
 }


### PR DESCRIPTION
Ignore always_specify_types lint in the generated code.

We have always_specify_types turned on and the library will fail our CI without this.