### PR TITLE
Allow using enums as FreezedUnionValue values

### DIFF
--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -1073,6 +1073,31 @@ which would update the previous json to:
 ]
 ```
 
+An enum can also be used as a union value, optionally using the `JsonValue`
+annotation to override the value string:
+
+```dart
+enum MyResponseType {
+  @JsonValue('Default') defaultResponse,
+  @JsonValue('SpecialCase') specialCase,
+  @JsonValue('Error') error,
+}
+
+@Freezed(unionKey: 'type', unionValueCase: FreezedUnionCase.pascal)
+abstract class MyResponse with _$MyResponse {
+  @FreezedUnionValue(MyResponseType.defaultResponse)
+  const factory MyResponse(String a) = MyResponseData;
+
+  @FreezedUnionValue(MyResponseType.specialCase)
+  const factory MyResponse.special(String a, int b) = MyResponseSpecial;
+
+  @FreezedUnionValue(MyResponseType.error)
+  const factory MyResponse.error(String message) = MyResponseError;
+
+  // ...
+}
+```
+
 If you want to customize key and value for all the classes, you can specify it inside your
 `build.yaml` file, for example:
 

--- a/packages/freezed/test/integration/json.dart
+++ b/packages/freezed/test/integration/json.dart
@@ -90,12 +90,25 @@ class CustomKey with _$CustomKey {
       _$CustomKeyFromJson(json);
 }
 
+enum CustomUnionValues {
+  third,
+
+  @JsonValue('FOURTH')
+  fourth,
+}
+
 @freezed
 class CustomUnionValue with _$CustomUnionValue {
   const factory CustomUnionValue.first(int a) = _CustomUnionValueFirst;
 
   @FreezedUnionValue('SECOND')
   const factory CustomUnionValue.second(int a) = _CustomUnionValueSecond;
+
+  @FreezedUnionValue(CustomUnionValues.third)
+  const factory CustomUnionValue.third(int a) = _CustomUnionValueThird;
+
+  @FreezedUnionValue(CustomUnionValues.fourth)
+  const factory CustomUnionValue.fourth(int a) = _CustomUnionValueFourth;
 
   factory CustomUnionValue.fromJson(Map<String, dynamic> json) =>
       _$CustomUnionValueFromJson(json);

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -106,6 +106,22 @@ Future<void> main() async {
         }),
         CustomUnionValue.second(21),
       );
+
+      expect(
+        CustomUnionValue.fromJson(<String, dynamic>{
+          'runtimeType': 'third',
+          'a': 10,
+        }),
+        CustomUnionValue.third(10),
+      );
+
+      expect(
+        CustomUnionValue.fromJson(<String, dynamic>{
+          'runtimeType': 'FOURTH',
+          'a': 5,
+        }),
+        CustomUnionValue.fourth(5),
+      );
     });
 
     test('toJson', () {
@@ -117,6 +133,16 @@ Future<void> main() async {
       expect(
         CustomUnionValue.second(21).toJson(),
         <String, dynamic>{'runtimeType': 'SECOND', 'a': 21},
+      );
+
+      expect(
+        CustomUnionValue.third(10).toJson(),
+        <String, dynamic>{'runtimeType': 'third', 'a': 10},
+      );
+
+      expect(
+        CustomUnionValue.fourth(5).toJson(),
+        <String, dynamic>{'runtimeType': 'FOURTH', 'a': 5},
       );
     });
   });
@@ -156,7 +182,7 @@ Future<void> main() async {
 
       expect(
           () => CustomUnionValue.fromJson(<String, dynamic>{
-                'runtimeType': 'third',
+                'runtimeType': 'fifth',
                 'a': 10,
               }),
           throwsA(const TypeMatcher<FallThroughError>()));

--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -304,10 +304,31 @@ class With {
 ///     "b": 42
 ///   }
 /// ]
+///
+/// An enum can also be used as a union value, optionally using the [JsonValue]
+/// annotation to override the value string:
+///
+/// ```dart
+/// enum MyResponseType { defaultResponse, @JsonValue('SpecialCase') specialCase }
+///
+/// @freezed
+/// class MyResponse with _$MyResponse {
+///   @FreezedUnionValue(MyResponseType.default)
+///   const factory MyResponse(String a) = MyResponseData;
+///
+///   @FreezedUnionValue(MyResponseType.specialCase)
+///   const factory MyResponse.special(String a, int b) = MyResponseSpecial;
+///
+///   factory MyResponse.fromJson(Map<String, dynamic> json) => _$MyResponseFromJson(json);
+/// }
+/// ```
 class FreezedUnionValue {
   const FreezedUnionValue(this.value);
 
-  final String value;
+  /// The value to use to identify the union type.
+  ///
+  /// This must be either a [String] or enum.
+  final Object value;
 }
 
 /// Options for automatic union values renaming.


### PR DESCRIPTION
This resolves #468.

There ~~are two~~ is one possible concern~~s~~ with this PR:
1) Integer values, while used as-is when serializing and deserializing enums in json_serializable,
   are converted to strings here. This is because the existing JSON and union code only uses strings.
2) ~~There are no tests. There aren't any exists tests (as far as I can tell) for union annotations at
   all, so I hope this is okay.~~