### PR TITLE
Readme fix pre-null version

### DIFF
--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -21,7 +21,8 @@ In that case, you can fix the error by adding the following to your `pubspec.yam
 
 ```yaml
 dependency_overrides:
-  freezed_annotation: ^0.12.7
+  freezed: ^0.12.7
+  freezed_annotation: ^0.12.0
 ```
 
 # Motivation


### PR DESCRIPTION
freezed_annotation has no version 0.12.7 published, thus 0.12.0 is required
Also I added freezed for clarification.