### PR TITLE
upgrade json_serializable to 5.0.0

### DIFF
--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -72,6 +72,7 @@ See [the example](https://github.com/rrousselGit/freezed/blob/master/packages/fr
 - [Index](#index)
 - [How to use](#how-to-use)
   - [Install](#install)
+    - [Disabling invalid_annotation_target warning and warning in generates files.](#disabling-invalid_annotation_target-warning-and-warning-in-generates-files)
   - [Run the generator](#run-the-generator)
   - [Ignore lint warnings on generated files](#ignore-lint-warnings-on-generated-files)
 - [The features](#the-features)
@@ -120,6 +121,28 @@ This installs three packages:
 - [build_runner](https://pub.dev/packages/build_runner), the tool to run code-generators
 - [freezed], the code generator
 - [freezed_annotation](https://pub.dev/packages/freezed_annotation), a package containing annotations for [freezed].
+
+
+### Disabling invalid_annotation_target warning and warning in generates files.
+
+If you plan on using [Frezed] in combination with `json_serializable`, recent
+versions of `json_serializable` and `meta` may require you to disable the
+`invalid_annotation_target` warning.
+
+Similarly, you may want to disable warnings that happen in `.freezed.dart`, if any.
+
+To do that, you can add the following to an `analysis_options.yaml`
+at the root of your project:
+
+```yaml
+analyzer:
+  exclude:
+    - "**/*.g.dart"
+    - "**/*.freezed.dart"
+  errors:
+    invalid_annotation_target: ignore
+```
+
 
 ## Run the generator
 

--- a/packages/freezed/analysis_options.yaml
+++ b/packages/freezed/analysis_options.yaml
@@ -5,6 +5,9 @@ analyzer:
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false
+  errors:
+    invalid_annotation_target: ignore
+
 linter:
   rules:
     # - public_member_api_docs

--- a/packages/freezed/example/lib/main.freezed.dart
+++ b/packages/freezed/example/lib/main.freezed.dart
@@ -302,7 +302,7 @@ class _$DataCopyWithImpl<$Res> extends _$UnionCopyWithImpl<$Res>
 class _$Data with DiagnosticableTreeMixin implements Data {
   const _$Data(this.value);
 
-  factory _$Data.fromJson(Map<String, dynamic> json) => _$_$DataFromJson(json);
+  factory _$Data.fromJson(Map<String, dynamic> json) => _$$DataFromJson(json);
 
   @override
   final int value;
@@ -391,7 +391,7 @@ class _$Data with DiagnosticableTreeMixin implements Data {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$_$DataToJson(this)..['custom-key'] = 'Default';
+    return _$$DataToJson(this)..['custom-key'] = 'Default';
   }
 }
 
@@ -427,7 +427,7 @@ class _$Loading with DiagnosticableTreeMixin implements Loading {
   const _$Loading();
 
   factory _$Loading.fromJson(Map<String, dynamic> json) =>
-      _$_$LoadingFromJson(json);
+      _$$LoadingFromJson(json);
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
@@ -502,7 +502,7 @@ class _$Loading with DiagnosticableTreeMixin implements Loading {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$_$LoadingToJson(this)..['custom-key'] = 'Loading';
+    return _$$LoadingToJson(this)..['custom-key'] = 'Loading';
   }
 }
 
@@ -549,7 +549,7 @@ class _$ErrorDetails with DiagnosticableTreeMixin implements ErrorDetails {
   const _$ErrorDetails([this.message]);
 
   factory _$ErrorDetails.fromJson(Map<String, dynamic> json) =>
-      _$_$ErrorDetailsFromJson(json);
+      _$$ErrorDetailsFromJson(json);
 
   @override
   final String? message;
@@ -638,7 +638,7 @@ class _$ErrorDetails with DiagnosticableTreeMixin implements ErrorDetails {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$_$ErrorDetailsToJson(this)..['custom-key'] = 'Error';
+    return _$$ErrorDetailsToJson(this)..['custom-key'] = 'Error';
   }
 }
 
@@ -694,7 +694,7 @@ class _$Complex with DiagnosticableTreeMixin implements Complex {
   const _$Complex(this.a, this.b);
 
   factory _$Complex.fromJson(Map<String, dynamic> json) =>
-      _$_$ComplexFromJson(json);
+      _$$ComplexFromJson(json);
 
   @override
   final int a;
@@ -790,7 +790,7 @@ class _$Complex with DiagnosticableTreeMixin implements Complex {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$_$ComplexToJson(this)..['custom-key'] = 'Complex';
+    return _$$ComplexToJson(this)..['custom-key'] = 'Complex';
   }
 }
 

--- a/packages/freezed/example/lib/main.g.dart
+++ b/packages/freezed/example/lib/main.g.dart
@@ -6,42 +6,35 @@ part of 'main.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$Data _$_$DataFromJson(Map<String, dynamic> json) {
-  return _$Data(
-    json['value'] as int,
-  );
-}
+_$Data _$$DataFromJson(Map<String, dynamic> json) => _$Data(
+      json['value'] as int,
+    );
 
-Map<String, dynamic> _$_$DataToJson(_$Data instance) => <String, dynamic>{
+Map<String, dynamic> _$$DataToJson(_$Data instance) => <String, dynamic>{
       'value': instance.value,
     };
 
-_$Loading _$_$LoadingFromJson(Map<String, dynamic> json) {
-  return _$Loading();
-}
+_$Loading _$$LoadingFromJson(Map<String, dynamic> json) => _$Loading();
 
-Map<String, dynamic> _$_$LoadingToJson(_$Loading instance) =>
+Map<String, dynamic> _$$LoadingToJson(_$Loading instance) =>
     <String, dynamic>{};
 
-_$ErrorDetails _$_$ErrorDetailsFromJson(Map<String, dynamic> json) {
-  return _$ErrorDetails(
-    json['message'] as String?,
-  );
-}
+_$ErrorDetails _$$ErrorDetailsFromJson(Map<String, dynamic> json) =>
+    _$ErrorDetails(
+      json['message'] as String?,
+    );
 
-Map<String, dynamic> _$_$ErrorDetailsToJson(_$ErrorDetails instance) =>
+Map<String, dynamic> _$$ErrorDetailsToJson(_$ErrorDetails instance) =>
     <String, dynamic>{
       'message': instance.message,
     };
 
-_$Complex _$_$ComplexFromJson(Map<String, dynamic> json) {
-  return _$Complex(
-    json['a'] as int,
-    json['b'] as String,
-  );
-}
+_$Complex _$$ComplexFromJson(Map<String, dynamic> json) => _$Complex(
+      json['a'] as int,
+      json['b'] as String,
+    );
 
-Map<String, dynamic> _$_$ComplexToJson(_$Complex instance) => <String, dynamic>{
+Map<String, dynamic> _$$ComplexToJson(_$Complex instance) => <String, dynamic>{
       'a': instance.a,
       'b': instance.b,
     };

--- a/packages/freezed/example/pubspec.yaml
+++ b/packages/freezed/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 dev_dependencies:
   freezed:
     path: ../
-  json_serializable: ^4.0.0
+  json_serializable: ^5.0.0
   build_runner:
   flutter_test:
     sdk: flutter

--- a/packages/freezed/lib/builder.dart
+++ b/packages/freezed/lib/builder.dart
@@ -8,6 +8,6 @@ Builder freezed(BuilderOptions options) {
   return PartBuilder([FreezedGenerator(options.config)], '.freezed.dart',
       header: '''
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
     ''');
 }

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -39,6 +39,10 @@ class Concrete {
     return '_\$${constructor.redirectedName}';
   }
 
+  String get nonPrivateConcreteName {
+    return '\$${constructor.redirectedName}';
+  }
+
   @override
   String toString() {
     final asserts = constructor.asserts.join(',');
@@ -167,7 +171,7 @@ ${copyWith.abstractCopyWithGetter}
 
   String get _concreteFromJsonConstructor {
     if (!shouldGenerateJson) return '';
-    return 'factory $concreteName.fromJson(Map<String, dynamic> json) => _\$${concreteName}FromJson(json);';
+    return 'factory $concreteName.fromJson(Map<String, dynamic> json) => _\$${nonPrivateConcreteName}FromJson(json);';
   }
 
   String get _toJson {
@@ -180,7 +184,7 @@ ${copyWith.abstractCopyWithGetter}
     return '''
 @override
 Map<String, dynamic> toJson() {
-  return _\$${concreteName}ToJson(this)$addRuntimeType;
+  return _\$${nonPrivateConcreteName}ToJson(this)$addRuntimeType;
 }''';
   }
 

--- a/packages/freezed/lib/src/templates/prototypes.dart
+++ b/packages/freezed/lib/src/templates/prototypes.dart
@@ -142,7 +142,9 @@ String _unionPrototype(
     );
 
     if (constructor.isDefault) {
-      buffer..write(template)..write(',');
+      buffer
+        ..write(template)
+        ..write(',');
     } else {
       parameters.add(template);
     }

--- a/packages/freezed/lib/src/templates/tear_off.dart
+++ b/packages/freezed/lib/src/templates/tear_off.dart
@@ -46,7 +46,9 @@ const $outputName = _\$${name}TearOff();
       final parameters = StringBuffer();
       for (final positional
           in targetConstructor.parameters.allPositionalParameters) {
-        parameters..write(positional.name)..write(',');
+        parameters
+          ..write(positional.name)
+          ..write(',');
       }
       for (final named in targetConstructor.parameters.namedParameters) {
         parameters

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: ^1.5.0
+  analyzer: ^2.0.0
   build: ^2.0.1
   build_config: ^1.0.0
   collection: ^1.15.0
@@ -18,8 +18,8 @@ dependencies:
   freezed_annotation: ">=0.14.2 <2.0.0"
 
 dev_dependencies:
-  json_serializable: ^4.1.1
-  json_annotation: ^4.0.1
+  json_serializable: ^5.0.0
+  json_annotation: ^4.1.0
   build_test: ^2.1.0
   build_runner: ^2.0.0
   test: ^1.16.8

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -25,7 +25,3 @@ dev_dependencies:
   test: ^1.16.8
   matcher: ^0.12.10
   source_gen_test: ^1.0.0
-
-dependency_overrides:
-  freezed_annotation:
-    path: ../freezed_annotation

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -25,3 +25,7 @@ dev_dependencies:
   test: ^1.16.8
   matcher: ^0.12.10
   source_gen_test: ^1.0.0
+
+dependency_overrides:
+  freezed_annotation:
+    path: ../freezed_annotation

--- a/packages/freezed/test/integration/json.dart
+++ b/packages/freezed/test/integration/json.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: invalid_annotation_target
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'json.freezed.dart';

--- a/packages/freezed/test/integration/json.dart
+++ b/packages/freezed/test/integration/json.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: invalid_annotation_target
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'json.freezed.dart';

--- a/packages/freezed_annotation/pubspec.yaml
+++ b/packages/freezed_annotation/pubspec.yaml
@@ -10,5 +10,5 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  json_annotation: ^4.0.1
+  json_annotation: ^4.1.0
   meta: ^1.3.0


### PR DESCRIPTION
[#474](https://github.com/rrousselGit/freezed/issues/474)
Mentioned in json_serializable [CHANGELOG](https://github.com/google/json_serializable.dart/blob/master/json_serializable/CHANGELOG.md) 5.0.0
- Improve names of private classes generated for `toJson` and `fromJson`.
That's why added why I added:
```dart
String get nonPrivateConcreteName {
    return '\$${constructor.redirectedName}';
}
```