### PR TITLE
Support block body syntax for `fromJson` constructor.

### DIFF
--- a/packages/freezed/CHANGELOG.md
+++ b/packages/freezed/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Fixed a bug where a `fromJson` constructor is not generated when using the
+  block body syntax.
+
 # 0.12.2
 
 - Upgrade the depenencies (analyzer, build_runner)

--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -329,8 +329,12 @@ class FreezedGenerator extends ParserGenerator<_GlobalData, Data, Freezed> {
           return element.isFactory &&
               element.name == 'fromJson' &&
               element.parameters.length == 1 &&
-              (element.parameters[0].type.getDisplayString(withNullability: false) == 'dynamic' ||
-                  element.parameters[0].type.getDisplayString(withNullability: false) == 'Map<String, dynamic>');
+              (element.parameters[0].type
+                          .getDisplayString(withNullability: false) ==
+                      'dynamic' ||
+                  element.parameters[0].type
+                          .getDisplayString(withNullability: false) ==
+                      'Map<String, dynamic>');
         });
 
     return Data(

--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -326,14 +326,11 @@ class FreezedGenerator extends ParserGenerator<_GlobalData, Data, Freezed> {
 
     final needsJsonSerializable = globalData.hasJson &&
         element.constructors.any((element) {
-          if (element.isFactory && element.name == 'fromJson') {
-            final ast = element.session
-                .getParsedLibraryByElement(element.library)
-                .getElementDeclaration(element)
-                ?.node;
-            return ast.endToken.stringValue == ';';
-          }
-          return false;
+          return element.isFactory &&
+              element.name == 'fromJson' &&
+              element.parameters.length == 1 &&
+              (element.parameters[0].type.getDisplayString(withNullability: false) == 'dynamic' ||
+                  element.parameters[0].type.getDisplayString(withNullability: false) == 'Map<String, dynamic>');
         });
 
     return Data(

--- a/packages/freezed/test/integration/json.dart
+++ b/packages/freezed/test/integration/json.dart
@@ -3,6 +3,26 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'json.freezed.dart';
 part 'json.g.dart';
 
+// regression test for https://github.com/rrousselGit/freezed/issues/285
+
+@freezed
+abstract class Regression285 with _$Regression285 {
+  const factory Regression285(String a) = _Regression285;
+
+  factory Regression285.fromJson(dynamic json) {
+    return _$Regression285FromJson(json as Map<String, dynamic>);
+  }
+}
+
+@freezed
+abstract class Regression285n2 with _$Regression285n2 {
+  const factory Regression285n2(String a) = _Regression285n2;
+
+  factory Regression285n2.fromJson(Map<String, dynamic> json) {
+    return _$Regression285n2FromJson(json);
+  }
+}
+
 // regression test for https://github.com/rrousselGit/freezed/issues/280
 
 @freezed

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -8,6 +8,17 @@ import 'common.dart';
 import 'integration/json.dart';
 
 Future<void> main() async {
+  test('Should be able to declare fromJson constructor using block body syntax', () {
+    expect(
+      Regression285.fromJson(<String, String>{'a': 'value'}),
+      Regression285('value'),
+    );
+    expect(
+      Regression285n2.fromJson(<String, String>{'a': 'value2'}),
+      Regression285n2('value2'),
+    );
+  });
+
   test('can have a custom fromJson', () {
     expect(
       Regression280.fromJson(<String, String>{'foo': 'value'}),

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -8,7 +8,8 @@ import 'common.dart';
 import 'integration/json.dart';
 
 Future<void> main() async {
-  test('Should be able to declare fromJson constructor using block body syntax', () {
+  test('Should be able to declare fromJson constructor using block body syntax',
+      () {
     expect(
       Regression285.fromJson(<String, String>{'a': 'value'}),
       Regression285('value'),


### PR DESCRIPTION
This pull request should fix the regression introduced by PR #283 which causes the `fromJson` constructor defined using the block body syntax no longer being generated. This PR should also enable the custom`fromJson` constructor implementation.