### PR TITLE
Fix build.yml until `dart_style: 2.2.2` gets published

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           - packages/freezed_annotation
           - packages/freezed/example
         channel:
-          - beta
+          - master
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,7 @@ name: Build
 on:
   push:
   pull_request:
-  schedule:
-    # runs the CI everyday at 10AM
-    - cron: "0 10 * * *"
+  workflow_dispatch:
 
 jobs:
   freezed:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,9 @@ name: Build
 on:
   push:
   pull_request:
-  workflow_dispatch:
+  schedule:
+    # runs the CI everyday at 10AM
+    - cron: "0 10 * * *"
 
 jobs:
   freezed:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           - packages/freezed_annotation
           - packages/freezed/example
         channel:
-          - dev
+          - beta
 
     steps:
       - uses: actions/checkout@v2

--- a/packages/_internal/lib/models.dart
+++ b/packages/_internal/lib/models.dart
@@ -84,7 +84,7 @@ class Data with _$Data {
 }
 
 @freezed
-abstract class GlobalData with _$GlobalData {
+class GlobalData with _$GlobalData {
   factory GlobalData({
     required bool hasJson,
     required bool hasDiagnostics,

--- a/packages/_internal/lib/models.freezed.dart
+++ b/packages/_internal/lib/models.freezed.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
 
 part of 'models.dart';
@@ -11,7 +12,7 @@ part of 'models.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 class _$CloneablePropertyTearOff {
@@ -195,19 +196,22 @@ class _$_CloneableProperty implements _CloneableProperty {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _CloneableProperty &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.typeName, typeName) ||
-                other.typeName == typeName) &&
-            (identical(other.type, type) || other.type == type) &&
-            (identical(other.nullable, nullable) ||
-                other.nullable == nullable) &&
-            (identical(other.genericParameters, genericParameters) ||
-                other.genericParameters == genericParameters));
+            const DeepCollectionEquality().equals(other.name, name) &&
+            const DeepCollectionEquality().equals(other.typeName, typeName) &&
+            const DeepCollectionEquality().equals(other.type, type) &&
+            const DeepCollectionEquality().equals(other.nullable, nullable) &&
+            const DeepCollectionEquality()
+                .equals(other.genericParameters, genericParameters));
   }
 
   @override
   int get hashCode => Object.hash(
-      runtimeType, name, typeName, type, nullable, genericParameters);
+      runtimeType,
+      const DeepCollectionEquality().hash(name),
+      const DeepCollectionEquality().hash(typeName),
+      const DeepCollectionEquality().hash(type),
+      const DeepCollectionEquality().hash(nullable),
+      const DeepCollectionEquality().hash(genericParameters));
 
   @JsonKey(ignore: true)
   @override
@@ -621,26 +625,24 @@ class _$_ConstructorDetails extends _ConstructorDetails {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _ConstructorDetails &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.unionValue, unionValue) ||
-                other.unionValue == unionValue) &&
-            (identical(other.isConst, isConst) || other.isConst == isConst) &&
-            (identical(other.redirectedName, redirectedName) ||
-                other.redirectedName == redirectedName) &&
-            (identical(other.parameters, parameters) ||
-                other.parameters == parameters) &&
+            const DeepCollectionEquality().equals(other.name, name) &&
+            const DeepCollectionEquality()
+                .equals(other.unionValue, unionValue) &&
+            const DeepCollectionEquality().equals(other.isConst, isConst) &&
+            const DeepCollectionEquality()
+                .equals(other.redirectedName, redirectedName) &&
+            const DeepCollectionEquality()
+                .equals(other.parameters, parameters) &&
             const DeepCollectionEquality()
                 .equals(other.impliedProperties, impliedProperties) &&
-            (identical(other.isDefault, isDefault) ||
-                other.isDefault == isDefault) &&
-            (identical(other.isFallback, isFallback) ||
-                other.isFallback == isFallback) &&
-            (identical(other.hasJsonSerializable, hasJsonSerializable) ||
-                other.hasJsonSerializable == hasJsonSerializable) &&
-            (identical(other.fullName, fullName) ||
-                other.fullName == fullName) &&
-            (identical(other.escapedName, escapedName) ||
-                other.escapedName == escapedName) &&
+            const DeepCollectionEquality().equals(other.isDefault, isDefault) &&
+            const DeepCollectionEquality()
+                .equals(other.isFallback, isFallback) &&
+            const DeepCollectionEquality()
+                .equals(other.hasJsonSerializable, hasJsonSerializable) &&
+            const DeepCollectionEquality().equals(other.fullName, fullName) &&
+            const DeepCollectionEquality()
+                .equals(other.escapedName, escapedName) &&
             const DeepCollectionEquality()
                 .equals(other.withDecorators, withDecorators) &&
             const DeepCollectionEquality()
