### PR TITLE
fix deprecated_member_use of analyzer 2.1.0 using flutter channel dev

### DIFF
--- a/packages/freezed/lib/src/utils.dart
+++ b/packages/freezed/lib/src/utils.dart
@@ -30,7 +30,7 @@ Future<AstNode> tryGetAstNodeForElement(
 
   while (true) {
     try {
-      final result = library.session.getParsedLibraryByElement2(library)
+      final result = library.session.getParsedLibraryByElement(library)
           as ParsedLibraryResult?;
 
       return result!.getElementDeclaration(element)!.node;

--- a/packages/freezed/test/bidirectional_test.dart
+++ b/packages/freezed/test/bidirectional_test.dart
@@ -17,7 +17,7 @@ void main() {
     );
 
     final errorResult = await main.session
-            .getErrors2('/freezed/test/integration/bidirectional.freezed.dart')
+            .getErrors('/freezed/test/integration/bidirectional.freezed.dart')
         as ErrorsResult;
 
     expect(errorResult.errors, isEmpty);

--- a/packages/freezed/test/common.dart
+++ b/packages/freezed/test/common.dart
@@ -19,7 +19,7 @@ $src
   }, (r) => r.findLibraryByName('main'));
 
   final errorResult = await main.session
-      .getErrors2('/freezed/test/integration/main.dart') as ErrorsResult;
+      .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
   final criticalErrors = errorResult.errors
       .where((element) => element.severity == Severity.error)
       .toList();

--- a/packages/freezed/test/decorator_test.dart
+++ b/packages/freezed/test/decorator_test.dart
@@ -16,11 +16,11 @@ void main() {
     );
 
     var errorResult = await main.session
-            .getErrors2('/freezed/test/integration/decorator.freezed.dart')
+            .getErrors('/freezed/test/integration/decorator.freezed.dart')
         as ErrorsResult;
     expect(errorResult.errors, isEmpty);
     errorResult = await main.session
-        .getErrors2('/freezed/test/integration/decorator.dart') as ErrorsResult;
+        .getErrors('/freezed/test/integration/decorator.dart') as ErrorsResult;
   });
 
   test('warns if try to use deprecated property', () async {
@@ -52,7 +52,7 @@ void main() {
     );
 
     var errorResult = await main.session
-        .getErrors2('/freezed/test/integration/main.dart') as ErrorsResult;
+        .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
     expect(
         errorResult.errors.map((e) => e.errorCode.name),
         anyOf([

--- a/packages/freezed/test/deep_copy_test.dart
+++ b/packages/freezed/test/deep_copy_test.dart
@@ -21,7 +21,7 @@ void main() {
     );
 
     final errorResult = await main.session
-            .getErrors2('/freezed/test/integration/deep_copy.freezed.dart')
+            .getErrors('/freezed/test/integration/deep_copy.freezed.dart')
         as ErrorsResult;
 
     expect(errorResult.errors, isEmpty);
@@ -37,7 +37,7 @@ void main() {
     );
 
     final errorResult = await main.session
-            .getErrors2('/freezed/test/integration/deep_copy2.freezed.dart')
+            .getErrors('/freezed/test/integration/deep_copy2.freezed.dart')
         as ErrorsResult;
 
     expect(errorResult.errors, isEmpty);

--- a/packages/freezed/test/generic_test.dart
+++ b/packages/freezed/test/generic_test.dart
@@ -61,7 +61,7 @@ void main() {
     );
 
     final errorResult = await main.session
-            .getErrors2('/freezed/test/integration/generic.freezed.dart')
+            .getErrors('/freezed/test/integration/generic.freezed.dart')
         as ErrorsResult;
 
     expect(errorResult.errors, isEmpty);

--- a/packages/freezed/test/generics_refs_test.dart
+++ b/packages/freezed/test/generics_refs_test.dart
@@ -18,7 +18,7 @@ void main() {
     );
 
     final errorResult = await main.session
-            .getErrors2('/freezed/test/integration/generics_refs.freezed.dart')
+            .getErrors('/freezed/test/integration/generics_refs.freezed.dart')
         as ErrorsResult;
 
     expect(errorResult.errors, isEmpty);

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -359,7 +359,7 @@ Future<void> main() async {
 
   test('has no issue', () async {
     var errorResult = await jsonFile.session
-            .getErrors2('/freezed/test/integration/json.freezed.dart')
+            .getErrors('/freezed/test/integration/json.freezed.dart')
         as ErrorsResult;
     expect(errorResult.errors, isEmpty);
   }, skip: true);

--- a/packages/freezed/test/map_test.dart
+++ b/packages/freezed/test/map_test.dart
@@ -269,7 +269,7 @@ void main() {
       );
 
       final errorResult = await main.session
-          .getErrors2('/freezed/test/integration/main.dart') as ErrorsResult;
+          .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
 
       expect(errorResult.errors, isNotEmpty);
     });
@@ -383,7 +383,7 @@ void main() {
       );
 
       final errorResult = await main.session
-          .getErrors2('/freezed/test/integration/main.dart') as ErrorsResult;
+          .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
 
       expect(errorResult.errors, isEmpty);
     });
@@ -406,7 +406,7 @@ void main() {
       );
 
       final errorResult = await main.session
-          .getErrors2('/freezed/test/integration/main.dart') as ErrorsResult;
+          .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
 
       expect(errorResult.errors, isNotEmpty);
     });

