### PR TITLE
Support json_serializable 6.0.1

### DIFF
--- a/packages/_internal/lib/models.dart
+++ b/packages/_internal/lib/models.dart
@@ -25,7 +25,7 @@ String constructorNameToCallbackName(String name) => name;
 /// This allows Freezed to support deep copy of the object.
 /// This does include primitives like [int] and [List].
 @freezed
-abstract class CloneableProperty with _$CloneableProperty {
+class CloneableProperty with _$CloneableProperty {
   factory CloneableProperty({
     required String name,
     required String typeName,
@@ -39,7 +39,7 @@ abstract class CloneableProperty with _$CloneableProperty {
 ///
 /// This only includes constructors where Freezed needs to generate something.
 @freezed
-abstract class ConstructorDetails with _$ConstructorDetails {
+class ConstructorDetails with _$ConstructorDetails {
   factory ConstructorDetails({
     required String name,
     required String unionValue,
@@ -64,7 +64,7 @@ abstract class ConstructorDetails with _$ConstructorDetails {
 }
 
 @freezed
-abstract class Data with _$Data {
+class Data with _$Data {
   @Assert('constructors.isNotEmpty')
   factory Data({
     required String name,
@@ -80,7 +80,7 @@ abstract class Data with _$Data {
 }
 
 @freezed
-abstract class GlobalData with _$GlobalData {
+class GlobalData with _$GlobalData {
   factory GlobalData({
     required bool hasJson,
     required bool hasDiagnostics,

--- a/packages/_internal/lib/models.freezed.dart
+++ b/packages/_internal/lib/models.freezed.dart
@@ -1,5 +1,6 @@
+// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
 
 part of 'models.dart';
 
@@ -192,30 +193,21 @@ class _$_CloneableProperty implements _CloneableProperty {
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
-        (other is _CloneableProperty &&
-            (identical(other.name, name) ||
-                const DeepCollectionEquality().equals(other.name, name)) &&
+        (other.runtimeType == runtimeType &&
+            other is _CloneableProperty &&
+            (identical(other.name, name) || other.name == name) &&
             (identical(other.typeName, typeName) ||
-                const DeepCollectionEquality()
-                    .equals(other.typeName, typeName)) &&
-            (identical(other.type, type) ||
-                const DeepCollectionEquality().equals(other.type, type)) &&
+                other.typeName == typeName) &&
+            (identical(other.type, type) || other.type == type) &&
             (identical(other.nullable, nullable) ||
-                const DeepCollectionEquality()
-                    .equals(other.nullable, nullable)) &&
+                other.nullable == nullable) &&
             (identical(other.genericParameters, genericParameters) ||
-                const DeepCollectionEquality()
-                    .equals(other.genericParameters, genericParameters)));
+                other.genericParameters == genericParameters));
   }
 
   @override
-  int get hashCode =>
-      runtimeType.hashCode ^
-      const DeepCollectionEquality().hash(name) ^
-      const DeepCollectionEquality().hash(typeName) ^
-      const DeepCollectionEquality().hash(type) ^
-      const DeepCollectionEquality().hash(nullable) ^
-      const DeepCollectionEquality().hash(genericParameters);
+  int get hashCode => Object.hash(
+      runtimeType, name, typeName, type, nullable, genericParameters);
 
   @JsonKey(ignore: true)
   @override
@@ -233,16 +225,15 @@ abstract class _CloneableProperty implements CloneableProperty {
       _$_CloneableProperty;
 
   @override
-  String get name => throw _privateConstructorUsedError;
+  String get name;
   @override
-  String get typeName => throw _privateConstructorUsedError;
+  String get typeName;
   @override
-  String get type => throw _privateConstructorUsedError;
+  String get type;
   @override
-  bool get nullable => throw _privateConstructorUsedError;
+  bool get nullable;
   @override
-  GenericsParameterTemplate get genericParameters =>
-      throw _privateConstructorUsedError;
+  GenericsParameterTemplate get genericParameters;
   @override
   @JsonKey(ignore: true)
   _$CloneablePropertyCopyWith<_CloneableProperty> get copyWith =>
@@ -610,70 +601,55 @@ class _$_ConstructorDetails extends _ConstructorDetails {
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
-        (other is _ConstructorDetails &&
-            (identical(other.name, name) ||
-                const DeepCollectionEquality().equals(other.name, name)) &&
+        (other.runtimeType == runtimeType &&
+            other is _ConstructorDetails &&
+            (identical(other.name, name) || other.name == name) &&
             (identical(other.unionValue, unionValue) ||
-                const DeepCollectionEquality()
-                    .equals(other.unionValue, unionValue)) &&
-            (identical(other.isConst, isConst) ||
-                const DeepCollectionEquality()
-                    .equals(other.isConst, isConst)) &&
+                other.unionValue == unionValue) &&
+            (identical(other.isConst, isConst) || other.isConst == isConst) &&
             (identical(other.redirectedName, redirectedName) ||
-                const DeepCollectionEquality()
-                    .equals(other.redirectedName, redirectedName)) &&
+                other.redirectedName == redirectedName) &&
             (identical(other.parameters, parameters) ||
-                const DeepCollectionEquality()
-                    .equals(other.parameters, parameters)) &&
-            (identical(other.impliedProperties, impliedProperties) ||
-                const DeepCollectionEquality()
-                    .equals(other.impliedProperties, impliedProperties)) &&
+                other.parameters == parameters) &&
+            const DeepCollectionEquality()
+                .equals(other.impliedProperties, impliedProperties) &&
             (identical(other.isDefault, isDefault) ||
-                const DeepCollectionEquality()
-                    .equals(other.isDefault, isDefault)) &&
+                other.isDefault == isDefault) &&
             (identical(other.isFallback, isFallback) ||
-                const DeepCollectionEquality()
-                    .equals(other.isFallback, isFallback)) &&
+                other.isFallback == isFallback) &&
             (identical(other.hasJsonSerializable, hasJsonSerializable) ||
-                const DeepCollectionEquality()
-                    .equals(other.hasJsonSerializable, hasJsonSerializable)) &&
+                other.hasJsonSerializable == hasJsonSerializable) &&
             (identical(other.fullName, fullName) ||
-                const DeepCollectionEquality()
-                    .equals(other.fullName, fullName)) &&
-            (identical(other.withDecorators, withDecorators) ||
-                const DeepCollectionEquality()
-                    .equals(other.withDecorators, withDecorators)) &&
-            (identical(other.implementsDecorators, implementsDecorators) ||
-                const DeepCollectionEquality().equals(
-                    other.implementsDecorators, implementsDecorators)) &&
-            (identical(other.decorators, decorators) ||
-                const DeepCollectionEquality()
-                    .equals(other.decorators, decorators)) &&
-            (identical(other.cloneableProperties, cloneableProperties) ||
-                const DeepCollectionEquality()
-                    .equals(other.cloneableProperties, cloneableProperties)) &&
-            (identical(other.asserts, asserts) ||
-                const DeepCollectionEquality().equals(other.asserts, asserts)));
+                other.fullName == fullName) &&
+            const DeepCollectionEquality()
+                .equals(other.withDecorators, withDecorators) &&
+            const DeepCollectionEquality()
+                .equals(other.implementsDecorators, implementsDecorators) &&
+            const DeepCollectionEquality()
+                .equals(other.decorators, decorators) &&
+            const DeepCollectionEquality()
+                .equals(other.cloneableProperties, cloneableProperties) &&
+            const DeepCollectionEquality().equals(other.asserts, asserts));
   }
 
   @override
-  int get hashCode =>
-      runtimeType.hashCode ^
-      const DeepCollectionEquality().hash(name) ^
-      const DeepCollectionEquality().hash(unionValue) ^
-      const DeepCollectionEquality().hash(isConst) ^
-      const DeepCollectionEquality().hash(redirectedName) ^
-      const DeepCollectionEquality().hash(parameters) ^
-      const DeepCollectionEquality().hash(impliedProperties) ^
-      const DeepCollectionEquality().hash(isDefault) ^
-      const DeepCollectionEquality().hash(isFallback) ^
-      const DeepCollectionEquality().hash(hasJsonSerializable) ^
-      const DeepCollectionEquality().hash(fullName) ^
-      const DeepCollectionEquality().hash(withDecorators) ^
-      const DeepCollectionEquality().hash(implementsDecorators) ^
-      const DeepCollectionEquality().hash(decorators) ^
-      const DeepCollectionEquality().hash(cloneableProperties) ^
-      const DeepCollectionEquality().hash(asserts);
+  int get hashCode => Object.hash(
+      runtimeType,
+      name,
+      unionValue,
+      isConst,
+      redirectedName,
+      parameters,
+      const DeepCollectionEquality().hash(impliedProperties),
+      isDefault,
+      isFallback,
+      hasJsonSerializable,
+      fullName,
+      const DeepCollectionEquality().hash(withDecorators),
+      const DeepCollectionEquality().hash(implementsDecorators),
+      const DeepCollectionEquality().hash(decorators),
+      const DeepCollectionEquality().hash(cloneableProperties),
+      const DeepCollectionEquality().hash(asserts));
 
   @JsonKey(ignore: true)
   @override
@@ -701,36 +677,35 @@ abstract class _ConstructorDetails extends ConstructorDetails {
   _ConstructorDetails._() : super._();
 
   @override
-  String get name => throw _privateConstructorUsedError;
+  String get name;
   @override
-  String get unionValue => throw _privateConstructorUsedError;
+  String get unionValue;
   @override
-  bool get isConst => throw _privateConstructorUsedError;
+  bool get isConst;
   @override
-  String get redirectedName => throw _privateConstructorUsedError;
+  String get redirectedName;
   @override
-  ParametersTemplate get parameters => throw _privateConstructorUsedError;
+  ParametersTemplate get parameters;
   @override
-  List<Property> get impliedProperties => throw _privateConstructorUsedError;
+  List<Property> get impliedProperties;
   @override
-  bool get isDefault => throw _privateConstructorUsedError;
+  bool get isDefault;
   @override
-  bool get isFallback => throw _privateConstructorUsedError;
+  bool get isFallback;
   @override
-  bool get hasJsonSerializable => throw _privateConstructorUsedError;
+  bool get hasJsonSerializable;
   @override
-  String get fullName => throw _privateConstructorUsedError;
+  String get fullName;
   @override
-  List<String> get withDecorators => throw _privateConstructorUsedError;
+  List<String> get withDecorators;
   @override
-  List<String> get implementsDecorators => throw _privateConstructorUsedError;
+  List<String> get implementsDecorators;
   @override
-  List<String> get decorators => throw _privateConstructorUsedError;
+  List<String> get decorators;
   @override
-  List<CloneableProperty> get cloneableProperties =>
-      throw _privateConstructorUsedError;
+  List<CloneableProperty> get cloneableProperties;
   @override
-  List<AssertTemplate> get asserts => throw _privateConstructorUsedError;
+  List<AssertTemplate> get asserts;
   @override
   @JsonKey(ignore: true)
   _$ConstructorDetailsCopyWith<_ConstructorDetails> get copyWith =>
@@ -985,51 +960,42 @@ class _$_Data implements _Data {
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
-        (other is _Data &&
-            (identical(other.name, name) ||
-                const DeepCollectionEquality().equals(other.name, name)) &&
+        (other.runtimeType == runtimeType &&
+            other is _Data &&
+            (identical(other.name, name) || other.name == name) &&
             (identical(other.needsJsonSerializable, needsJsonSerializable) ||
-                const DeepCollectionEquality().equals(
-                    other.needsJsonSerializable, needsJsonSerializable)) &&
+                other.needsJsonSerializable == needsJsonSerializable) &&
             (identical(other.unionKey, unionKey) ||
-                const DeepCollectionEquality()
-                    .equals(other.unionKey, unionKey)) &&
-            (identical(other.concretePropertiesName, concretePropertiesName) ||
-                const DeepCollectionEquality().equals(
-                    other.concretePropertiesName, concretePropertiesName)) &&
-            (identical(other.constructors, constructors) ||
-                const DeepCollectionEquality()
-                    .equals(other.constructors, constructors)) &&
+                other.unionKey == unionKey) &&
+            const DeepCollectionEquality()
+                .equals(other.concretePropertiesName, concretePropertiesName) &&
+            const DeepCollectionEquality()
+                .equals(other.constructors, constructors) &&
             (identical(other.genericsDefinitionTemplate,
                     genericsDefinitionTemplate) ||
-                const DeepCollectionEquality().equals(
-                    other.genericsDefinitionTemplate,
-                    genericsDefinitionTemplate)) &&
+                other.genericsDefinitionTemplate ==
+                    genericsDefinitionTemplate) &&
             (identical(other.genericsParameterTemplate,
                     genericsParameterTemplate) ||
-                const DeepCollectionEquality().equals(
-                    other.genericsParameterTemplate,
-                    genericsParameterTemplate)) &&
+                other.genericsParameterTemplate == genericsParameterTemplate) &&
             (identical(other.shouldUseExtends, shouldUseExtends) ||
-                const DeepCollectionEquality()
-                    .equals(other.shouldUseExtends, shouldUseExtends)) &&
+                other.shouldUseExtends == shouldUseExtends) &&
             (identical(other.hasCustomToString, hasCustomToString) ||
-                const DeepCollectionEquality()
-                    .equals(other.hasCustomToString, hasCustomToString)));
+                other.hasCustomToString == hasCustomToString));
   }
 
   @override
-  int get hashCode =>
-      runtimeType.hashCode ^
-      const DeepCollectionEquality().hash(name) ^
-      const DeepCollectionEquality().hash(needsJsonSerializable) ^
-      const DeepCollectionEquality().hash(unionKey) ^
-      const DeepCollectionEquality().hash(concretePropertiesName) ^
-      const DeepCollectionEquality().hash(constructors) ^
-      const DeepCollectionEquality().hash(genericsDefinitionTemplate) ^
-      const DeepCollectionEquality().hash(genericsParameterTemplate) ^
-      const DeepCollectionEquality().hash(shouldUseExtends) ^
-      const DeepCollectionEquality().hash(hasCustomToString);
+  int get hashCode => Object.hash(
+      runtimeType,
+      name,
+      needsJsonSerializable,
+      unionKey,
+      const DeepCollectionEquality().hash(concretePropertiesName),
+      const DeepCollectionEquality().hash(constructors),
+      genericsDefinitionTemplate,
+      genericsParameterTemplate,
+      shouldUseExtends,
+      hasCustomToString);
 
   @JsonKey(ignore: true)
   @override
@@ -1050,26 +1016,23 @@ abstract class _Data implements Data {
       required bool hasCustomToString}) = _$_Data;
 
   @override
-  String get name => throw _privateConstructorUsedError;
+  String get name;
   @override
-  bool get needsJsonSerializable => throw _privateConstructorUsedError;
+  bool get needsJsonSerializable;
   @override
-  String get unionKey => throw _privateConstructorUsedError;
+  String get unionKey;
   @override
-  List<String> get concretePropertiesName => throw _privateConstructorUsedError;
+  List<String> get concretePropertiesName;
   @override
-  List<ConstructorDetails> get constructors =>
-      throw _privateConstructorUsedError;
+  List<ConstructorDetails> get constructors;
   @override
-  GenericsDefinitionTemplate get genericsDefinitionTemplate =>
-      throw _privateConstructorUsedError;
+  GenericsDefinitionTemplate get genericsDefinitionTemplate;
   @override
-  GenericsParameterTemplate get genericsParameterTemplate =>
-      throw _privateConstructorUsedError;
+  GenericsParameterTemplate get genericsParameterTemplate;
   @override
-  bool get shouldUseExtends => throw _privateConstructorUsedError;
+  bool get shouldUseExtends;
   @override
-  bool get hasCustomToString => throw _privateConstructorUsedError;
+  bool get hasCustomToString;
   @override
   @JsonKey(ignore: true)
   _$DataCopyWith<_Data> get copyWith => throw _privateConstructorUsedError;
@@ -1189,20 +1152,15 @@ class _$_GlobalData implements _GlobalData {
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
-        (other is _GlobalData &&
-            (identical(other.hasJson, hasJson) ||
-                const DeepCollectionEquality()
-                    .equals(other.hasJson, hasJson)) &&
+        (other.runtimeType == runtimeType &&
+            other is _GlobalData &&
+            (identical(other.hasJson, hasJson) || other.hasJson == hasJson) &&
             (identical(other.hasDiagnostics, hasDiagnostics) ||
-                const DeepCollectionEquality()
-                    .equals(other.hasDiagnostics, hasDiagnostics)));
+                other.hasDiagnostics == hasDiagnostics));
   }
 
   @override
-  int get hashCode =>
-      runtimeType.hashCode ^
-      const DeepCollectionEquality().hash(hasJson) ^
-      const DeepCollectionEquality().hash(hasDiagnostics);
+  int get hashCode => Object.hash(runtimeType, hasJson, hasDiagnostics);
 
   @JsonKey(ignore: true)
   @override
@@ -1215,9 +1173,9 @@ abstract class _GlobalData implements GlobalData {
       _$_GlobalData;
 
   @override
-  bool get hasJson => throw _privateConstructorUsedError;
+  bool get hasJson;
   @override
-  bool get hasDiagnostics => throw _privateConstructorUsedError;
+  bool get hasDiagnostics;
   @override
   @JsonKey(ignore: true)
   _$GlobalDataCopyWith<_GlobalData> get copyWith =>

--- a/packages/_internal/pubspec.lock
+++ b/packages/_internal/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "28.0.0"
+    version: "30.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.7.0"
   args:
     dependency: transitive
     description:
@@ -84,7 +84,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.2"
+    version: "8.1.3"
   charcode:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "0.3.5"
   code_builder:
     dependency: transitive
     description:
@@ -161,14 +161,14 @@ packages:
       path: "../freezed"
       relative: true
     source: path
-    version: "0.14.5"
+    version: "0.15.0+1"
   freezed_annotation:
     dependency: "direct main"
     description:
       path: "../freezed_annotation"
       relative: true
     source: path
-    version: "0.14.3"
+    version: "0.15.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -224,7 +224,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.3.0"
   logging:
     dependency: transitive
     description:
@@ -252,7 +252,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   package_config:
     dependency: transitive
     description:

--- a/packages/_internal/pubspec.yaml
+++ b/packages/_internal/pubspec.yaml
@@ -2,11 +2,11 @@ name: example
 description: A new Flutter project.
 
 environment:
-  sdk: ">=2.12.0-0.0.dev <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
   freezed_annotation: ">=0.14.0"
 
 dev_dependencies:
   build_runner:
-  freezed: ^0.14.0
+  freezed: ^0.15.0+1

--- a/packages/freezed/example/pubspec.yaml
+++ b/packages/freezed/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 dev_dependencies:
   freezed:
     path: ../
-  json_serializable: ^5.0.0
+  json_serializable: ^6.0.1
   build_runner:
   flutter_test:
     sdk: flutter

--- a/packages/freezed/example/pubspec.yaml
+++ b/packages/freezed/example/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
     sdk: flutter
   freezed_annotation:
     path: ../../freezed_annotation
+  json_annotation: ^4.3.0
 
 dev_dependencies:
   freezed:

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -9,19 +9,19 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
-  analyzer: ^2.5.0
-  build: ^2.0.1
+  analyzer: ^2.7.0
+  build: ^2.1.1
   build_config: ^1.0.0
   collection: ^1.15.0
-  meta: ^1.3.0
-  source_gen: ^1.0.0
+  meta: ^1.7.0
+  source_gen: ^1.1.1
   freezed_annotation: ^0.15.0
 
 dev_dependencies:
-  json_serializable: ^5.0.0
-  json_annotation: ^4.1.0
-  build_test: ^2.1.0
-  build_runner: ^2.0.0
-  test: ^1.16.8
-  matcher: ^0.12.10
-  source_gen_test: ^1.0.0
+  json_serializable: ^6.0.1
+  json_annotation: ^4.3.0
+  build_test: ^2.1.4
+  build_runner: ^2.1.4
+  test: ^1.19.3
+  matcher: ^0.12.11
+  source_gen_test: ^1.0.1

--- a/packages/freezed/test/integration/json.dart
+++ b/packages/freezed/test/integration/json.dart
@@ -250,3 +250,35 @@ class DurationValue with _$DurationValue {
   factory DurationValue.fromJson(Map<String, dynamic> json) =>
       _$DurationValueFromJson(json);
 }
+
+@JsonEnum(alwaysCreate: true, fieldRename: FieldRename.kebab)
+enum StandAloneEnum {
+  expected,
+  specialResult,
+  @JsonValue('unknown')
+  unknownResult,
+}
+
+Iterable<String> get standAloneEnumValues => _$StandAloneEnumEnumMap.values;
+
+@JsonEnum()
+enum Enum {
+  alpha,
+  beta,
+  gamma,
+}
+
+@freezed
+class EnumJson with _$EnumJson {
+  factory EnumJson({
+    @JsonKey(
+      disallowNullValue: true,
+      required: true,
+      unknownEnumValue: JsonKey.nullForUndefinedEnumValue,
+    )
+        Enum? status,
+  }) = _EnumJson;
+
+  factory EnumJson.fromJson(Map<String, dynamic> json) =>
+      _$EnumJsonFromJson(json);
+}

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -460,6 +460,29 @@ Future<void> main() async {
     );
   });
 