@@ -655,17 +657,17 @@ class _$_ConstructorDetails extends _ConstructorDetails {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      name,
-      unionValue,
-      isConst,
-      redirectedName,
-      parameters,
+      const DeepCollectionEquality().hash(name),
+      const DeepCollectionEquality().hash(unionValue),
+      const DeepCollectionEquality().hash(isConst),
+      const DeepCollectionEquality().hash(redirectedName),
+      const DeepCollectionEquality().hash(parameters),
       const DeepCollectionEquality().hash(impliedProperties),
-      isDefault,
-      isFallback,
-      hasJsonSerializable,
-      fullName,
-      escapedName,
+      const DeepCollectionEquality().hash(isDefault),
+      const DeepCollectionEquality().hash(isFallback),
+      const DeepCollectionEquality().hash(hasJsonSerializable),
+      const DeepCollectionEquality().hash(fullName),
+      const DeepCollectionEquality().hash(escapedName),
       const DeepCollectionEquality().hash(withDecorators),
       const DeepCollectionEquality().hash(implementsDecorators),
       const DeepCollectionEquality().hash(decorators),
@@ -1040,50 +1042,45 @@ class _$_Data implements _Data {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _Data &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.needsJsonSerializable, needsJsonSerializable) ||
-                other.needsJsonSerializable == needsJsonSerializable) &&
-            (identical(other.unionKey, unionKey) ||
-                other.unionKey == unionKey) &&
+            const DeepCollectionEquality().equals(other.name, name) &&
+            const DeepCollectionEquality()
+                .equals(other.needsJsonSerializable, needsJsonSerializable) &&
+            const DeepCollectionEquality().equals(other.unionKey, unionKey) &&
             const DeepCollectionEquality()
                 .equals(other.concretePropertiesName, concretePropertiesName) &&
             const DeepCollectionEquality()
                 .equals(other.constructors, constructors) &&
-            (identical(other.genericsDefinitionTemplate,
-                    genericsDefinitionTemplate) ||
-                other.genericsDefinitionTemplate ==
-                    genericsDefinitionTemplate) &&
-            (identical(other.genericsParameterTemplate,
-                    genericsParameterTemplate) ||
-                other.genericsParameterTemplate == genericsParameterTemplate) &&
-            (identical(other.shouldUseExtends, shouldUseExtends) ||
-                other.shouldUseExtends == shouldUseExtends) &&
-            (identical(other.hasCustomToString, hasCustomToString) ||
-                other.hasCustomToString == hasCustomToString) &&
-            (identical(other.hasCustomEquals, hasCustomEquals) ||
-                other.hasCustomEquals == hasCustomEquals) &&
-            (identical(other.shouldGenerateMaybeMap, shouldGenerateMaybeMap) ||
-                other.shouldGenerateMaybeMap == shouldGenerateMaybeMap) &&
-            (identical(
-                    other.shouldGenerateMaybeWhen, shouldGenerateMaybeWhen) ||
-                other.shouldGenerateMaybeWhen == shouldGenerateMaybeWhen));
+            const DeepCollectionEquality().equals(
+                other.genericsDefinitionTemplate, genericsDefinitionTemplate) &&
+            const DeepCollectionEquality().equals(
+                other.genericsParameterTemplate, genericsParameterTemplate) &&
+            const DeepCollectionEquality()
+                .equals(other.shouldUseExtends, shouldUseExtends) &&
+            const DeepCollectionEquality()
+                .equals(other.hasCustomToString, hasCustomToString) &&
+            const DeepCollectionEquality()
+                .equals(other.hasCustomEquals, hasCustomEquals) &&
+            const DeepCollectionEquality()
+                .equals(other.shouldGenerateMaybeMap, shouldGenerateMaybeMap) &&
+            const DeepCollectionEquality().equals(
+                other.shouldGenerateMaybeWhen, shouldGenerateMaybeWhen));
   }
 
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      name,
-      needsJsonSerializable,
-      unionKey,
+      const DeepCollectionEquality().hash(name),
+      const DeepCollectionEquality().hash(needsJsonSerializable),
+      const DeepCollectionEquality().hash(unionKey),
       const DeepCollectionEquality().hash(concretePropertiesName),
       const DeepCollectionEquality().hash(constructors),
-      genericsDefinitionTemplate,
-      genericsParameterTemplate,
-      shouldUseExtends,
-      hasCustomToString,
-      hasCustomEquals,
-      shouldGenerateMaybeMap,
-      shouldGenerateMaybeWhen);
+      const DeepCollectionEquality().hash(genericsDefinitionTemplate),
+      const DeepCollectionEquality().hash(genericsParameterTemplate),
+      const DeepCollectionEquality().hash(shouldUseExtends),
+      const DeepCollectionEquality().hash(hasCustomToString),
+      const DeepCollectionEquality().hash(hasCustomEquals),
+      const DeepCollectionEquality().hash(shouldGenerateMaybeMap),
+      const DeepCollectionEquality().hash(shouldGenerateMaybeWhen));
 
   @JsonKey(ignore: true)
   @override
