### PR TITLE
Add screaming snake union case type

### DIFF
--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -399,6 +399,9 @@ Read here: https://github.com/rrousselGit/freezed/tree/master/packages/freezed#t
       case 'snake':
         unionValueCase = FreezedUnionCase.snake;
         break;
+      case 'screamingSnake':
+        unionValueCase = FreezedUnionCase.screamingSnake;
+        break;
       case null:
         final enumIndex = annotation
             .getField('unionValueCase')!
@@ -679,6 +682,8 @@ extension on ConstructorElement {
         return pascalCase(constructorName);
       case FreezedUnionCase.snake:
         return snakeCase(constructorName);
+      case FreezedUnionCase.screamingSnake:
+        return screamingSnake(constructorName);
       default:
         throw FallThroughError();
     }

--- a/packages/freezed/lib/src/utils.dart
+++ b/packages/freezed/lib/src/utils.dart
@@ -48,6 +48,8 @@ String kebabCase(String input) => _fixCase(input, '-');
 
 String snakeCase(String input) => _fixCase(input, '_');
 
+String screamingSnake(String input) => snakeCase(input).toUpperCase();
+
 String pascalCase(String input) {
   if (input.isEmpty) {
     return '';

--- a/packages/freezed/test/integration/json.dart
+++ b/packages/freezed/test/integration/json.dart
@@ -196,6 +196,17 @@ class UnionValueCaseSnake with _$UnionValueCaseSnake {
       _$UnionValueCaseSnakeFromJson(json);
 }
 
+@Freezed(unionValueCase: FreezedUnionCase.screamingSnake)
+class UnionValueCaseScreamingSnake with _$UnionValueCaseScreamingSnake {
+  const factory UnionValueCaseScreamingSnake.first(int a) =
+      _UnionValueCaseScreamingSnakeFirst;
+  const factory UnionValueCaseScreamingSnake.secondValue(int a) =
+      _UnionValueCaseScreamingSnakeSecondValue;
+
+  factory UnionValueCaseScreamingSnake.fromJson(Map<String, dynamic> json) =>
+      _$UnionValueCaseScreamingSnakeFromJson(json);
+}
+
 @Freezed(unionKey: 'runtimeType')
 class RuntimeTypeKey with _$RuntimeTypeKey {
   const factory RuntimeTypeKey.first(int a) = _RuntimeTypeKeyFirst;
@@ -381,6 +392,21 @@ class UnrecognizedKeysUnionValueCaseSnake
   factory UnrecognizedKeysUnionValueCaseSnake.fromJson(
           Map<String, dynamic> json) =>
       _$UnrecognizedKeysUnionValueCaseSnakeFromJson(json);
+}
+
+@Freezed(unionValueCase: FreezedUnionCase.screamingSnake)
+class UnrecognizedKeysUnionValueCaseScreamingSnake
+    with _$UnrecognizedKeysUnionValueCaseScreamingSnake {
+  @JsonSerializable(disallowUnrecognizedKeys: true)
+  const factory UnrecognizedKeysUnionValueCaseScreamingSnake.first(int a) =
+      _UnrecognizedKeysUnionValueCaseScreamingSnakeFirst;
+  @JsonSerializable(disallowUnrecognizedKeys: true)
+  const factory UnrecognizedKeysUnionValueCaseScreamingSnake.secondValue(
+      int a) = _UnrecognizedKeysUnionValueCaseScreamingSnakeSecondValue;
+
+  factory UnrecognizedKeysUnionValueCaseScreamingSnake.fromJson(
+          Map<String, dynamic> json) =>
+      _$UnrecognizedKeysUnionValueCaseScreamingSnakeFromJson(json);
 }
 
 @freezed

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -380,6 +380,36 @@ Future<void> main() async {
         <String, dynamic>{'runtimeType': 'second_value', 'a': 21},
       );
     });
+
+    test('FreezedUnionCase.screamingSnake fromJson', () {
+      expect(
+        UnionValueCaseScreamingSnake.fromJson(<String, dynamic>{
+          'runtimeType': 'FIRST',
+          'a': 42,
+        }),
+        UnionValueCaseScreamingSnake.first(42),
+      );
+
+      expect(
+        UnionValueCaseScreamingSnake.fromJson(<String, dynamic>{
+          'runtimeType': 'SECOND_VALUE',
+          'a': 21,
+        }),
+        UnionValueCaseScreamingSnake.secondValue(21),
+      );
+    });
+
+    test('FreezedUnionCase.screamingSnake toJson', () {
+      expect(
+        UnionValueCaseScreamingSnake.first(42).toJson(),
+        <String, dynamic>{'runtimeType': 'FIRST', 'a': 42},
+      );
+
+      expect(
+        UnionValueCaseScreamingSnake.secondValue(21).toJson(),
+        <String, dynamic>{'runtimeType': 'SECOND_VALUE', 'a': 21},
+      );
+    });
   });
 
   group('JsonSerializable.disallowUnrecognizedKeys', () {
@@ -572,6 +602,38 @@ Future<void> main() async {
         expect(
           UnrecognizedKeysUnionValueCaseSnake.secondValue(21).toJson(),
           <String, dynamic>{'runtimeType': 'second_value', 'a': 21},
+        );
+      });
+
+      test('FreezedUnionCase.screamingScreamingSnake fromJson', () {
+        expect(
+          UnrecognizedKeysUnionValueCaseScreamingSnake
+              .fromJson(<String, dynamic>{
+            'runtimeType': 'FIRST',
+            'a': 42,
+          }),
+          UnrecognizedKeysUnionValueCaseScreamingSnake.first(42),
+        );
+
+        expect(
+          UnrecognizedKeysUnionValueCaseScreamingSnake
+              .fromJson(<String, dynamic>{
+            'runtimeType': 'SECOND_VALUE',
+            'a': 21,
+          }),
+          UnrecognizedKeysUnionValueCaseScreamingSnake.secondValue(21),
+        );
+      });
+
+      test('FreezedUnionCase.screamingScreamingSnake toJson', () {
+        expect(
+          UnrecognizedKeysUnionValueCaseScreamingSnake.first(42).toJson(),
+          <String, dynamic>{'runtimeType': 'FIRST', 'a': 42},
+        );
+
+        expect(
+          UnrecognizedKeysUnionValueCaseScreamingSnake.secondValue(21).toJson(),
+          <String, dynamic>{'runtimeType': 'SECOND_VALUE', 'a': 21},
         );
       });
     });

--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -317,4 +317,7 @@ enum FreezedUnionCase {
 
   /// Encodes a constructor named `snakeCase` with a JSON value `snake_case`.
   snake,
+
+  /// Encodes a constructor named `screamingSnakeCase` with a JSON value `SCREAMING_SNAKE_CASE`.
+  screamingSnake,
 }


### PR DESCRIPTION
Some languages use `SCREAMING_SNAKE_CASE` (occasionally called "macro case" I believe) for enum values and constants.

This adds screaming snake as another union case option.

This could also be done with a series of `@FreezedUnionValue()` overrides but this is a nice-to-have when dealing with e.g an API that uses screaming snake for its discriminator consistently.

As a contrived example:

```
@Freezed(
  unionKey: 'action',
  unionValueCase: FreezedUnionCase.screamingSnake
)
class GitAction {
  GitAction.stage(List<String> files) = _Stage;
  GitAction.commit(String message) = _Commit;
}

// for
{
   "action": "STAGE",
   "files": [ "README.md" ]
}

// and 

{
   "action": "COMMIT",
   "message": "Updated readme"
}
```