### PR TITLE
fix: Take nested exports into account

### DIFF
--- a/packages/freezed/lib/src/tools/recursive_import_locator.dart
+++ b/packages/freezed/lib/src/tools/recursive_import_locator.dart
@@ -52,12 +52,11 @@ class RecursiveImportLocator {
     }
 
     return library.exportedLibraries.any((export) {
-      return export.isRelevant(whereLibrary) &&
-          _doesExportRecursively(
-            library: export,
-            where: where,
-            whereLibrary: whereLibrary,
-          );
+      return _doesExportRecursively(
+        library: export,
+        where: where,
+        whereLibrary: whereLibrary,
+      );
     });
   }
 }

--- a/packages/freezed/test/integration/export.dart
+++ b/packages/freezed/test/integration/export.dart
@@ -1,0 +1,13 @@
+import 'export_freezed_annotation.dart';
+
+part 'export.freezed.dart';
+
+part 'export.g.dart';
+
+@freezed
+class Export with _$Export {
+  const factory Export(int a) = _Export;
+
+  factory Export.fromJson(Map<String, dynamic> json) =>
+      _$ExportFromJson(json);
+}

--- a/packages/freezed/test/integration/export.dart
+++ b/packages/freezed/test/integration/export.dart
@@ -8,6 +8,5 @@ part 'export.g.dart';
 class Export with _$Export {
   const factory Export(int a) = _Export;
 
-  factory Export.fromJson(Map<String, dynamic> json) =>
-      _$ExportFromJson(json);
+  factory Export.fromJson(Map<String, dynamic> json) => _$ExportFromJson(json);
 }

--- a/packages/freezed/test/integration/export_freezed_annotation.dart
+++ b/packages/freezed/test/integration/export_freezed_annotation.dart
@@ -1,0 +1,1 @@
+export 'package:freezed_annotation/freezed_annotation.dart';

--- a/packages/freezed/test/recursive_import_locator_test.dart
+++ b/packages/freezed/test/recursive_import_locator_test.dart
@@ -1,0 +1,14 @@
+import 'package:test/test.dart';
+
+import 'integration/export.dart';
+
+void main() {
+  test('recursive export of json_annotation works', () {
+    expect(
+      Export.fromJson(<String, dynamic>{
+        'a': 42,
+      }),
+      const Export(42),
+    );
+  });
+}


### PR DESCRIPTION
Our current setup: we have a package `core` with the following content:

```dart
library core;

export 'package:freezed_annotation/freezed_annotation.dart';
// ... other exports and imports
```

Also, we have a dependent package where we use freezed with something like this:

```dart
import 'package:core/core.dart';

part 'get_services.freezed.dart';

part 'get_services.g.dart';

@freezed
class GetServicesResponseDto with _$GetServicesResponseDto {
  const factory GetServicesResponseDto({
    required List<ServiceDto> services,
  }) = _GetServicesResponseDto;

  factory GetServicesResponseDto.fromJson(Map<String, dynamic> json) => _$GetServicesResponseDtoFromJson(json);
}
```

The problem is that `get_services.g.dart` is not generated, but it is generated if I add directly `import 'package:freezed_annotation/freezed_annotation.dart';`

The proposed fix solves the problem, since `export.isRelevant(whereLibrary)` blocks locator from going deeper into exported libraries. But maybe I'm missing something and this code is needed for something else?