### PR TITLE
Use regex to parse With and Implements annotations

### DIFF
--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -299,16 +299,27 @@ Read here: https://github.com/rrousselGit/freezed/tree/master/packages/freezed#t
     return result;
   }
 
+  String _extractTypeFromGenericAnnotation(
+    String annotation,
+    ConstructorElement element,
+  ) {
+    final reg = RegExp(r'.*?<(.+)>');
+    final match = reg.firstMatch(annotation)?.group(1);
+    if (match == null) {
+      throw InvalidGenerationSourceError(
+        'Annotation does not properly specify type: $annotation',
+        element: element,
+      );
+    }
+
+    return match;
+  }
+
   Iterable<String> _withDecorationTypes(ConstructorElement constructor) sync* {
     for (final metadata in constructor.metadata) {
       if (!metadata.isWith) continue;
-      final object = metadata.computeConstantValue()!;
 
-      yield resolveFullTypeStringFrom(
-        constructor.library,
-        (object.type! as InterfaceType).typeArguments.single,
-        withNullability: false,
-      );
+      yield _extractTypeFromGenericAnnotation(metadata.toSource(), constructor);
     }
   }
 
@@ -317,13 +328,8 @@ Read here: https://github.com/rrousselGit/freezed/tree/master/packages/freezed#t
   ) sync* {
     for (final metadata in constructor.metadata) {
       if (!metadata.isImplements) continue;
-      final object = metadata.computeConstantValue()!;
 
-      yield resolveFullTypeStringFrom(
-        constructor.library,
-        (object.type! as InterfaceType).typeArguments.single,
-        withNullability: false,
-      );
+      yield _extractTypeFromGenericAnnotation(metadata.toSource(), constructor);
     }
   }
 

--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -9,7 +9,6 @@ import 'package:freezed/src/templates/parameter_template.dart';
 import 'package:freezed/src/templates/properties.dart';
 import 'package:freezed/src/templates/prototypes.dart';
 import 'package:freezed/src/templates/tear_off.dart';
-import 'package:freezed/src/tools/type.dart';
 import 'package:freezed/src/utils.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:source_gen/source_gen.dart';


### PR DESCRIPTION
I propose a different way for parsing and outputting the `@With` and `@Implements` annotations that use the new "generic" approach.
The rationale is that we should be able to assume that the soundness (syntax error and well-formed types within the generic quotes) is guaranteed by the compiler itself, and whichever type is extracted by the regex can be copy-pasted, as it is, inside the generated file.

This approach would also solve edge-case situations like the one that surfaced in #535 