### PR TITLE
Exclude generated files from coverage

### DIFF
--- a/packages/freezed/lib/builder.dart
+++ b/packages/freezed/lib/builder.dart
@@ -7,6 +7,7 @@ import 'src/freezed_generator.dart';
 Builder freezed(BuilderOptions options) {
   return PartBuilder([FreezedGenerator(options.config)], '.freezed.dart',
       header: '''
+// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides
     ''');


### PR DESCRIPTION
This resolves #442 and #333.

i know this should be the role of source_gen instead, not Freezed, as this isn't Freezed-specific. But i guess until source_gen provides the solution to the issue, this would a great solution.