### PR TITLE
Correct README example

### DIFF
--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -409,7 +409,7 @@ for computed properties.
 For example, you may write:
 
 ```dart
-abstract class Todos with _$Todos {
+class Todos with _$Todos {
   // Required for adding a custom field.
   Todos._();
   factory Todos(List<Todo> todos) = _Todos;

--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -410,6 +410,8 @@ For example, you may write:
 
 ```dart
 abstract class Todos with _$Todos {
+  // Required for adding a custom field.
+  Todos._();
   factory Todos(List<Todo> todos) = _Todos;
 
   late final completed = todos.where((t) => t.completed).toList();


### PR DESCRIPTION
The previous version does not build/compile because:

> Final variables require a MyClass._() constructor