### PR TITLE
being explicit about json_serializable dependency

### DIFF
--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -1033,6 +1033,13 @@ class Model with _$Model {
 }
 ```
 
+Don't forget to add `json_serializable` to your `pubspec.yaml`:
+
+```yaml
+dev_dependencies:
+  json_serializable:
+```
+
 That's it!\
 With these changes, [Freezed] will automatically ask [json_serializable] to generate all the necessary
 `fromJson`/`toJson`.


### PR DESCRIPTION
I keep forgetting to do this and always come back to the doc to see what went wrong and find myself doing everything right, but still not getting `.g.dart` in my file system. I guess this note will help next time