### PR TITLE
DiagnosticableTreeMixin related code still generated when foundation.dart is not imported

### DIFF
--- a/packages/freezed/example/lib/time_slot.dart
+++ b/packages/freezed/example/lib/time_slot.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'time_slot.freezed.dart';
+
+@freezed
+
+/// This is class has been added to address the issue described in
+/// https://github.com/rrousselGit/freezed/issues/220
+abstract class TimeSlot with _$TimeSlot {
+  factory TimeSlot({
+    TimeOfDay start,
+    TimeOfDay end,
+  }) = _TimeSlot;
+}

--- a/packages/freezed/example/lib/time_slot.freezed.dart
+++ b/packages/freezed/example/lib/time_slot.freezed.dart
@@ -82,7 +82,7 @@ class __$TimeSlotCopyWithImpl<$Res> extends _$TimeSlotCopyWithImpl<$Res>
   }
 }
 
-class _$_TimeSlot with DiagnosticableTreeMixin implements _TimeSlot {
+class _$_TimeSlot implements _TimeSlot {
   _$_TimeSlot({this.start, this.end});
 
   @override
@@ -91,17 +91,8 @@ class _$_TimeSlot with DiagnosticableTreeMixin implements _TimeSlot {
   final TimeOfDay end;
 
   @override
-  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+  String toString() {
     return 'TimeSlot(start: $start, end: $end)';
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties
-      ..add(DiagnosticsProperty('type', 'TimeSlot'))
-      ..add(DiagnosticsProperty('start', start))
-      ..add(DiagnosticsProperty('end', end));
   }
 
   @override

--- a/packages/freezed/example/lib/time_slot.freezed.dart
+++ b/packages/freezed/example/lib/time_slot.freezed.dart
@@ -1,0 +1,137 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
+
+part of 'time_slot.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+class _$TimeSlotTearOff {
+  const _$TimeSlotTearOff();
+
+  _TimeSlot call({TimeOfDay start, TimeOfDay end}) {
+    return _TimeSlot(
+      start: start,
+      end: end,
+    );
+  }
+}
+
+// ignore: unused_element
+const $TimeSlot = _$TimeSlotTearOff();
+
+mixin _$TimeSlot {
+  TimeOfDay get start;
+  TimeOfDay get end;
+
+  $TimeSlotCopyWith<TimeSlot> get copyWith;
+}
+
+abstract class $TimeSlotCopyWith<$Res> {
+  factory $TimeSlotCopyWith(TimeSlot value, $Res Function(TimeSlot) then) =
+      _$TimeSlotCopyWithImpl<$Res>;
+  $Res call({TimeOfDay start, TimeOfDay end});
+}
+
+class _$TimeSlotCopyWithImpl<$Res> implements $TimeSlotCopyWith<$Res> {
+  _$TimeSlotCopyWithImpl(this._value, this._then);
+
+  final TimeSlot _value;
+  // ignore: unused_field
+  final $Res Function(TimeSlot) _then;
+
+  @override
+  $Res call({
+    Object start = freezed,
+    Object end = freezed,
+  }) {
+    return _then(_value.copyWith(
+      start: start == freezed ? _value.start : start as TimeOfDay,
+      end: end == freezed ? _value.end : end as TimeOfDay,
+    ));
+  }
+}
+
+abstract class _$TimeSlotCopyWith<$Res> implements $TimeSlotCopyWith<$Res> {
+  factory _$TimeSlotCopyWith(_TimeSlot value, $Res Function(_TimeSlot) then) =
+      __$TimeSlotCopyWithImpl<$Res>;
+  @override
+  $Res call({TimeOfDay start, TimeOfDay end});
+}
+
+class __$TimeSlotCopyWithImpl<$Res> extends _$TimeSlotCopyWithImpl<$Res>
+    implements _$TimeSlotCopyWith<$Res> {
+  __$TimeSlotCopyWithImpl(_TimeSlot _value, $Res Function(_TimeSlot) _then)
+      : super(_value, (v) => _then(v as _TimeSlot));
+
+  @override
+  _TimeSlot get _value => super._value as _TimeSlot;
+
+  @override
+  $Res call({
+    Object start = freezed,
+    Object end = freezed,
+  }) {
+    return _then(_TimeSlot(
+      start: start == freezed ? _value.start : start as TimeOfDay,
+      end: end == freezed ? _value.end : end as TimeOfDay,
+    ));
+  }
+}
+
+class _$_TimeSlot with DiagnosticableTreeMixin implements _TimeSlot {
+  _$_TimeSlot({this.start, this.end});
+
+  @override
+  final TimeOfDay start;
+  @override
+  final TimeOfDay end;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'TimeSlot(start: $start, end: $end)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'TimeSlot'))
+      ..add(DiagnosticsProperty('start', start))
+      ..add(DiagnosticsProperty('end', end));
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _TimeSlot &&
+            (identical(other.start, start) ||
+                const DeepCollectionEquality().equals(other.start, start)) &&
+            (identical(other.end, end) ||
+                const DeepCollectionEquality().equals(other.end, end)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(start) ^
+      const DeepCollectionEquality().hash(end);
+
+  @override
+  _$TimeSlotCopyWith<_TimeSlot> get copyWith =>
+      __$TimeSlotCopyWithImpl<_TimeSlot>(this, _$identity);
+}
+
+abstract class _TimeSlot implements TimeSlot {
+  factory _TimeSlot({TimeOfDay start, TimeOfDay end}) = _$_TimeSlot;
+
+  @override
+  TimeOfDay get start;
+  @override
+  TimeOfDay get end;
+  @override
+  _$TimeSlotCopyWith<_TimeSlot> get copyWith;
+}

--- a/packages/freezed/example/test/diagnosticable_test.dart
+++ b/packages/freezed/example/test/diagnosticable_test.dart
@@ -1,8 +1,9 @@
-import 'package:flutter/foundation.dart';
-import 'package:flutter_test/flutter_test.dart';
-
 import 'package:example/diagnosticable.dart' as diagnosticable;
 import 'package:example/non_diagnosticable.dart' as non_diagnosticable;
+import 'package:example/time_slot.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('use Diagnosticable instead of toString if possible', () {
@@ -57,5 +58,13 @@ void main() {
     value = non_diagnosticable.Example.named(42);
     expect(value, isNot(isA<DiagnosticableTree>()));
     expect(value.toString(), 'Example<int>.named(c: 42)');
+  });
+  test('timeslot is not Diagnosticable', () {
+    final timeslot = TimeSlot(
+      start: const TimeOfDay(hour: 10, minute: 30),
+      end: const TimeOfDay(hour: 12, minute: 45),
+    );
+
+    expect(timeslot, isNot(isA<DiagnosticableTree>()));
   });
 }

--- a/packages/freezed/lib/src/tools/recursive_import_locator.dart
+++ b/packages/freezed/lib/src/tools/recursive_import_locator.dart
@@ -1,0 +1,60 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:meta/meta.dart';
+
+typedef ExportPredicate = bool Function(Element);
+typedef LibraryPredicate = bool Function(LibraryElement);
+
+ExportPredicate isClass(String className) {
+  return (element) => element is ClassElement && element.name == className;
+}
+
+ExportPredicate isWithin(String libraryRootName) {
+  return (element) =>
+      element.librarySource.fullName.startsWith('/$libraryRootName/');
+}
+
+class RecursiveImportLocator {
+  const RecursiveImportLocator();
+
+  bool hasImport({
+    @required LibraryElement root,
+    @required ExportPredicate where,
+    LibraryPredicate whereLibrary,
+  }) {
+    return root.importedLibraries.any((lib) => _doesExportRecursively(
+          library: lib,
+          where: where,
+          whereLibrary: whereLibrary,
+        ));
+  }
+
+  bool _doesExportRecursively({
+    @required LibraryElement library,
+    @required ExportPredicate where,
+    LibraryPredicate whereLibrary,
+  }) {
+    assert(library != null);
+    assert(where != null);
+
+    if (whereLibrary?.call(library) ?? true) {
+      if (library.topLevelElements.any(where)) {
+        return true;
+      }
+    }
+
+    return library.exportedLibraries.any((export) {
+      final shouldContinueRecursion = whereLibrary?.call(export) ?? true;
+
+      if (shouldContinueRecursion) {
+        return shouldContinueRecursion &&
+            _doesExportRecursively(
+              library: export,
+              where: where,
+              whereLibrary: whereLibrary,
+            );
+      } else {
+        return false;
+      }
+    });
+  }
+}

--- a/packages/freezed/lib/src/tools/recursive_import_locator.dart
+++ b/packages/freezed/lib/src/tools/recursive_import_locator.dart
@@ -50,7 +50,7 @@ class RecursiveImportLocator {
     }
 
     return library.exportedLibraries.any((export) {
-      return library.isRelevant(whereLibrary) &&
+      return export.isRelevant(whereLibrary) &&
           _doesExportRecursively(
             library: export,
             where: where,


### PR DESCRIPTION
Hey Remi,

first of all thanks for this awesome library :tada: 

I wanted to get a deeper understanding of the internals of freezed and thus I considered to fix a bug or two... So I picked #220, which you labeled as a good starting point. _(honestly, it was trickier than I expected it to be in the first place)_

The problem with the current implementation is that `_libraryHasElement` searches recursively for any exported classes within the imports, but it does not take the `show` and `hide` keyword into account. 
I moved `_libraryHasElement` into a separate class `RecursiveImportLocator` and added some logic to consider `show` and `hide`. It's quite a simple approach and I might have overlooked some edge case, but at least for the described issue it works :wink: 

I hope this PR is fine for you and I'm curious about your feedback :slightly_smiling_face: 

Best regards,
Alex

@skybur @rrousselGit  