### PR TITLE
Support nullable unionKey

### DIFF
--- a/packages/freezed/lib/src/templates/from_json_template.dart
+++ b/packages/freezed/lib/src/templates/from_json_template.dart
@@ -49,7 +49,7 @@ class FromJson {
       }
 
       content = '''
-        switch (json['$unionKey'] as String) {
+        switch (json['$unionKey'] as String?) {
           $cases
           default:
             $defaultCase

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -123,6 +123,19 @@ Future<void> main() async {
   });
 
   group('FreezedUnionFallback', () {
+    test(
+        'when fallback is non-null, if fromJson receives null as value, fallbacks to default',
+        () {
+      expect(
+        UnionFallback.fromJson(<String, dynamic>{'type': null, 'a': 42}),
+        UnionFallback.fallback(42),
+      );
+      expect(
+        UnionFallback.fromJson(<String, dynamic>{'a': 42}),
+        UnionFallback.fallback(42),
+      );
+    });
+
     test('fromJson', () {
       expect(
         UnionFallback.fromJson(<String, dynamic>{


### PR DESCRIPTION
Closes #467 by introducing a `nullableUnionKey` property to the `Freezed` annotation.