### PR TITLE
add option to exclude code coverage from generated files 

### DIFF
--- a/packages/freezed/lib/builder.dart
+++ b/packages/freezed/lib/builder.dart
@@ -5,9 +5,13 @@ import 'src/freezed_generator.dart';
 
 /// Builds generators for `build_runner` to run
 Builder freezed(BuilderOptions options) {
-  return PartBuilder([FreezedGenerator(options.config)], '.freezed.dart',
-      header: '''
-// GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
-    ''');
+  final coverage = options.config['no-coverage'] as bool ?? false;
+
+  return PartBuilder(
+    [FreezedGenerator(options.config)],
+    '.freezed.dart',
+    header: '// GENERATED CODE - DO NOT MODIFY BY HAND\n'
+        '// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies\n'
+        '${coverage ? '// coverage:ignore-file\n' : ''}',
+  );
 }


### PR DESCRIPTION
Add the option of excluding the generated files from the test code coverage.

Default behaviour remains the same