### PR TITLE
Throw a CheckedFromJsonException instead of a FallThroughError when an unknown union type value is encountered

### DIFF
--- a/packages/freezed/example/lib/main.freezed.dart
+++ b/packages/freezed/example/lib/main.freezed.dart
@@ -175,7 +175,8 @@ Union _$UnionFromJson(Map<String, dynamic> json) {
       return Complex.fromJson(json);
 
     default:
-      throw FallThroughError();
+      throw CheckedFromJsonException(json, 'custom-key', 'Union',
+          'Invalid union type "${json['custom-key']}"!');
   }
 }
 

--- a/packages/freezed/example/test/json_test.dart
+++ b/packages/freezed/example/test/json_test.dart
@@ -2,6 +2,7 @@
 
 import 'package:example/main.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 
 void main() {
   test('Union toJson', () {
@@ -32,5 +33,18 @@ void main() {
       Union.fromJson(<String, dynamic>{'custom-key': 'Loading'}),
       const Union.loading(),
     );
+  });
+
+  test('Union fromJson with invalid union type value', () {
+    final json = <String, dynamic>{'custom-key': 'InvalidValue'};
+    void deserialize() => Union.fromJson(json);
+    expect(deserialize, throwsA(isA<CheckedFromJsonException>()));
+    try {
+      deserialize();
+    } on CheckedFromJsonException catch (e) {
+      expect(e.key, 'custom-key');
+      expect(e.map, json);
+      expect(e.className, 'Union');
+    }
   });
 }

--- a/packages/freezed/example/test/json_test.dart
+++ b/packages/freezed/example/test/json_test.dart
@@ -2,7 +2,6 @@
 
 import 'package:example/main.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:freezed_annotation/freezed_annotation.dart';
 
 void main() {
   test('Union toJson', () {
@@ -33,18 +32,5 @@ void main() {
       Union.fromJson(<String, dynamic>{'custom-key': 'Loading'}),
       const Union.loading(),
     );
-  });
-
-  test('Union fromJson with invalid union type value', () {
-    final json = <String, dynamic>{'custom-key': 'InvalidValue'};
-    void deserialize() => Union.fromJson(json);
-    expect(deserialize, throwsA(isA<CheckedFromJsonException>()));
-    try {
-      deserialize();
-    } on CheckedFromJsonException catch (e) {
-      expect(e.key, 'custom-key');
-      expect(e.map, json);
-      expect(e.className, 'Union');
-    }
   });
 }

--- a/packages/freezed/lib/src/parse_generator.dart
+++ b/packages/freezed/lib/src/parse_generator.dart
@@ -27,7 +27,6 @@ abstract class ParserGenerator<GlobalData, Data, Annotation>
         hasGeneratedGlobalCode = true;
         for (final value
             in generateForAll(globalData).map((e) => e.toString())) {
-          assert(value.length == value.trim().length);
           values.writeln(value);
         }
       }
@@ -36,7 +35,6 @@ abstract class ParserGenerator<GlobalData, Data, Annotation>
       if (data == null) continue;
       for (final value
           in generateForData(globalData, data).map((e) => e.toString())) {
-        assert(value.length == value.trim().length);
         values.writeln(value);
       }
     }

--- a/packages/freezed/lib/src/templates/from_json_template.dart
+++ b/packages/freezed/lib/src/templates/from_json_template.dart
@@ -39,7 +39,8 @@ class FromJson {
       }).join();
 
       // TODO(rrousselGit): update logic once https://github.com/rrousselGit/freezed/pull/370 lands
-      var defaultCase = 'throw FallThroughError();';
+      var defaultCase =
+          'throw CheckedFromJsonException(json, \'$unionKey\', \'$name\', \'Invalid union type "\${json[\'$unionKey\']}"!\');';
       final fallbackConstructor =
           constructors.singleWhereOrNull((element) => element.isFallback);
       if (fallbackConstructor != null) {

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -164,7 +164,7 @@ Future<void> main() async {
         throwsA(
           isA<CheckedFromJsonException>()
               .having((e) => e.key, 'key', 'runtimeType')
-              .having((e) => e.map, 'map', 'invalidUnionTypeValueJson')
+              .having((e) => e.map, 'map', invalidUnionTypeValueJson)
               .having((e) => e.className, 'className', 'CustomUnionValue'),
         ),
       );

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -159,15 +159,15 @@ Future<void> main() async {
         'runtimeType': 'third',
         'a': 10,
       };
-      expect(() => CustomUnionValue.fromJson(invalidUnionTypeValueJson),
-          throwsA(isA<CheckedFromJsonException>()));
-      try {
-        CustomUnionValue.fromJson(invalidUnionTypeValueJson);
-      } on CheckedFromJsonException catch (e) {
-        expect(e.key, 'runtimeType');
-        expect(e.map, invalidUnionTypeValueJson);
-        expect(e.className, 'CustomUnionValue');
-      }
+      expect(
+        () => CustomUnionValue.fromJson(invalidUnionTypeValueJson),
+        throwsA(
+          isA<CheckedFromJsonException>()
+              .having((e) => e.key, 'key', 'runtimeType')
+              .having((e) => e.map, 'map', 'invalidUnionTypeValueJson')
+              .having((e) => e.className, 'className', 'CustomUnionValue'),
+        ),
+      );
     });
   });
 
@@ -401,24 +401,27 @@ Future<void> main() async {
   });
 
   test('throws if runtimeType matches nothing', () {
-    Map<String, dynamic> json;
+    const emptyJson = <String, dynamic>{};
+    expect(
+      () => Json.fromJson(emptyJson),
+      throwsA(
+        isA<CheckedFromJsonException>()
+            .having((e) => e.key, 'key', 'runtimeType')
+            .having((e) => e.map, 'map', emptyJson)
+            .having((e) => e.className, 'className', 'Json'),
+      ),
+    );
 
-    void check() {
-      expect(
-          () => Json.fromJson(json), throwsA(isA<CheckedFromJsonException>()));
-      try {
-        Json.fromJson(json);
-      } on CheckedFromJsonException catch (e) {
-        expect(e.key, 'runtimeType');
-        expect(e.map, json);
-        expect(e.className, 'Json');
-      }
-    }
-
-    json = <String, dynamic>{};
-    check();
-    json = <String, dynamic>{'runtimeType': 'unknown'};
-    check();
+    const unknownTypeJson = <String, dynamic>{'runtimeType': 'unknown'};
+    expect(
+      () => Json.fromJson(unknownTypeJson),
+      throwsA(
+        isA<CheckedFromJsonException>()
+            .having((e) => e.key, 'key', 'runtimeType')
+            .having((e) => e.map, 'map', unknownTypeJson)
+            .having((e) => e.className, 'className', 'Json'),
+      ),
+    );
   });
 
   test('fromJson', () {


### PR DESCRIPTION
According to the Dart documentation:
> An `Error` object represents a program failure that the programmer
> should have avoided.
>
> Examples include calling a function with invalid arguments,
> or even with the wrong number of arguments,
> or calling it at a time when it is not allowed.
>
> These are not errors that a caller should expect or catch -
> if they occur, the program is erroneous,
> and terminating the program may be the safest response.

In my opinion, a `FallThroughError` is not appropriate to throw when an unknown union type value is deserialized.

- Situations like these may need to be caught, like when receiving arbitrary input in a HTTP request
- `FallThroughError` is an implementation detail - why should us developers care that a switch is being used for this?

This PR replaces the error with a `CheckedFromJsonException`, the exception used by json_serializable when invalid JSON data is deserialised. It allows developers to catch it, and includes more information about its cause.