### PR TITLE
Improve pub points

### DIFF
--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -1,6 +1,6 @@
-export "package:collection/collection.dart";
-export "package:json_annotation/json_annotation.dart";
-export "package:meta/meta.dart";
+export 'package:collection/collection.dart';
+export 'package:json_annotation/json_annotation.dart';
+export 'package:meta/meta.dart';
 
 class Freezed {
   const Freezed._();


### PR DESCRIPTION
Should comply with "Only use double quotes for strings containing single quotes." requirement, which was leading to a 10 point deduction to the pub score.