### PR TITLE
fix #646

### DIFF
--- a/packages/freezed/lib/src/templates/prototypes.dart
+++ b/packages/freezed/lib/src/templates/prototypes.dart
@@ -148,9 +148,15 @@ String _whenPrototype(
         ...constructor.parameters.requiredPositionalParameters
             .map((e) => e.copyWith(isFinal: false)),
         ...constructor.parameters.optionalPositionalParameters
-            .map((e) => e.copyWith(isFinal: false)),
-        ...constructor.parameters.namedParameters
-            .map((e) => e.copyWith(isRequired: false, isFinal: false)),
+            .map((e) => e.copyWith(
+                  isFinal: false,
+                  showDefaultValue: false,
+                )),
+        ...constructor.parameters.namedParameters.map((e) => e.copyWith(
+              isRequired: false,
+              isFinal: false,
+              showDefaultValue: false,
+            )),
       ]);
     },
   );

--- a/packages/freezed/test/integration/json.dart
+++ b/packages/freezed/test/integration/json.dart
@@ -3,6 +3,13 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'json.freezed.dart';
 part 'json.g.dart';
 
+@freezed
+class NoWhen with _$NoWhen {
+  factory NoWhen({int? first}) = _NoWhen;
+
+  factory NoWhen.fromJson(Map<String, dynamic> json) => _$NoWhenFromJson(json);
+}
+
 abstract class Base {}
 
 @freezed

--- a/packages/freezed/test/integration/json.dart
+++ b/packages/freezed/test/integration/json.dart
@@ -471,26 +471,6 @@ class DefaultValue with _$DefaultValue {
 }
 
 @freezed
