### PR TITLE
Properly handle class names with dollar sign `$`

### DIFF
--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -246,6 +246,7 @@ Read here: https://github.com/rrousselGit/freezed/tree/master/packages/freezed#t
           unionValue: constructor.unionValue(configs.unionValueCase),
           isConst: constructor.isConst,
           fullName: _fullName(element, constructor),
+          escapedName: _escapedName(element, constructor),
           impliedProperties: [
             for (final parameter in constructor.parameters)
               await Property.fromParameter(parameter, buildStep),
@@ -537,6 +538,21 @@ Read here: https://github.com/rrousselGit/freezed/tree/master/packages/freezed#t
     return constructor.name.isEmpty
         ? '${element.name}$generics'
         : '${element.name}$generics.${constructor.name}';
+  }
+
+  String _escapedName(ClassElement element, ConstructorElement constructor) {
+    var generics = element.typeParameters.map((e) {
+      return '\$${e.name}';
+    }).join(', ');
+    if (generics.isNotEmpty) {
+      generics = '<$generics>';
+    }
+
+    final escapedElementName = element.name.replaceAll(r'$', r'\$');
+
+    return constructor.name.isEmpty
+        ? '$escapedElementName$generics'
+        : '$escapedElementName$generics.${constructor.name}';
   }
 
   /// For:

--- a/packages/freezed/lib/src/models.dart
+++ b/packages/freezed/lib/src/models.dart
@@ -41,6 +41,7 @@ abstract class ConstructorDetails with _$ConstructorDetails {
     required bool isFallback,
     required bool hasJsonSerializable,
     required String fullName,
+    required String escapedName,
     required List<String> withDecorators,
     required List<String> implementsDecorators,
     required List<String> decorators,

--- a/packages/freezed/lib/src/models.freezed.dart
+++ b/packages/freezed/lib/src/models.freezed.dart
@@ -264,6 +264,7 @@ class _$ConstructorDetailsTearOff {
       required bool isFallback,
       required bool hasJsonSerializable,
       required String fullName,
+      required String escapedName,
       required List<String> withDecorators,
       required List<String> implementsDecorators,
       required List<String> decorators,
@@ -280,6 +281,7 @@ class _$ConstructorDetailsTearOff {
       isFallback: isFallback,
       hasJsonSerializable: hasJsonSerializable,
       fullName: fullName,
+      escapedName: escapedName,
       withDecorators: withDecorators,
       implementsDecorators: implementsDecorators,
       decorators: decorators,
@@ -304,6 +306,7 @@ mixin _$ConstructorDetails {
   bool get isFallback => throw _privateConstructorUsedError;
   bool get hasJsonSerializable => throw _privateConstructorUsedError;
   String get fullName => throw _privateConstructorUsedError;
+  String get escapedName => throw _privateConstructorUsedError;
   List<String> get withDecorators => throw _privateConstructorUsedError;
   List<String> get implementsDecorators => throw _privateConstructorUsedError;
   List<String> get decorators => throw _privateConstructorUsedError;
@@ -479,6 +482,7 @@ class __$ConstructorDetailsCopyWithImpl<$Res>
     Object? isFallback = freezed,
     Object? hasJsonSerializable = freezed,
     Object? fullName = freezed,
+    Object? escapedName = freezed,
     Object? withDecorators = freezed,
     Object? implementsDecorators = freezed,
     Object? decorators = freezed,
@@ -526,6 +530,10 @@ class __$ConstructorDetailsCopyWithImpl<$Res>
           ? _value.fullName
           : fullName // ignore: cast_nullable_to_non_nullable
               as String,
+      escapedName: escapedName == freezed
+          ? _value.escapedName
+          : escapedName // ignore: cast_nullable_to_non_nullable
+              as String,
       withDecorators: withDecorators == freezed
           ? _value.withDecorators
           : withDecorators // ignore: cast_nullable_to_non_nullable
@@ -564,6 +572,7 @@ class _$_ConstructorDetails extends _ConstructorDetails {
       required this.isFallback,
       required this.hasJsonSerializable,
       required this.fullName,
+      required this.escapedName,
       required this.withDecorators,
       required this.implementsDecorators,
       required this.decorators,
@@ -591,6 +600,8 @@ class _$_ConstructorDetails extends _ConstructorDetails {
   final bool hasJsonSerializable;
   @override
   final String fullName;
+  @override
+  final String escapedName;
   @override
   final List<String> withDecorators;
   @override
@@ -693,6 +704,7 @@ abstract class _ConstructorDetails extends ConstructorDetails {
       required bool isFallback,
       required bool hasJsonSerializable,
       required String fullName,
+      required String escapedName,
       required List<String> withDecorators,
       required List<String> implementsDecorators,
       required List<String> decorators,

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -206,7 +206,7 @@ Map<String, dynamic> toJson() {
 void debugFillProperties(DiagnosticPropertiesBuilder properties) {
   super.debugFillProperties(properties);
   properties
-    ..add(DiagnosticsProperty('type', '${constructor.fullName}'))
+    ..add(DiagnosticsProperty('type', '${constructor.fullName.replaceAll(r'$', r'\$')}'))
     $diagnostics;
 }
 ''';
@@ -323,7 +323,7 @@ ${whenOrNullPrototype(allConstructors)} {
     return '''
 @override
 String toString($parameters) {
-  return '${constructor.fullName}(${properties.join(', ')})';
+  return '${constructor.fullName.replaceAll(r'$', r'\$')}(${properties.join(', ')})';
 }
 ''';
   }

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -206,7 +206,7 @@ Map<String, dynamic> toJson() {
 void debugFillProperties(DiagnosticPropertiesBuilder properties) {
   super.debugFillProperties(properties);
   properties
-    ..add(DiagnosticsProperty('type', '${constructor.fullName.replaceAll(r'$', r'\$')}'))
+    ..add(DiagnosticsProperty('type', '${constructor.escapedName}'))
     $diagnostics;
 }
 ''';
@@ -323,7 +323,7 @@ ${whenOrNullPrototype(allConstructors)} {
     return '''
 @override
 String toString($parameters) {
-  return '${constructor.fullName.replaceAll(r'$', r'\$')}(${properties.join(', ')})';
+  return '${constructor.escapedName}(${properties.join(', ')})';
 }
 ''';
   }

--- a/packages/freezed/test/integration/special_class_name.dart
+++ b/packages/freezed/test/integration/special_class_name.dart
@@ -1,0 +1,9 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'special_class_name.freezed.dart';
+
+@freezed
+class Class$With$Special$Name with _$Class$With$Special$Name {
+  factory Class$With$Special$Name({String? a, int? b}) =
+      _Class$With$Special$Name;
+}

--- a/packages/freezed/test/special_class_name_test.dart
+++ b/packages/freezed/test/special_class_name_test.dart
@@ -1,0 +1,15 @@
+// ignore_for_file: prefer_const_constructors, omit_local_variable_types
+import 'package:test/test.dart';
+
+import 'integration/special_class_name.dart';
+
+Future<void> main() async {
+  test('toString will properly handle dollar signs', () {
+    final value = Class$With$Special$Name(a: 'a', b: 1);
+
+    expect(
+      value.toString(),
+      r'Class$With$Special$Name(a: a, b: 1)',
+    );
+  });
+}


### PR DESCRIPTION
Freezed currently doesn't support the generation of classes with dollar sign character `$` (eg. `My$Class`) unless `toString` method is manually overridden because, due to the lack of escaping, code generation would consider `$Class` as a interpolation variable.

This quick fix simply escapes the character on both `toString` and `debugFillProperties` methods, where it's used inside a string.