### PR TITLE
Fix typo in CHANGELOG.md

### DIFF
--- a/packages/freezed/CHANGELOG.md
+++ b/packages/freezed/CHANGELOG.md
@@ -9,7 +9,7 @@
   ```
 
 - **Breaking**: Freezed now converts Lists/Maps/Sets into UnmodifiableListView/UnmodifiableMapView/UnmodifiableSetView.
-  This can be disabled for one class by specifying `@Feezed(makeCollectionsUnmodifiable: false)`.
+  This can be disabled for one class by specifying `@Freezed(makeCollectionsUnmodifiable: false)`.
   Alternatively, this can be configured inside the `build.yaml` file
 
 - Added parameters of `@Freezed` to customize the generated code.


### PR DESCRIPTION
This PR fixes a typo in the CHANGELOG for 2.0.0