-class DefaultValueNamedConstructor with _$DefaultValueNamedConstructor {
-  factory DefaultValueNamedConstructor.named([@Default(42) int value]) =
-      _DefaultValueNamedConstructor;
-
-  factory DefaultValueNamedConstructor.fromJson(Map<String, dynamic> json) =>
-      _$DefaultValueNamedConstructorFromJson(json);
-}
-
-@freezed
-class NamedDefaultValueNamedConstructor
-    with _$NamedDefaultValueNamedConstructor {
-  factory NamedDefaultValueNamedConstructor.named({@Default(42) int value}) =
-      _NamedDefaultValueNamedConstructor;
-
-  factory NamedDefaultValueNamedConstructor.fromJson(
-          Map<String, dynamic> json) =>
-      _$NamedDefaultValueNamedConstructorFromJson(json);
-}
-
-@freezed
 class DefaultValueJsonKey with _$DefaultValueJsonKey {
   factory DefaultValueJsonKey([
     @Default(42) @JsonKey(defaultValue: 21) int value,

--- a/packages/freezed/test/integration/json.dart
+++ b/packages/freezed/test/integration/json.dart
@@ -471,6 +471,26 @@ class DefaultValue with _$DefaultValue {
 }
 
 @freezed
+class DefaultValueNamedConstructor with _$DefaultValueNamedConstructor {
+  factory DefaultValueNamedConstructor.named([@Default(42) int value]) =
+      _DefaultValueNamedConstructor;
+
+  factory DefaultValueNamedConstructor.fromJson(Map<String, dynamic> json) =>
+      _$DefaultValueNamedConstructorFromJson(json);
+}
+
+@freezed
+class NamedDefaultValueNamedConstructor
+    with _$NamedDefaultValueNamedConstructor {
+  factory NamedDefaultValueNamedConstructor.named({@Default(42) int value}) =
+      _NamedDefaultValueNamedConstructor;
+
+  factory NamedDefaultValueNamedConstructor.fromJson(
+          Map<String, dynamic> json) =>
+      _$NamedDefaultValueNamedConstructorFromJson(json);
+}
+
+@freezed
 class DefaultValueJsonKey with _$DefaultValueJsonKey {
   factory DefaultValueJsonKey([
     @Default(42) @JsonKey(defaultValue: 21) int value,

--- a/packages/freezed/test/integration/multiple_constructors.dart
+++ b/packages/freezed/test/integration/multiple_constructors.dart
@@ -3,6 +3,24 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'multiple_constructors.freezed.dart';
 
 @freezed
+class DefaultValueNamedConstructor with _$DefaultValueNamedConstructor {
+  factory DefaultValueNamedConstructor.a([@Default(42) int value]) =
+      _ADefaultValueNamedConstructor;
+  factory DefaultValueNamedConstructor.b([@Default(42) int value]) =
+      _BDefaultValueNamedConstructor;
+}
+
+@freezed
+class NamedDefaultValueNamedConstructor
+    with _$NamedDefaultValueNamedConstructor {
+  factory NamedDefaultValueNamedConstructor.a({@Default(42) int value}) =
+      _BNamedDefaultValueNamedConstructor;
+
+  factory NamedDefaultValueNamedConstructor.b({@Default(42) int value}) =
+      _ANamedDefaultValueNamedConstructor;
+}
+
+@freezed
 class NoCommonParam with _$NoCommonParam {
   const factory NoCommonParam(String a, {int? b}) = NoCommonParam0;
   const factory NoCommonParam.named(double c, [Object? d]) = NoCommonParam1;

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -41,6 +41,27 @@ Future<void> main() async {
     );
   });
 
+  test('Do not generate when/map even if fromJson is present', () async {
+    await expectLater(compile(r'''
+import 'json.dart';
+
+void main() {
+  final a = NoWhen();
+}
+'''), completes);
+
+    await expectLater(compile(r'''
+import 'json.dart';
+import 'json.dart';
+
+void main() {
+  final a = NoWhen();
+  a.whenOrNull();
+  a.mapOrNull();
+}
+'''), throwsCompileError);
+  });
+
   group('Freezed.unionKey', () {
     test('fromJson', () {
       expect(

--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -84,21 +84,18 @@ class FreezedMapOptions {
   ///
   /// If null, will fallback to the build.yaml configs
   /// If that value is null too, defaults to true.
-  @JsonKey(defaultValue: true)
   final bool? map;
 
   /// Whether to generate `Union.mapOrNull`
   ///
   /// If null, will fallback to the build.yaml configs
   /// If that value is null too, defaults to true.
-  @JsonKey(defaultValue: true)
   final bool? mapOrNull;
 
   /// Whether to generate `Union.maybeMap`
   ///
   /// If null, will fallback to the build.yaml configs
   /// If that value is null too, defaults to true.
-  @JsonKey(defaultValue: true)
   final bool? maybeMap;
 }
 
@@ -131,21 +128,18 @@ class FreezedWhenOptions {
   ///
   /// If null, will fallback to the build.yaml configs
   /// If that value is null too, defaults to true.
-  @JsonKey(defaultValue: true)
   final bool? when;
 
   /// Whether to generate `Union.whenOrNull`
   ///
   /// If null, will fallback to the build.yaml configs
   /// If that value is null too, defaults to true.
-  @JsonKey(defaultValue: true)
   final bool? whenOrNull;
 
   /// Whether to generate `Union.maybeWhen`
   ///
   /// If null, will fallback to the build.yaml configs.
   /// If that value is null too, defaults to true.
-  @JsonKey(defaultValue: true)
   final bool? maybeWhen;
 }
 

--- a/packages/freezed_annotation/lib/freezed_annotation.g.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.g.dart
@@ -10,16 +10,16 @@ part of 'freezed_annotation.dart';
 
 FreezedMapOptions _$FreezedMapOptionsFromJson(Map<String, dynamic> json) =>
     FreezedMapOptions(
-      map: json['map'] as bool? ?? true,
-      mapOrNull: json['map_or_null'] as bool? ?? true,
-      maybeMap: json['maybe_map'] as bool? ?? true,
+      map: json['map'] as bool?,
+      mapOrNull: json['map_or_null'] as bool?,
+      maybeMap: json['maybe_map'] as bool?,
     );
 
 FreezedWhenOptions _$FreezedWhenOptionsFromJson(Map<String, dynamic> json) =>
     FreezedWhenOptions(
-      when: json['when'] as bool? ?? true,
-      whenOrNull: json['when_or_null'] as bool? ?? true,
-      maybeWhen: json['maybe_when'] as bool? ?? true,
+      when: json['when'] as bool?,
+      whenOrNull: json['when_or_null'] as bool?,
+      maybeWhen: json['maybe_when'] as bool?,
     );
 
 Freezed _$FreezedFromJson(Map<String, dynamic> json) => Freezed(

--- a/packages/freezed_annotation/test/freezed_test.dart
+++ b/packages/freezed_annotation/test/freezed_test.dart
@@ -5,20 +5,28 @@ void main() {
   group('FreezedMapOptions', () {
     test('.fromJson', () {
       expect(FreezedMapOptions.fromJson({'map': false}).map, isFalse);
-      expect(FreezedMapOptions.fromJson({'map': false}).mapOrNull, isTrue);
-      expect(FreezedMapOptions.fromJson({'map': false}).maybeMap, isTrue);
+      expect(FreezedMapOptions.fromJson({'map': false}).mapOrNull, isNull);
+      expect(FreezedMapOptions.fromJson({'map': false}).maybeMap, isNull);
 
-      expect(FreezedMapOptions.fromJson({'map_or_null': false}).map, isTrue);
-      expect(FreezedMapOptions.fromJson({'map_or_null': false}).mapOrNull,
-          isFalse);
+      expect(FreezedMapOptions.fromJson({'map_or_null': false}).map, isNull);
       expect(
-          FreezedMapOptions.fromJson({'map_or_null': false}).maybeMap, isTrue);
+        FreezedMapOptions.fromJson({'map_or_null': false}).mapOrNull,
+        isFalse,
+      );
+      expect(
+        FreezedMapOptions.fromJson({'map_or_null': false}).maybeMap,
+        isNull,
+      );
 
-      expect(FreezedMapOptions.fromJson({'maybe_map': false}).map, isTrue);
+      expect(FreezedMapOptions.fromJson({'maybe_map': false}).map, isNull);
       expect(
-          FreezedMapOptions.fromJson({'maybe_map': false}).mapOrNull, isTrue);
+        FreezedMapOptions.fromJson({'maybe_map': false}).mapOrNull,
+        isNull,
+      );
       expect(
-          FreezedMapOptions.fromJson({'maybe_map': false}).maybeMap, isFalse);
+        FreezedMapOptions.fromJson({'maybe_map': false}).maybeMap,
+        isFalse,
+      );
     });
 
     test('.all', () {
@@ -43,23 +51,23 @@ void main() {
   group('FreezedWhenOptions', () {
     test('.fromJson', () {
       expect(FreezedWhenOptions.fromJson({'when': false}).when, isFalse);
-      expect(FreezedWhenOptions.fromJson({'when': false}).whenOrNull, isTrue);
-      expect(FreezedWhenOptions.fromJson({'when': false}).maybeWhen, isTrue);
+      expect(FreezedWhenOptions.fromJson({'when': false}).whenOrNull, isNull);
+      expect(FreezedWhenOptions.fromJson({'when': false}).maybeWhen, isNull);
 
-      expect(FreezedWhenOptions.fromJson({'when_or_null': false}).when, isTrue);
+      expect(FreezedWhenOptions.fromJson({'when_or_null': false}).when, isNull);
       expect(
         FreezedWhenOptions.fromJson({'when_or_null': false}).whenOrNull,
         isFalse,
       );
       expect(
         FreezedWhenOptions.fromJson({'when_or_null': false}).maybeWhen,
-        isTrue,
+        isNull,
       );
 
-      expect(FreezedWhenOptions.fromJson({'maybe_when': false}).when, isTrue);
+      expect(FreezedWhenOptions.fromJson({'maybe_when': false}).when, isNull);
       expect(
         FreezedWhenOptions.fromJson({'maybe_when': false}).whenOrNull,
-        isTrue,
+        isNull,
       );
       expect(
         FreezedWhenOptions.fromJson({'maybe_when': false}).maybeWhen,


### PR DESCRIPTION
fixes: #646
The `when` prototype was not setting `showDefaultValue` to false for optional parameters.

For some reason this only shows up with named constructors. I added some samples in the integration test for json.