### PR TITLE
Added example of how to apply json custom converter in freezed documentation

### DIFF
--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -1083,6 +1083,8 @@ abstract class MyModel with _$MyModel {
 }
 ```
 
+**Note**: In order to serialize nested lists of freezed objects, you are supposed to either specify a `@JsonSerializable(explicitToJson: true)` or change `explicitToJson` inside your `build.yaml` file ([see the documentation](https://github.com/google/json_serializable.dart/tree/master/json_serializable#build-configuration)).
+
 **What about `@JsonKey` annotation?**
 
 All decorators passed to a constructor parameter are "copy-pasted" to the generated property too.\

--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -1083,7 +1083,7 @@ abstract class MyModel with _$MyModel {
 }
 ```
 
-**Note**: In order to serialize nested lists of freezed objects, you are supposed to either specify a `@JsonSerializable(explicitToJson: true)` or change `explicitToJson` inside your `build.yaml` file ([see the documentation](https://github.com/google/json_serializable.dart/tree/master/json_serializable#build-configuration)).
+**Note**: In order to serialize nested lists of freezed objects, you are supposed to either specify a `@JsonSerializable(explicitToJson: true)` or change `explicit_to_json` inside your `build.yaml` file ([see the documentation](https://github.com/google/json_serializable.dart/tree/master/json_serializable#build-configuration)).
 
 **What about `@JsonKey` annotation?**
 

--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -45,29 +45,31 @@ See [the example](https://github.com/rrousselGit/freezed/blob/master/packages/fr
 
 # Index
 
+- [Motivation](#motivation)
+- [Index](#index)
 - [How to use](#how-to-use)
   - [Install](#install)
   - [Run the generator](#run-the-generator)
 - [The features](#the-features)
   - [The syntax](#the-syntax)
-    - [basics](#basics)
-    - [custom getters and methods](#custom-getters-and-methods)
-    - [non-nullable](#non-nullable)
-    - [default values](#default-values)
-    - [late](#late)
-    - [constructor tear-off](#constructor-tear-off)
-    - [decorators](#decorators)
-    - [mixins and interfaces for individual classes for union types](#mixins-and-interfaces-for-individual-classes-for-union-types)
-  - [==/toString](#toString)
-  - [copyWith](#copyWith)
-    - [deep copy](#deep-copy)
+    - [Basics](#basics)
+    - [Custom getters and methods](#custom-getters-and-methods)
+    - [Non-nullable](#non-nullable)
+    - [Default values](#default-values)
+    - [Late](#late)
+    - [Constructor tear-off](#constructor-tear-off)
+    - [Decorators](#decorators)
+    - [Mixins and Interfaces for individual classes for union types](#mixins-and-interfaces-for-individual-classes-for-union-types)
+  - [==/toString](#tostring)
+  - [copyWith](#copywith)
+    - [Deep copy](#deep-copy)
   - [Unions/Sealed classes](#unionssealed-classes)
-    - [shared properties](#shared-properties)
-    - [when](#when)
-    - [maybeWhen](#maybeWhen)
-    - [map/maybeMap](#mapMaybeMap)
-  - [fromJson/toJson](#fromjsontojson)
-    - [classes with multiple constructors](#fromjson---classes-with-multiple-constructors)
+    - [Shared properties](#shared-properties)
+    - [When](#when)
+    - [MaybeWhen](#maybewhen)
+    - [Map/MaybeMap](#mapmaybemap)
+  - [FromJson/ToJson](#fromjsontojson)
+    - [fromJSON - classes with multiple constructors](#fromjson---classes-with-multiple-constructors)
 
 # How to use
 
@@ -1054,6 +1056,30 @@ class MyResponseConverter implements JsonConverter<MyResponse, Map<String, dynam
 
   @override
   Map<String, dynamic> toJson(MyResponse data) => data.toJson();
+}
+```
+
+To then apply your custom converter pass the decorator to a constructor parameter.
+
+```dart
+@freezed
+abstract class MyModel with _$MyModel {
+  const factory MyModel(@MyResponseConverter() MyResponse myResponse) = MyModelData;
+  
+  factory MyModel.fromJson(Map<String, dynamic> json) => _$MyModelFromJson(json);
+}
+```
+
+By doing this, json serializable will use `MyResponseConverter.fromJson()` and `MyResponseConverter.toJson()` to convert `MyResponse`.
+
+You can also use a custom converter on a constructor parameter contained in a `List`.
+
+```dart
+@freezed
+abstract class MyModel with _$MyModel {
+  const factory MyModel(@MyResponseConverter() List<MyResponse> myResponse) = MyModelData;
+  
+  factory MyModel.fromJson(Map<String, dynamic> json) => _$MyModelFromJson(json);
 }
 ```
 


### PR DESCRIPTION
The PR aims to clarify two features from #240 and #232.

It adds two code examples on how to apply the custom converter decorator `MyResponseConverter` already present inside the documentation. Specifically, one example illustrates how to apply the decorator by passing it as a constructor parameter, while the second one shows that the converter works also on a `List` parameter.

It also adds a note below it to clarify that, in order to serialize nested list of freezer objects, you are supposed to either specify a `@JsonSerializable(explicitToJson: true)` or change `explicit_to_json` inside your `build.yaml` file (taken from [here](https://github.com/rrousselGit/freezed/issues/232#issuecomment-658708471)).

**Note**: The PR introduces a repetition. The reference to `build.yaml` to define some custom json_serializable flags is present both inside the PR and at the very bottom of the original documentation. I think the note may be helpful right below the json_serializable section to clarify the concepts explained above.