### PR TITLE
Fix `sort_unnamed_constructors_first` and `cast_nullable_to_non_nullable`

### DIFF
--- a/packages/freezed/analysis_options.yaml
+++ b/packages/freezed/analysis_options.yaml
@@ -79,3 +79,4 @@ linter:
     - unrelated_type_equality_checks
     - use_rethrow_when_possible
     - valid_regexps
+    - cast_nullable_to_non_nullable

--- a/packages/freezed/lib/builder.dart
+++ b/packages/freezed/lib/builder.dart
@@ -10,6 +10,6 @@ Builder freezed(BuilderOptions options) {
   return PartBuilder([FreezedGenerator(options.config)], '.freezed.dart',
       header: '''
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, cast_nullable_to_non_nullable
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides
     ''');
 }

--- a/packages/freezed/lib/builder.dart
+++ b/packages/freezed/lib/builder.dart
@@ -10,6 +10,6 @@ Builder freezed(BuilderOptions options) {
   return PartBuilder([FreezedGenerator(options.config)], '.freezed.dart',
       header: '''
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, cast_nullable_to_non_nullable
     ''');
 }

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -73,8 +73,8 @@ $_toJson
 
 
 abstract class ${constructor.redirectedName}$genericsDefinition $_superKeyword $name$genericsParameter$interfaces {
-  $_privateConcreteConstructor
   $_isConst factory ${constructor.redirectedName}(${constructor.parameters.asExpandedDefinition}) = $concreteName$genericsParameter;
+  $_privateConcreteConstructor
 
   $_redirectedFromJsonConstructor
 

--- a/packages/freezed/lib/src/templates/copy_with.dart
+++ b/packages/freezed/lib/src/templates/copy_with.dart
@@ -177,11 +177,14 @@ $_abstractClassName${genericsParameter.append('$clonedClassName$genericsParamete
     @required String returnType,
   }) {
     String parameterToValue(Parameter p) {
-      var ternary = '${p.name} == freezed ? $accessor.${p.name} : ${p.name}';
-      if (p.type != 'Object?' && p.type != null) {
-        ternary = '$ternary as ${p.type}';
+      final ternary = '${p.name} == freezed ? $accessor.${p.name} : ${p.name}';
+      var cast = '';
+      if (p.type != 'Object?' && p.type != 'Object' && p.type != null) {
+        cast = '${p.type.contains('?') ? '' : '!'} as ${p.type}';
+      } else {
+        cast = '${p.type.contains('?') ? '' : '!'}';
       }
-      return '$ternary,';
+      return '$ternary$cast,';
     }
 
     final constructorParameters = StringBuffer()

--- a/packages/freezed/lib/src/templates/copy_with.dart
+++ b/packages/freezed/lib/src/templates/copy_with.dart
@@ -171,15 +171,21 @@ $_abstractClassName${genericsParameter.append('$clonedClassName$genericsParamete
     return '@override $prototype $body';
   }
 
+  String _ignoreLints(String s,
+          [List<String> lints = const ['cast_nullable_to_non_nullable']]) =>
+      '''
+// ignore: ${lints.join(', ')}
+$s''';
+
   String _copyWithMethodBody({
     String accessor = '_value',
     @required ParametersTemplate parametersTemplate,
     @required String returnType,
   }) {
     String parameterToValue(Parameter p) {
-      var ternary = '${p.name} == freezed ? $accessor.${p.name} : ${p.name}';
+      var ternary = '${p.name} == freezed ? $accessor.${p.name} : ${p.name} ';
       if (p.type != 'Object?' && p.type != null) {
-        ternary = '$ternary as ${p.type}';
+        ternary += _ignoreLints('as ${p.type}');
       }
       return '$ternary,';
     }
@@ -193,9 +199,7 @@ $_abstractClassName${genericsParameter.append('$clonedClassName$genericsParamete
       )
       ..writeAll(
         parametersTemplate.namedParameters.map<String>(
-          (p) {
-            return '${p.name}: ${parameterToValue(p)}';
-          },
+          (p) => '${p.name}: ${parameterToValue(p)}',
         ),
       );
 

--- a/packages/freezed/lib/src/templates/copy_with.dart
+++ b/packages/freezed/lib/src/templates/copy_with.dart
@@ -179,10 +179,11 @@ $_abstractClassName${genericsParameter.append('$clonedClassName$genericsParamete
     String parameterToValue(Parameter p) {
       final ternary = '${p.name} == freezed ? $accessor.${p.name} : ${p.name}';
       var cast = '';
-      if (p.type != 'Object?' && p.type != 'Object' && p.type != null) {
-        cast = '${p.type.contains('?') ? '' : '!'} as ${p.type}';
-      } else {
-        cast = '${p.type.contains('?') ? '' : '!'}';
+      if (p.type != null) {
+        cast = p.type.contains('?') ? '' : '!';
+        if (p.type != 'Object?' && p.type != 'Object') {
+          cast += ' as ${p.type}';
+        }
       }
       return '$ternary$cast,';
     }

--- a/packages/freezed/lib/src/templates/copy_with.dart
+++ b/packages/freezed/lib/src/templates/copy_with.dart
@@ -177,15 +177,11 @@ $_abstractClassName${genericsParameter.append('$clonedClassName$genericsParamete
     @required String returnType,
   }) {
     String parameterToValue(Parameter p) {
-      final ternary = '${p.name} == freezed ? $accessor.${p.name} : ${p.name}';
-      var cast = '';
-      if (p.type != null) {
-        cast = p.type.contains('?') ? '' : '!';
-        if (p.type != 'Object?' && p.type != 'Object') {
-          cast += ' as ${p.type}';
-        }
+      var ternary = '${p.name} == freezed ? $accessor.${p.name} : ${p.name}';
+      if (p.type != 'Object?' && p.type != null) {
+        ternary = '$ternary as ${p.type}';
       }
-      return '$ternary$cast,';
+      return '$ternary,';
     }
 
     final constructorParameters = StringBuffer()


### PR DESCRIPTION
This fixes 2 lints. 

The first one being `sort_unnamed_constructors_first`, the abstract template didn't have the unnamed constructor so if you had the lint enabled it would complain. 

Second one is related to null safety, it doesn't like when we cast potentially nullable objects (`Object?`) as OneClass because it makes it non nullable and it's not a good practice. I added a `!` when the class is non-nullable. 

It passes all tests.