### PR TITLE
fix(from-json-tear-off): adjust type signature of fromJson tear-off

### DIFF
--- a/packages/freezed/lib/src/templates/tear_off.dart
+++ b/packages/freezed/lib/src/templates/tear_off.dart
@@ -74,7 +74,7 @@ ${targetConstructor.redirectedName}$genericsParameter $ctorName$genericsDefiniti
 
     if (serializable) {
       yield '''
-$name$genericsParameter fromJson$genericsDefinition(Map<String, Object> json) {
+$name$genericsParameter fromJson$genericsDefinition(Map<String, Object?> json) {
   return $name$genericsParameter.fromJson(json);
 }
 ''';


### PR DESCRIPTION
fixes https://github.com/rrousselGit/freezed/issues/517

this change swaps the type signature of the generated fromJson tear-off
to Map<String, Object?> instead of Map<String, Object>.

it seems most likely that this was missed in the upgrade to null-safety.
this essentially restores the previously intended behavior. maybe once
the next version of dart lands we won't need to generate these anymore
:) but for now it's super useful when it works!

**Note on testing**
this change doesn't update the tests because the file that tests this
is set to run with dart 2.9. i _think_ it's probably safe to change that test 
file to allow dart 2.12+, but i didn't wanna any unnecessary changes. 

fwiw if those tests were running with 2.12+ they'd have shown this issue:
![image](https://user-images.githubusercontent.com/407586/133936863-94640337-2ba7-446f-ae9a-e015c2efb29a.png)