@@ -1251,13 +1248,16 @@ class _$_GlobalData implements _GlobalData {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _GlobalData &&
-            (identical(other.hasJson, hasJson) || other.hasJson == hasJson) &&
-            (identical(other.hasDiagnostics, hasDiagnostics) ||
-                other.hasDiagnostics == hasDiagnostics));
+            const DeepCollectionEquality().equals(other.hasJson, hasJson) &&
+            const DeepCollectionEquality()
+                .equals(other.hasDiagnostics, hasDiagnostics));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, hasJson, hasDiagnostics);
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(hasJson),
+      const DeepCollectionEquality().hash(hasDiagnostics));
 
   @JsonKey(ignore: true)
   @override

--- a/packages/_internal/pubspec.lock
+++ b/packages/_internal/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "30.0.0"
+    version: "36.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.0"
+    version: "3.3.1"
   args:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.1"
   build_config:
     dependency: transitive
     description:
@@ -56,21 +56,21 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.6"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.7"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.2.2"
+    version: "7.2.3"
   built_collection:
     dependency: transitive
     description:
@@ -84,7 +84,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.3"
+    version: "8.1.4"
   charcode:
     dependency: transitive
     description:
@@ -99,13 +99,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.5"
   code_builder:
     dependency: transitive
     description:
@@ -140,7 +133,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   file:
     dependency: transitive
     description:
@@ -158,17 +151,17 @@ packages:
   freezed:
     dependency: "direct dev"
     description:
-      path: "../freezed"
-      relative: true
-    source: path
-    version: "1.0.2+1"
+      name: freezed
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.1"
   freezed_annotation:
     dependency: "direct main"
     description:
-      path: "../freezed_annotation"
-      relative: true
-    source: path
-    version: "1.0.0"
+      name: freezed_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -196,7 +189,7 @@ packages:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.2.0"
   http_parser:
     dependency: transitive
     description:
@@ -217,14 +210,14 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   logging:
     dependency: transitive
     description:
@@ -266,7 +259,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   pool:
     dependency: transitive
     description:
@@ -287,7 +280,7 @@ packages:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   shelf:
     dependency: transitive
     description:
@@ -308,14 +301,14 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -387,4 +380,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.16.0-100.0.dev <3.0.0"

--- a/packages/_internal/pubspec.yaml
+++ b/packages/_internal/pubspec.yaml
@@ -5,8 +5,8 @@ environment:
   sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
-  freezed_annotation: ">=0.14.0"
+  freezed_annotation:
 
 dev_dependencies:
   build_runner:
-  freezed: ^0.15.0+1
+  freezed:

--- a/packages/freezed/example/pubspec.yaml
+++ b/packages/freezed/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   freezed:
     path: ../
-  json_serializable: ^6.1.3
+  json_serializable: ^6.1.4
   build_runner:
   flutter_test:
     sdk: flutter
@@ -24,3 +24,6 @@ dependency_overrides:
     path: ../
   freezed_annotation:
     path: ../../freezed_annotation
+  dart_style:
+    git:
+      url: "https://github.com/dart-lang/dart_style.git"

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -9,19 +9,24 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
-  analyzer: ^3.0.0
-  build: ^2.0.0
+  analyzer: ^3.3.1
+  build: ^2.2.1
   build_config: ^1.0.0
   collection: ^1.15.0
   meta: ^1.7.0
-  source_gen: ^1.2.0
-  freezed_annotation: ^1.0.0
+  source_gen: ^1.2.1
+  freezed_annotation: ^1.1.0
 
 dev_dependencies:
-  json_serializable: ^6.1.3
+  json_serializable: ^6.1.4
   json_annotation: ^4.4.0
   build_test: ^2.1.5
   build_runner: ^2.1.7
   test: ^1.20.1
   matcher: ^0.12.11
   source_gen_test: ^1.0.2
+
+dependency_overrides:
+  dart_style:
+    git:
+      url: "https://github.com/dart-lang/dart_style.git"

--- a/packages/freezed_annotation/pubspec.yaml
+++ b/packages/freezed_annotation/pubspec.yaml
@@ -10,5 +10,5 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  json_annotation: ^4.3.0
+  json_annotation: ^4.4.0
   meta: ^1.7.0

--- a/scripts/setup_dependencies.sh
+++ b/scripts/setup_dependencies.sh
@@ -8,10 +8,17 @@ dart pub get
 cd ../freezed
 
 echo "overriding freezed dependencies"
+if grep -Fxq "dependency_overrides:" pubspec.yaml
+then
+echo "
+  freezed_annotation:
+    path: ../freezed_annotation" >> pubspec.yaml
+else
 echo "
 dependency_overrides:
   freezed_annotation:
     path: ../freezed_annotation" >> pubspec.yaml
+fi
 
 echo "Installing freezed"
 dart pub get


### PR DESCRIPTION
This would be a fix, so that the build workflow runs again.
But if you don't want any dependency_overrides in the repo and want to wait till dart_style 2.2.2 gets published,
then close this pull request. 👍

- added to freezed/pubspec.yaml and freezed/example/pubspec.yaml
```YAML
dependency_overrides:
  dart_style:
    git:
      url: "https://github.com/dart-lang/dart_style.git"
```
- changed setup_dependencies.sh so it doesn't error: _Key 'dependency_overrides' is duplicated_
- flutter packages upgrade in `_internal`, `freezed`, `freezed_annotations`