### PR TITLE
switch to flutter channel master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           - packages/freezed_annotation
           - packages/freezed/example
         channel:
-          - beta
+          - master
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           - packages/freezed_annotation
           - packages/freezed/example
         channel:
-          - dev
+          - beta
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The support for the channel dev was discontinued by the flutter team [#switching-flutter-channels](https://docs.flutter.dev/development/tools/sdk/upgrading#switching-flutter-channels)
>  The dev channel was retired as of Flutter 2.8.