### PR TITLE
Add missing closing backticks to JSON code blocks

### DIFF
--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -127,6 +127,7 @@ class Freezed {
   ///     "b": 42
   ///   }
   /// ]
+  /// ```
   final String? fallbackUnion;
 }
 
@@ -304,6 +305,7 @@ class With {
 ///     "b": 42
 ///   }
 /// ]
+/// ```
 class FreezedUnionValue {
   const FreezedUnionValue(this.value);
 


### PR DESCRIPTION
These missing backticks tripped up GitHub's code highlighting real hard.