### PR TITLE
Fix "information" plural typo

### DIFF
--- a/packages/_internal/lib/models.dart
+++ b/packages/_internal/lib/models.dart
@@ -35,7 +35,7 @@ class CloneableProperty with _$CloneableProperty {
   }) = _CloneableProperty;
 }
 
-/// The informations of a specific constructor of a class tagged with `@freezed`.
+/// The information of a specific constructor of a class tagged with `@freezed`.
 ///
 /// This only includes constructors where Freezed needs to generate something.
 @freezed

--- a/packages/_internal/lib/models.freezed.dart
+++ b/packages/_internal/lib/models.freezed.dart
@@ -11,7 +11,7 @@ part of 'models.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 class _$CloneablePropertyTearOff {

--- a/packages/freezed/CHANGELOG.md
+++ b/packages/freezed/CHANGELOG.md
@@ -114,7 +114,7 @@ Fixed examples in the README
 
 # 0.14.1
 
-- Added the ability to customise the JSON value of a union. See https://github.com/rrousselGit/freezed#fromjson---classes-with-multiple-constructors for more informations (Thanks to @ookami-kb)
+- Added the ability to customise the JSON value of a union. See https://github.com/rrousselGit/freezed#fromjson---classes-with-multiple-constructors for more information (Thanks to @ookami-kb)
 
 - Fix an issue where Freezed would not generate code properly if `freezed_annotation`
   was indirectly imported (by importing a library that exports `freezed_annotation`) (Thanks to @ookami-kb)

--- a/packages/freezed/example/lib/diagnosticable.freezed.dart
+++ b/packages/freezed/example/lib/diagnosticable.freezed.dart
@@ -11,7 +11,7 @@ part of 'diagnosticable.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 class _$ExampleTearOff {

--- a/packages/freezed/example/lib/equals.freezed.dart
+++ b/packages/freezed/example/lib/equals.freezed.dart
@@ -11,7 +11,7 @@ part of 'equals.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 class _$EqualsTearOff {

--- a/packages/freezed/example/lib/main.freezed.dart
+++ b/packages/freezed/example/lib/main.freezed.dart
@@ -11,7 +11,7 @@ part of 'main.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 class _$MyClassTearOff {

--- a/packages/freezed/example/lib/non_diagnosticable.freezed.dart
+++ b/packages/freezed/example/lib/non_diagnosticable.freezed.dart
@@ -11,7 +11,7 @@ part of 'non_diagnosticable.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 class _$ExampleTearOff {

--- a/packages/freezed/example/lib/time_slot.freezed.dart
+++ b/packages/freezed/example/lib/time_slot.freezed.dart
@@ -11,7 +11,7 @@ part of 'time_slot.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 class _$TimeSlotTearOff {

--- a/packages/freezed/lib/src/models.dart
+++ b/packages/freezed/lib/src/models.dart
@@ -25,7 +25,7 @@ abstract class CloneableProperty with _$CloneableProperty {
   }) = _CloneableProperty;
 }
 
-/// The informations of a specific constructor of a class tagged with `@freezed`.
+/// The information of a specific constructor of a class tagged with `@freezed`.
 ///
 /// This only includes constructors where Freezed needs to generate something.
 @freezed

--- a/packages/freezed/lib/src/models.freezed.dart
+++ b/packages/freezed/lib/src/models.freezed.dart
@@ -11,7 +11,7 @@ part of 'models.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 class _$CloneablePropertyTearOff {

--- a/packages/freezed/lib/src/templates/properties.dart
+++ b/packages/freezed/lib/src/templates/properties.dart
@@ -11,7 +11,7 @@ const privConstUsedErrorString =
     'It seems like you constructed your class using `MyClass._()`. '
     'This constructor is only meant to be used by freezed '
     'and you are not supposed to need it nor use it.'
-    '\\nPlease check the documentation here for more informations: '
+    '\\nPlease check the documentation here for more information: '
     'https://github.com/rrousselGit/freezed#custom-getters-and-methods';
 
 const privConstUsedErrorVarName = '_privateConstructorUsedError';

--- a/packages/freezed_annotation/CHANGELOG.md
+++ b/packages/freezed_annotation/CHANGELOG.md
@@ -33,7 +33,7 @@ Upgraded to support last json_annotation version
 
 # 0.14.1
 
-- Added the ability to customise the JSON value of a union. See https://github.com/rrousselGit/freezed#fromjson---classes-with-multiple-constructors for more informations (Thanks to @ookami-kb)
+- Added the ability to customise the JSON value of a union. See https://github.com/rrousselGit/freezed#fromjson---classes-with-multiple-constructors for more information (Thanks to @ookami-kb)
 
 # 0.14.0
 


### PR DESCRIPTION
In English, there is no plural for "information". It's just information.

> We do not use information in the plural form and we do not use it with a/an. We use piece or pieces to make information countable:
I found a lot of information about Ecuador on the Internet.
Not: I found a lot of informations about Ecuador …

https://dictionary.cambridge.org/grammar/british-grammar/information