### PR TITLE
Feature/union fallback

### DIFF
--- a/packages/_internal/lib/models.dart
+++ b/packages/_internal/lib/models.dart
@@ -48,6 +48,7 @@ abstract class ConstructorDetails with _$ConstructorDetails {
     required ParametersTemplate parameters,
     required List<Property> impliedProperties,
     required bool isDefault,
+    required bool isFallback,
     required bool hasJsonSerializable,
     required String fullName,
     required List<String> withDecorators,

--- a/packages/_internal/lib/models.freezed.dart
+++ b/packages/_internal/lib/models.freezed.dart
@@ -260,6 +260,7 @@ class _$ConstructorDetailsTearOff {
       required ParametersTemplate parameters,
       required List<Property> impliedProperties,
       required bool isDefault,
+      required bool isFallback,
       required bool hasJsonSerializable,
       required String fullName,
       required List<String> withDecorators,
@@ -276,6 +277,7 @@ class _$ConstructorDetailsTearOff {
       parameters: parameters,
       impliedProperties: impliedProperties,
       isDefault: isDefault,
+      isFallback: isFallback,
       hasJsonSerializable: hasJsonSerializable,
       fullName: fullName,
       withDecorators: withDecorators,
@@ -300,6 +302,7 @@ mixin _$ConstructorDetails {
   ParametersTemplate get parameters => throw _privateConstructorUsedError;
   List<Property> get impliedProperties => throw _privateConstructorUsedError;
   bool get isDefault => throw _privateConstructorUsedError;
+  bool get isFallback => throw _privateConstructorUsedError;
   bool get hasJsonSerializable => throw _privateConstructorUsedError;
   String get fullName => throw _privateConstructorUsedError;
   List<String> get withDecorators => throw _privateConstructorUsedError;
@@ -328,6 +331,7 @@ abstract class $ConstructorDetailsCopyWith<$Res> {
       ParametersTemplate parameters,
       List<Property> impliedProperties,
       bool isDefault,
+      bool isFallback,
       bool hasJsonSerializable,
       String fullName,
       List<String> withDecorators,
@@ -356,6 +360,7 @@ class _$ConstructorDetailsCopyWithImpl<$Res>
     Object? parameters = freezed,
     Object? impliedProperties = freezed,
     Object? isDefault = freezed,
+    Object? isFallback = freezed,
     Object? hasJsonSerializable = freezed,
     Object? fullName = freezed,
     Object? withDecorators = freezed,
@@ -393,6 +398,10 @@ class _$ConstructorDetailsCopyWithImpl<$Res>
       isDefault: isDefault == freezed
           ? _value.isDefault
           : isDefault // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isFallback: isFallback == freezed
+          ? _value.isFallback
+          : isFallback // ignore: cast_nullable_to_non_nullable
               as bool,
       hasJsonSerializable: hasJsonSerializable == freezed
           ? _value.hasJsonSerializable
@@ -445,6 +454,7 @@ abstract class _$ConstructorDetailsCopyWith<$Res>
       ParametersTemplate parameters,
       List<Property> impliedProperties,
       bool isDefault,
+      bool isFallback,
       bool hasJsonSerializable,
       String fullName,
       List<String> withDecorators,
@@ -475,6 +485,7 @@ class __$ConstructorDetailsCopyWithImpl<$Res>
     Object? parameters = freezed,
     Object? impliedProperties = freezed,
     Object? isDefault = freezed,
+    Object? isFallback = freezed,
     Object? hasJsonSerializable = freezed,
     Object? fullName = freezed,
     Object? withDecorators = freezed,
@@ -512,6 +523,10 @@ class __$ConstructorDetailsCopyWithImpl<$Res>
       isDefault: isDefault == freezed
           ? _value.isDefault
           : isDefault // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isFallback: isFallback == freezed
+          ? _value.isFallback
+          : isFallback // ignore: cast_nullable_to_non_nullable
               as bool,
       hasJsonSerializable: hasJsonSerializable == freezed
           ? _value.hasJsonSerializable
@@ -559,6 +574,7 @@ class _$_ConstructorDetails extends _ConstructorDetails {
       required this.parameters,
       required this.impliedProperties,
       required this.isDefault,
+      required this.isFallback,
       required this.hasJsonSerializable,
       required this.fullName,
       required this.withDecorators,
@@ -584,6 +600,8 @@ class _$_ConstructorDetails extends _ConstructorDetails {
   @override
   final bool isDefault;
   @override
+  final bool isFallback;
+  @override
   final bool hasJsonSerializable;
   @override
   final String fullName;
@@ -602,7 +620,7 @@ class _$_ConstructorDetails extends _ConstructorDetails {
 
   @override
   String toString() {
-    return 'ConstructorDetails(name: $name, unionValue: $unionValue, isConst: $isConst, redirectedName: $redirectedName, parameters: $parameters, impliedProperties: $impliedProperties, isDefault: $isDefault, hasJsonSerializable: $hasJsonSerializable, fullName: $fullName, withDecorators: $withDecorators, implementsDecorators: $implementsDecorators, decorators: $decorators, cloneableProperties: $cloneableProperties, canOverrideToString: $canOverrideToString, asserts: $asserts)';
+    return 'ConstructorDetails(name: $name, unionValue: $unionValue, isConst: $isConst, redirectedName: $redirectedName, parameters: $parameters, impliedProperties: $impliedProperties, isDefault: $isDefault, isFallback: $isFallback, hasJsonSerializable: $hasJsonSerializable, fullName: $fullName, withDecorators: $withDecorators, implementsDecorators: $implementsDecorators, decorators: $decorators, cloneableProperties: $cloneableProperties, canOverrideToString: $canOverrideToString, asserts: $asserts)';
   }
 
   @override
@@ -629,6 +647,9 @@ class _$_ConstructorDetails extends _ConstructorDetails {
             (identical(other.isDefault, isDefault) ||
                 const DeepCollectionEquality()
                     .equals(other.isDefault, isDefault)) &&
+            (identical(other.isFallback, isFallback) ||
+                const DeepCollectionEquality()
+                    .equals(other.isFallback, isFallback)) &&
             (identical(other.hasJsonSerializable, hasJsonSerializable) ||
                 const DeepCollectionEquality()
                     .equals(other.hasJsonSerializable, hasJsonSerializable)) &&
@@ -664,6 +685,7 @@ class _$_ConstructorDetails extends _ConstructorDetails {
       const DeepCollectionEquality().hash(parameters) ^
       const DeepCollectionEquality().hash(impliedProperties) ^
       const DeepCollectionEquality().hash(isDefault) ^
+      const DeepCollectionEquality().hash(isFallback) ^
       const DeepCollectionEquality().hash(hasJsonSerializable) ^
       const DeepCollectionEquality().hash(fullName) ^
       const DeepCollectionEquality().hash(withDecorators) ^
@@ -688,6 +710,7 @@ abstract class _ConstructorDetails extends ConstructorDetails {
       required ParametersTemplate parameters,
       required List<Property> impliedProperties,
       required bool isDefault,
+      required bool isFallback,
       required bool hasJsonSerializable,
       required String fullName,
       required List<String> withDecorators,
@@ -712,6 +735,8 @@ abstract class _ConstructorDetails extends ConstructorDetails {
   List<Property> get impliedProperties => throw _privateConstructorUsedError;
   @override
   bool get isDefault => throw _privateConstructorUsedError;
+  @override
+  bool get isFallback => throw _privateConstructorUsedError;
   @override
   bool get hasJsonSerializable => throw _privateConstructorUsedError;
   @override

--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -285,6 +285,13 @@ Read here: https://github.com/rrousselGit/freezed/tree/master/packages/freezed#t
       );
     }
 
+    if (configs.fallbackUnion != null && result.none((c) => c.isFallback)) {
+      throw InvalidGenerationSourceError(
+        'Fallback union was specified but no ${configs.fallbackUnion} constructor exists.',
+        element: element,
+      );
+    }
+
     return result;
   }
 
@@ -371,9 +378,7 @@ Read here: https://github.com/rrousselGit/freezed/tree/master/packages/freezed#t
         configs['union_key']?.toString() ??
         'runtimeType';
 
-    final fallbackUnion =
-        annotation.getField('fallbackUnion')?.toStringValue() ??
-            configs['fallback_union']?.toString();
+    final fallbackUnion = annotation.getField('fallbackUnion')?.toStringValue();
 
     FreezedUnionCase unionValueCase;
     final fromConfig = configs['union_value_case']?.toString();

--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -255,7 +255,7 @@ Read here: https://github.com/rrousselGit/freezed/tree/master/packages/freezed#t
           implementsDecorators:
               _implementsDecorationTypes(constructor).toSet().toList(),
           isDefault: isDefaultConstructor(constructor),
-          isFallback: constructor.isUnionFallbackConstructor,
+          isFallback: constructor.isFallbackUnion(configs.fallbackUnion),
           hasJsonSerializable: constructor.hasJsonSerializable,
           cloneableProperties: await _cloneableProperties(
             buildStep,
@@ -371,6 +371,9 @@ Read here: https://github.com/rrousselGit/freezed/tree/master/packages/freezed#t
         configs['union_key']?.toString() ??
         'runtimeType';
 
+    final fallbackUnion = annotation.getField('fallbackUnion')?.toStringValue() ??
+        configs['fallback_union']?.toString();
+
     FreezedUnionCase unionValueCase;
     final fromConfig = configs['union_value_case']?.toString();
     switch (fromConfig) {
@@ -399,6 +402,7 @@ Read here: https://github.com/rrousselGit/freezed/tree/master/packages/freezed#t
 
     return Freezed(
       unionKey: rawUnionKey.replaceAll("'", r"\'").replaceAll(r'$', r'\$'),
+      fallbackUnion: fallbackUnion,
       unionValueCase: unionValueCase,
     );
   }
@@ -599,11 +603,9 @@ extension on Element {
 }
 
 extension on ConstructorElement {
-  bool get isUnionFallbackConstructor {
-    return const TypeChecker.fromRuntime(FreezedUnionFallback).hasAnnotationOf(
-      this,
-      throwOnUnresolved: false,
-    );
+  bool isFallbackUnion(String? fallbackConstructorName) {
+    final constructorName = isDefaultConstructor(this) ? 'default' : name;
+    return constructorName == fallbackConstructorName;
   }
 
   String unionValue(FreezedUnionCase unionCase) {

--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -255,7 +255,7 @@ Read here: https://github.com/rrousselGit/freezed/tree/master/packages/freezed#t
           implementsDecorators:
               _implementsDecorationTypes(constructor).toSet().toList(),
           isDefault: isDefaultConstructor(constructor),
-          isFallback: constructor.isUnionFallback,
+          isFallback: constructor.isUnionFallbackConstructor,
           hasJsonSerializable: constructor.hasJsonSerializable,
           cloneableProperties: await _cloneableProperties(
             buildStep,
@@ -599,7 +599,7 @@ extension on Element {
 }
 
 extension on ConstructorElement {
-  bool get isUnionFallback {
+  bool get isUnionFallbackConstructor {
     return const TypeChecker.fromRuntime(FreezedUnionFallback).hasAnnotationOf(
       this,
       throwOnUnresolved: false,

--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -371,8 +371,9 @@ Read here: https://github.com/rrousselGit/freezed/tree/master/packages/freezed#t
         configs['union_key']?.toString() ??
         'runtimeType';
 
-    final fallbackUnion = annotation.getField('fallbackUnion')?.toStringValue() ??
-        configs['fallback_union']?.toString();
+    final fallbackUnion =
+        annotation.getField('fallbackUnion')?.toStringValue() ??
+            configs['fallback_union']?.toString();
 
     FreezedUnionCase unionValueCase;
     final fromConfig = configs['union_value_case']?.toString();

--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -255,6 +255,7 @@ Read here: https://github.com/rrousselGit/freezed/tree/master/packages/freezed#t
           implementsDecorators:
               _implementsDecorationTypes(constructor).toSet().toList(),
           isDefault: isDefaultConstructor(constructor),
+          isFallback: constructor.isUnionFallback,
           hasJsonSerializable: constructor.hasJsonSerializable,
           cloneableProperties: await _cloneableProperties(
             buildStep,
@@ -598,6 +599,13 @@ extension on Element {
 }
 
 extension on ConstructorElement {
+  bool get isUnionFallback {
+    return const TypeChecker.fromRuntime(FreezedUnionFallback).hasAnnotationOf(
+      this,
+      throwOnUnresolved: false,
+    );
+  }
+
   String unionValue(FreezedUnionCase unionCase) {
     final annotation = const TypeChecker.fromRuntime(FreezedUnionValue)
         .firstAnnotationOf(this, throwOnUnresolved: false);

--- a/packages/freezed/lib/src/models.dart
+++ b/packages/freezed/lib/src/models.dart
@@ -38,6 +38,7 @@ abstract class ConstructorDetails with _$ConstructorDetails {
     required ParametersTemplate parameters,
     required List<Property> impliedProperties,
     required bool isDefault,
+    required bool isFallback,
     required bool hasJsonSerializable,
     required String fullName,
     required List<String> withDecorators,

--- a/packages/freezed/lib/src/models.freezed.dart
+++ b/packages/freezed/lib/src/models.freezed.dart
@@ -260,6 +260,7 @@ class _$ConstructorDetailsTearOff {
       required ParametersTemplate parameters,
       required List<Property> impliedProperties,
       required bool isDefault,
+      required bool isFallback,
       required bool hasJsonSerializable,
       required String fullName,
       required List<String> withDecorators,
@@ -276,6 +277,7 @@ class _$ConstructorDetailsTearOff {
       parameters: parameters,
       impliedProperties: impliedProperties,
       isDefault: isDefault,
+      isFallback: isFallback,
       hasJsonSerializable: hasJsonSerializable,
       fullName: fullName,
       withDecorators: withDecorators,
@@ -300,6 +302,7 @@ mixin _$ConstructorDetails {
   ParametersTemplate get parameters => throw _privateConstructorUsedError;
   List<Property> get impliedProperties => throw _privateConstructorUsedError;
   bool get isDefault => throw _privateConstructorUsedError;
+  bool get isFallback => throw _privateConstructorUsedError;
   bool get hasJsonSerializable => throw _privateConstructorUsedError;
   String get fullName => throw _privateConstructorUsedError;
   List<String> get withDecorators => throw _privateConstructorUsedError;
@@ -328,6 +331,7 @@ abstract class $ConstructorDetailsCopyWith<$Res> {
       ParametersTemplate parameters,
       List<Property> impliedProperties,
       bool isDefault,
+      bool isFallback,
       bool hasJsonSerializable,
       String fullName,
       List<String> withDecorators,
@@ -356,6 +360,7 @@ class _$ConstructorDetailsCopyWithImpl<$Res>
     Object? parameters = freezed,
     Object? impliedProperties = freezed,
     Object? isDefault = freezed,
+    Object? isFallback = freezed,
     Object? hasJsonSerializable = freezed,
     Object? fullName = freezed,
     Object? withDecorators = freezed,
@@ -393,6 +398,10 @@ class _$ConstructorDetailsCopyWithImpl<$Res>
       isDefault: isDefault == freezed
           ? _value.isDefault
           : isDefault // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isFallback: isFallback == freezed
+          ? _value.isFallback
+          : isFallback // ignore: cast_nullable_to_non_nullable
               as bool,
       hasJsonSerializable: hasJsonSerializable == freezed
           ? _value.hasJsonSerializable
@@ -445,6 +454,7 @@ abstract class _$ConstructorDetailsCopyWith<$Res>
       ParametersTemplate parameters,
       List<Property> impliedProperties,
       bool isDefault,
+      bool isFallback,
       bool hasJsonSerializable,
       String fullName,
       List<String> withDecorators,
@@ -475,6 +485,7 @@ class __$ConstructorDetailsCopyWithImpl<$Res>
     Object? parameters = freezed,
     Object? impliedProperties = freezed,
     Object? isDefault = freezed,
+    Object? isFallback = freezed,
     Object? hasJsonSerializable = freezed,
     Object? fullName = freezed,
     Object? withDecorators = freezed,
@@ -512,6 +523,10 @@ class __$ConstructorDetailsCopyWithImpl<$Res>
       isDefault: isDefault == freezed
           ? _value.isDefault
           : isDefault // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isFallback: isFallback == freezed
+          ? _value.isFallback
+          : isFallback // ignore: cast_nullable_to_non_nullable
               as bool,
       hasJsonSerializable: hasJsonSerializable == freezed
           ? _value.hasJsonSerializable
@@ -559,6 +574,7 @@ class _$_ConstructorDetails extends _ConstructorDetails {
       required this.parameters,
       required this.impliedProperties,
       required this.isDefault,
+      required this.isFallback,
       required this.hasJsonSerializable,
       required this.fullName,
       required this.withDecorators,
@@ -584,6 +600,8 @@ class _$_ConstructorDetails extends _ConstructorDetails {
   @override
   final bool isDefault;
   @override
+  final bool isFallback;
+  @override
   final bool hasJsonSerializable;
   @override
   final String fullName;
@@ -602,7 +620,7 @@ class _$_ConstructorDetails extends _ConstructorDetails {
 
   @override
   String toString() {
-    return 'ConstructorDetails(name: $name, unionValue: $unionValue, isConst: $isConst, redirectedName: $redirectedName, parameters: $parameters, impliedProperties: $impliedProperties, isDefault: $isDefault, hasJsonSerializable: $hasJsonSerializable, fullName: $fullName, withDecorators: $withDecorators, implementsDecorators: $implementsDecorators, decorators: $decorators, cloneableProperties: $cloneableProperties, canOverrideToString: $canOverrideToString, asserts: $asserts)';
+    return 'ConstructorDetails(name: $name, unionValue: $unionValue, isConst: $isConst, redirectedName: $redirectedName, parameters: $parameters, impliedProperties: $impliedProperties, isDefault: $isDefault, isFallback: $isFallback, hasJsonSerializable: $hasJsonSerializable, fullName: $fullName, withDecorators: $withDecorators, implementsDecorators: $implementsDecorators, decorators: $decorators, cloneableProperties: $cloneableProperties, canOverrideToString: $canOverrideToString, asserts: $asserts)';
   }
 
   @override
@@ -629,6 +647,9 @@ class _$_ConstructorDetails extends _ConstructorDetails {
             (identical(other.isDefault, isDefault) ||
                 const DeepCollectionEquality()
                     .equals(other.isDefault, isDefault)) &&
+            (identical(other.isFallback, isFallback) ||
+                const DeepCollectionEquality()
+                    .equals(other.isFallback, isFallback)) &&
             (identical(other.hasJsonSerializable, hasJsonSerializable) ||
                 const DeepCollectionEquality()
                     .equals(other.hasJsonSerializable, hasJsonSerializable)) &&
@@ -664,6 +685,7 @@ class _$_ConstructorDetails extends _ConstructorDetails {
       const DeepCollectionEquality().hash(parameters) ^
       const DeepCollectionEquality().hash(impliedProperties) ^
       const DeepCollectionEquality().hash(isDefault) ^
+      const DeepCollectionEquality().hash(isFallback) ^
       const DeepCollectionEquality().hash(hasJsonSerializable) ^
       const DeepCollectionEquality().hash(fullName) ^
       const DeepCollectionEquality().hash(withDecorators) ^
@@ -688,6 +710,7 @@ abstract class _ConstructorDetails extends ConstructorDetails {
       required ParametersTemplate parameters,
       required List<Property> impliedProperties,
       required bool isDefault,
+      required bool isFallback,
       required bool hasJsonSerializable,
       required String fullName,
       required List<String> withDecorators,
@@ -712,6 +735,8 @@ abstract class _ConstructorDetails extends ConstructorDetails {
   List<Property> get impliedProperties => throw _privateConstructorUsedError;
   @override
   bool get isDefault => throw _privateConstructorUsedError;
+  @override
+  bool get isFallback => throw _privateConstructorUsedError;
   @override
   bool get hasJsonSerializable => throw _privateConstructorUsedError;
   @override

--- a/packages/freezed/lib/src/templates/from_json_template.dart
+++ b/packages/freezed/lib/src/templates/from_json_template.dart
@@ -1,4 +1,5 @@
 import 'package:freezed/src/templates/parameter_template.dart';
+import 'package:collection/collection.dart';
 
 import '../models.dart';
 
@@ -37,12 +38,12 @@ class FromJson {
         ''';
       }).join();
 
+      // TODO(rrousselGit): update logic once https://github.com/rrousselGit/freezed/pull/370 lands
       var defaultCase = 'throw FallThroughError();';
-      if (constructors.any((element) => element.isFallback)) {
-        final fallbackConstructor =
-            constructors.singleWhere((element) => element.isFallback);
+      final fallbackConstructor =
+          constructors.singleWhereOrNull((element) => element.isFallback);
+      if (fallbackConstructor != null) {
         defaultCase =
-  // TODO(rrousselGit): update logic once https://github.com/rrousselGit/freezed/pull/370 lands
             'return ${fallbackConstructor.redirectedName}$genericParameters.fromJson(json);';
       }
 

--- a/packages/freezed/lib/src/templates/from_json_template.dart
+++ b/packages/freezed/lib/src/templates/from_json_template.dart
@@ -42,6 +42,7 @@ class FromJson {
         final fallbackConstructor =
             constructors.singleWhere((element) => element.isFallback);
         defaultCase =
+  // TODO(rrousselGit): update logic once https://github.com/rrousselGit/freezed/pull/370 lands
             'return ${fallbackConstructor.redirectedName}$genericParameters.fromJson(json);';
       }
 

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -14,8 +14,7 @@ dependencies:
   build_config: ^0.4.2
   meta: ^1.3.0
   source_gen: ^1.0.0
-  freezed_annotation: 
-    path: ../freezed_annotation/
+  freezed_annotation: ">=0.14.0 <2.0.0"
 
 dev_dependencies:
   json_serializable: ^4.0.0

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -14,7 +14,8 @@ dependencies:
   build_config: ^0.4.2
   meta: ^1.3.0
   source_gen: ^1.0.0
-  freezed_annotation: ">=0.14.0 <2.0.0"
+  freezed_annotation: 
+    path: ../freezed_annotation/
 
 dev_dependencies:
   json_serializable: ^4.0.0

--- a/packages/freezed/test/integration/json.dart
+++ b/packages/freezed/test/integration/json.dart
@@ -115,7 +115,8 @@ class UnionFallback with _$UnionFallback {
 class UnionDefaultFallback with _$UnionDefaultFallback {
   const factory UnionDefaultFallback(int a) = _UnionDefaultFallback;
   const factory UnionDefaultFallback.first(int a) = _UnionDefaultFallbackFirst;
-  const factory UnionDefaultFallback.second(int a) = _UnionDefaultFallbackSecond;
+  const factory UnionDefaultFallback.second(int a) =
+      _UnionDefaultFallbackSecond;
 
   factory UnionDefaultFallback.fromJson(Map<String, dynamic> json) =>
       _$UnionDefaultFallbackFromJson(json);

--- a/packages/freezed/test/integration/json.dart
+++ b/packages/freezed/test/integration/json.dart
@@ -101,6 +101,18 @@ class CustomUnionValue with _$CustomUnionValue {
       _$CustomUnionValueFromJson(json);
 }
 
+@freezed
+class UnionFallback with _$UnionFallback {
+  const factory UnionFallback.first(int a) = _UnionFallbackFirst;
+  const factory UnionFallback.second(int a) = _UnionFallbackSecond;
+
+  @FreezedUnionFallback()
+  const factory UnionFallback.fallback(int a) = _UnionFallbackFallback;
+
+  factory UnionFallback.fromJson(Map<String, dynamic> json) =>
+      _$UnionFallbackFromJson(json);
+}
+
 @Freezed(unionValueCase: FreezedUnionCase.pascal)
 class UnionValueCasePascal with _$UnionValueCasePascal {
   const factory UnionValueCasePascal.first(int a) = _UnionValueCasePascalFirst;

--- a/packages/freezed/test/integration/json.dart
+++ b/packages/freezed/test/integration/json.dart
@@ -101,16 +101,24 @@ class CustomUnionValue with _$CustomUnionValue {
       _$CustomUnionValueFromJson(json);
 }
 
-@freezed
+@Freezed(fallbackUnion: 'fallback')
 class UnionFallback with _$UnionFallback {
   const factory UnionFallback.first(int a) = _UnionFallbackFirst;
   const factory UnionFallback.second(int a) = _UnionFallbackSecond;
-
-  @FreezedUnionFallback()
   const factory UnionFallback.fallback(int a) = _UnionFallbackFallback;
 
   factory UnionFallback.fromJson(Map<String, dynamic> json) =>
       _$UnionFallbackFromJson(json);
+}
+
+@Freezed(fallbackUnion: 'default')
+class UnionDefaultFallback with _$UnionDefaultFallback {
+  const factory UnionDefaultFallback(int a) = _UnionDefaultFallback;
+  const factory UnionDefaultFallback.first(int a) = _UnionDefaultFallbackFirst;
+  const factory UnionDefaultFallback.second(int a) = _UnionDefaultFallbackSecond;
+
+  factory UnionDefaultFallback.fromJson(Map<String, dynamic> json) =>
+      _$UnionDefaultFallbackFromJson(json);
 }
 
 @Freezed(unionValueCase: FreezedUnionCase.pascal)

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -155,6 +155,26 @@ Future<void> main() async {
     });
   });
 
+  group('FreezedUnionFallback default', () {
+    test('fromJson', () {
+      expect(
+        UnionDefaultFallback.fromJson(<String, dynamic>{
+          'runtimeType': 'first',
+          'a': 42,
+        }),
+        UnionDefaultFallback.first(42),
+      );
+
+      expect(
+        UnionDefaultFallback.fromJson(<String, dynamic>{
+          'runtimeType': 'third',
+          'a': 10,
+        }),
+        UnionDefaultFallback(10),
+      );
+    });
+  });
+
   group('Freezed.unionValueCase', () {
     test('FreezedUnionCase.pascal fromJson', () {
       expect(

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -145,18 +145,13 @@ Future<void> main() async {
         }),
         UnionFallback.fallback(10),
       );
-    });
-
-    test('toJson', () {
-      expect(
-        CustomUnionValue.first(42).toJson(),
-        <String, dynamic>{'runtimeType': 'first', 'a': 42},
-      );
 
       expect(
-        CustomUnionValue.second(21).toJson(),
-        <String, dynamic>{'runtimeType': 'SECOND', 'a': 21},
-      );
+          () => CustomUnionValue.fromJson(<String, dynamic>{
+                'runtimeType': 'third',
+                'a': 10,
+              }),
+          throwsA(const TypeMatcher<FallThroughError>()));
     });
   });
 

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -148,6 +148,13 @@ Future<void> main() async {
       );
 
       expect(
+        UnionFallback.fromJson(<String, dynamic>{
+          'a': 55,
+        }),
+        UnionFallback.fallback(55),
+      );
+
+      expect(
           () => CustomUnionValue.fromJson(<String, dynamic>{
                 'runtimeType': 'third',
                 'a': 10,
@@ -172,6 +179,13 @@ Future<void> main() async {
           'a': 10,
         }),
         UnionDefaultFallback(10),
+      );
+
+      expect(
+        UnionDefaultFallback.fromJson(<String, dynamic>{
+          'a': 55,
+        }),
+        UnionDefaultFallback(55),
       );
     });
   });

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -120,6 +120,46 @@ Future<void> main() async {
     });
   });
 
+  group('FreezedUnionFallback', () {
+    test('fromJson', () {
+      expect(
+        UnionFallback.fromJson(<String, dynamic>{
+          'runtimeType': 'first',
+          'a': 42,
+        }),
+        UnionFallback.first(42),
+      );
+
+      expect(
+        UnionFallback.fromJson(<String, dynamic>{
+          'runtimeType': 'second',
+          'a': 21,
+        }),
+        UnionFallback.second(21),
+      );
+
+      expect(
+        UnionFallback.fromJson(<String, dynamic>{
+          'runtimeType': 'third',
+          'a': 10,
+        }),
+        UnionFallback.fallback(10),
+      );
+    });
+
+    test('toJson', () {
+      expect(
+        CustomUnionValue.first(42).toJson(),
+        <String, dynamic>{'runtimeType': 'first', 'a': 42},
+      );
+
+      expect(
+        CustomUnionValue.second(21).toJson(),
+        <String, dynamic>{'runtimeType': 'SECOND', 'a': 21},
+      );
+    });
+  });
+
   group('Freezed.unionValueCase', () {
     test('FreezedUnionCase.pascal fromJson', () {
       expect(

--- a/packages/freezed/test/source_gen_src.dart
+++ b/packages/freezed/test/source_gen_src.dart
@@ -154,6 +154,21 @@ class _Manual implements ManualFactory {
   }
 }
 
+@ShouldThrow('Fallback union was specified but no fallback constructor exists.')
+@Freezed(fallbackUnion: 'fallback')
+class FallbackUnionMissing {
+  factory FallbackUnionMissing.first() = _First;
+  factory FallbackUnionMissing.second() = _Second;
+}
+
+class _First implements FallbackUnionMissing {
+  _First();
+}
+
+class _Second implements FallbackUnionMissing {
+  _Second();
+}
+
 @ShouldThrow(
   'Marked ManualFactory2 with @freezed, but freezed has nothing to generate',
 )

--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -7,10 +7,11 @@ export 'package:meta/meta.dart';
 /// {@endtemplate}
 class Freezed {
   /// {@template freezed_annotation.freezed}
-  const Freezed(
-      {this.unionKey,
-      this.unionValueCase = FreezedUnionCase.none,
-      this.fallbackUnion});
+  const Freezed({
+    this.unionKey,
+    this.unionValueCase = FreezedUnionCase.none,
+    this.fallbackUnion,
+  });
 
   /// Determines what key should be used to de/serialize union types.
   ///

--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -274,6 +274,38 @@ class FreezedUnionValue {
   final String value;
 }
 
+/// An annotation used to specify fallback constructor used when union type is not matched
+///
+/// By default, Freezed generates code that will throw FallThroughError when type
+/// is not matched through constructor name or using [FreezedUnionValue].
+/// You can override this behavior by annotating constructor and using it as a fallback one
+///
+/// ```dart
+/// @freezed
+/// class MyResponse with _$MyResponse {
+///   const factory MyResponse.special(String a, int b) = MyResponseSpecial;
+///
+///   @FreezedUnionFallback()
+///   const factory MyResponse.fallback(String a, int b) = MyResponseFallback;
+///
+///   factory MyResponse.fromJson(Map<String, dynamic> json) => _$MyResponseFromJson(json);
+/// }
+/// ```
+///
+/// The constructor will be chosen as follows:
+///
+/// ```json
+/// [
+///   {
+///     "runtimeType": "default",
+///     "a": "This JSON object will use constructor MyResponse()"
+///   },
+///   {
+///     "runtimeType": "SpecialCase",
+///     "a": "This JSON object will use constructor MyResponse.special()",
+///     "b": 42
+///   }
+/// ]
 class FreezedUnionFallback {
   const FreezedUnionFallback();
 }

--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -274,6 +274,10 @@ class FreezedUnionValue {
   final String value;
 }
 
+class FreezedUnionFallback {
+  const FreezedUnionFallback();
+}
+
 /// Options for automatic union values renaming.
 enum FreezedUnionCase {
   /// Use the name without changes.

--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -7,11 +7,10 @@ export 'package:meta/meta.dart';
 /// {@endtemplate}
 class Freezed {
   /// {@template freezed_annotation.freezed}
-  const Freezed({
-    this.unionKey,
-    this.unionValueCase = FreezedUnionCase.none,
-    this.fallbackUnion
-  });
+  const Freezed(
+      {this.unionKey,
+      this.unionValueCase = FreezedUnionCase.none,
+      this.fallbackUnion});
 
   /// Determines what key should be used to de/serialize union types.
   ///
@@ -99,7 +98,7 @@ class Freezed {
   ///
   /// By default, Freezed generates code that will throw FallThroughError when type
   /// is not matched through constructor name or using [FreezedUnionValue].
-  /// You can override this behavior by providing it's name or 'default' to use 
+  /// You can override this behavior by providing it's name or `default` to use
   /// default constructor
   ///
   /// ```dart

--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -10,6 +10,7 @@ class Freezed {
   const Freezed({
     this.unionKey,
     this.unionValueCase = FreezedUnionCase.none,
+    this.fallbackUnion
   });
 
   /// Determines what key should be used to de/serialize union types.
@@ -92,6 +93,41 @@ class Freezed {
   /// You can also use [FreezedUnionValue] annotation to customize single
   /// union case.
   final FreezedUnionCase unionValueCase;
+
+  /// Determines which constructor should be used when there is no matching one
+  /// through constructor name or using [FreezedUnionValue]
+  ///
+  /// By default, Freezed generates code that will throw FallThroughError when type
+  /// is not matched through constructor name or using [FreezedUnionValue].
+  /// You can override this behavior by providing it's name or 'default' to use 
+  /// default constructor
+  ///
+  /// ```dart
+  /// @Freezed(fallbackUnion: 'fallback')
+  /// class MyResponse with _$MyResponse {
+  ///   const factory MyResponse.special(String a, int b) = MyResponseSpecial;
+  ///   const factory MyResponse.fallback(String a, int b) = MyResponseFallback;
+  ///
+  ///   factory MyResponse.fromJson(Map<String, dynamic> json) => _$MyResponseFromJson(json);
+  /// }
+  /// ```
+  ///
+  /// The constructor will be chosen as follows:
+  ///
+  /// ```json
+  /// [
+  ///   {
+  ///     "runtimeType": "special",
+  ///     "a": "This JSON object will use constructor MyResponse.special()"
+  ///     "b": 42
+  ///   },
+  ///   {
+  ///     "runtimeType": "surprise",
+  ///     "a": "This JSON object will use constructor MyResponse.fallback()",
+  ///     "b": 42
+  ///   }
+  /// ]
+  final String? fallbackUnion;
 }
 
 /// An annotation for the `freezed` package.
@@ -272,43 +308,6 @@ class FreezedUnionValue {
   const FreezedUnionValue(this.value);
 
   final String value;
-}
-
-/// An annotation used to specify fallback constructor used when union type is not matched
-///
-/// By default, Freezed generates code that will throw FallThroughError when type
-/// is not matched through constructor name or using [FreezedUnionValue].
-/// You can override this behavior by annotating constructor and using it as a fallback one
-///
-/// ```dart
-/// @freezed
-/// class MyResponse with _$MyResponse {
-///   const factory MyResponse.special(String a, int b) = MyResponseSpecial;
-///
-///   @FreezedUnionFallback()
-///   const factory MyResponse.fallback(String a, int b) = MyResponseFallback;
-///
-///   factory MyResponse.fromJson(Map<String, dynamic> json) => _$MyResponseFromJson(json);
-/// }
-/// ```
-///
-/// The constructor will be chosen as follows:
-///
-/// ```json
-/// [
-///   {
-///     "runtimeType": "special",
-///     "a": "This JSON object will use constructor MyResponse.special()"
-///     "b": 42
-///   },
-///   {
-///     "runtimeType": "surprise",
-///     "a": "This JSON object will use constructor MyResponse.fallback()",
-///     "b": 42
-///   }
-/// ]
-class FreezedUnionFallback {
-  const FreezedUnionFallback();
 }
 
 /// Options for automatic union values renaming.

--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -297,12 +297,13 @@ class FreezedUnionValue {
 /// ```json
 /// [
 ///   {
-///     "runtimeType": "default",
-///     "a": "This JSON object will use constructor MyResponse()"
+///     "runtimeType": "special",
+///     "a": "This JSON object will use constructor MyResponse.special()"
+///     "b": 42
 ///   },
 ///   {
-///     "runtimeType": "SpecialCase",
-///     "a": "This JSON object will use constructor MyResponse.special()",
+///     "runtimeType": "surprise",
+///     "a": "This JSON object will use constructor MyResponse.fallback()",
 ///     "b": 42
 ///   }
 /// ]


### PR DESCRIPTION
Hi, this is a small change to support fallback option for union types. Currently when type is not matched by factory constructor name or using custom **FreezedUnionValue** annotation generated code will throw **FallThroughError**. I've added **FreezedUnionFallback** annotation to mark constructor that should be used as a fallback one.