### PR TITLE
Allow a constructor parameter with json converter

### DIFF
--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -132,7 +132,8 @@ Read here: https://github.com/rrousselGit/freezed/tree/master/packages/freezed#t
     for (final parameter in constructor.parameters) {
       if (parameter.type.nullabilitySuffix != NullabilitySuffix.question &&
           parameter.isOptional &&
-          parameter.defaultValue == null) {
+          parameter.defaultValue == null &&
+          !parameter.hasJsonConverter) {
         final ctorName =
             constructor.isDefaultConstructor ? '' : '.${constructor.name}';
 

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -349,6 +349,10 @@ extension DefaultValue on ParameterElement {
   bool get hasJsonKey {
     return const TypeChecker.fromRuntime(JsonKey).hasAnnotationOf(this);
   }
+
+  bool get hasJsonConverter {
+    return const TypeChecker.fromRuntime(JsonConverter).hasAnnotationOf(this);
+  }
 }
 
 String? parseTypeSource(VariableElement element) {


### PR DESCRIPTION
Allow constructor parameter with json converter annotation to be generated without making the parameter nullable or using the `@Default()` annotation.