+  test('enum helpers', () {
+    expect(standAloneEnumValues, ['expected', 'special-result', 'unknown']);
+  });
+
+  test('unknown as null for enum', () {
+    expect(
+      () => EnumJson.fromJson(<String, dynamic>{}).status,
+      throwsA(isA<MissingRequiredKeysException>()),
+    );
+    expect(
+      () => EnumJson.fromJson(<String, dynamic>{'status': null}).status,
+      throwsA(isA<DisallowedNullValueException>()),
+    );
+    expect(
+      EnumJson.fromJson(<String, dynamic>{'status': 'gamma'}).status,
+      Enum.gamma,
+    );
+    expect(
+      EnumJson.fromJson(<String, dynamic>{'status': 'unknown'}).status,
+      isNull,
+    );
+  });
+
   test('if no fromJson exists, no constructors are made', () async {
     await expectLater(compile(r'''
 import 'json.dart';

--- a/packages/freezed_annotation/pubspec.yaml
+++ b/packages/freezed_annotation/pubspec.yaml
@@ -10,5 +10,5 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  json_annotation: ^4.1.0
-  meta: ^1.3.0
+  json_annotation: ^4.3.0
+  meta: ^1.7.0


### PR DESCRIPTION
#545

> - Added support for JsonSerializable.constructor to allow specifying an alternative constructor to invoke when creating a fromJson helper.

Not quite sure if it is needed to support this, and if so how to implement this.

> - Use the new $enumDecodeNullable and $enumDecode in `json_annotation' instead of generating these for each library. NOTE: This is a potential breaking change if any user code relies on the previously generated private functions.

Only a potential break , I'm not quite sure how to add a test for this.