--- a/packages/freezed/test/multiple_constructors_test.dart
+++ b/packages/freezed/test/multiple_constructors_test.dart
@@ -154,7 +154,7 @@ void main() {
             element.source.toString().contains('multiple_constructors')),
       );
 
-      final errorResult = await main.session.getErrors2(
+      final errorResult = await main.session.getErrors(
               '/freezed/test/integration/multiple_constructors.freezed.dart')
           as ErrorsResult;
 

--- a/packages/freezed/test/single_class_constructor_test.dart
+++ b/packages/freezed/test/single_class_constructor_test.dart
@@ -294,7 +294,7 @@ void main() {
   test('has no issue', () async {
     final singleClassLibrary = await analyze();
 
-    final errorResult = await singleClassLibrary.session.getErrors2(
+    final errorResult = await singleClassLibrary.session.getErrors(
             '/freezed/test/integration/single_class_constructor.freezed.dart')
         as ErrorsResult;
 
@@ -562,7 +562,7 @@ void main() {
     }, (r) => r.findLibraryByName('main'));
 
     final errorResult = await main.session
-        .getErrors2('/freezed/test/integration/main.dart') as ErrorsResult;
+        .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
 
     expect(
       errorResult.errors.map((e) => e.toString()),

--- a/packages/freezed/test/when_test.dart
+++ b/packages/freezed/test/when_test.dart
@@ -268,7 +268,7 @@ void main() {
       );
 
       final errorResult = await main.session
-          .getErrors2('/freezed/test/integration/main.dart') as ErrorsResult;
+          .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
 
       expect(errorResult.errors, isNotEmpty);
     });
@@ -382,7 +382,7 @@ void main() {
       );
 
       final errorResult = await main.session
-          .getErrors2('/freezed/test/integration/main.dart') as ErrorsResult;
+          .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
 
       expect(errorResult.errors, isEmpty);
     });
@@ -405,7 +405,7 @@ void main() {
       );
 
       final errorResult = await main.session
-          .getErrors2('/freezed/test/integration/main.dart') as ErrorsResult;
+          .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
 
       expect(errorResult.errors, isNotEmpty);
     });


### PR DESCRIPTION
On the newest flutter dev channel `2.6.0-0.0.pre`
Resolving dependencies is using `analyzer 2.1.0` (previously 2.0.0).
This should fix github action failing during Step - Analyze.