### PR TITLE
ValidClassUsage warning link to changelog instead

### DIFF
--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -155,8 +155,8 @@ class FreezedGenerator extends ParserGenerator<GlobalData, Data, Freezed> {
     if (element.isAbstract) {
       log.warning(
         '''
-The class ${element.name} was declared as abstract, but it is not need anymore.
-Read here: https://github.com/rrousselGit/freezed/tree/master/packages/freezed#the-abstract-keyword
+The class ${element.name} was declared as abstract, but it is not needed anymore.
+Read here: https://github.com/rrousselGit/freezed/blob/master/packages/freezed/CHANGELOG.md#0140
 ''',
       );
     }

--- a/packages/freezed/test/source_gen_src.dart
+++ b/packages/freezed/test/source_gen_src.dart
@@ -216,8 +216,8 @@ class Mixed0 implements Mixed {
   contains: true,
   expectedLogItems: [
     '''
-The class AstractClass was declared as abstract, but it is not need anymore.
-Read here: https://github.com/rrousselGit/freezed/tree/master/packages/freezed#the-abstract-keyword
+The class AstractClass was declared as abstract, but it is not needed anymore.
+Read here: https://github.com/rrousselGit/freezed/blob/master/packages/freezed/CHANGELOG.md#0140
 ''',
   ],
 )


### PR DESCRIPTION
**#the-abstract-keyword** is no longer a section in the [README.md](https://github.com/rrousselGit/freezed/tree/master/packages/freezed#the-abstract-keyword)

So this warning could instead point to the [CHANGELOG.md](https://github.com/rrousselGit/freezed/blob/master/packages/freezed/CHANGELOG.md#0140) where this change is documented.