### PR TITLE
Add links to the required dependencies

### DIFF
--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -88,9 +88,9 @@ dev_dependencies:
 
 This installs three packages:
 
-- build_runner, the tool to run code-generators
+- [build_runner](https://pub.dev/packages/build_runner), the tool to run code-generators
 - [freezed], the code generator
-- freezed_annotation, a package containing annotations for [freezed].
+- [freezed_annotation](https://pub.dev/packages/freezed_annotation), a package containing annotations for [freezed].
 
 ## Run the generator
 


### PR DESCRIPTION
This makes it easier to navigate to the packages and check their latest version when adding them to pubspec