### PR TITLE
Update README for generic class mixin example.

### DIFF
--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -614,7 +614,7 @@ In case you want to make your class generic, you do it like this:
 
 ```dart
 @freezed
-abstract class Example<T> with Example<T> {
+abstract class Example<T> with _$Example<T> {
   const factory Example.person(String name, int age) = Person<T>;
 
   @With.fromString('AdministrativeArea<T>')


### PR DESCRIPTION
In the "Mixin and Interfaces for individual classes for union types" section, the generic class mixin example is missing `_$'.