### PR TITLE
Fix deprecations for analyzer 4.3.0

### DIFF
--- a/packages/freezed/lib/src/tools/recursive_import_locator.dart
+++ b/packages/freezed/lib/src/tools/recursive_import_locator.dart
@@ -23,7 +23,7 @@ class RecursiveImportLocator {
     // based on importedLibraries in
     // analyzer-0.39.4/lib/src/dart/element/element.dart:5321
     final libraries = <_LibraryWithVisibility>{};
-    for (final import in root.imports) {
+    for (final import in root.libraryImports) {
       final library = import.importedLibrary;
       if (library != null) {
         libraries.add(_LibraryWithVisibility.root(library, import.combinators));
@@ -108,7 +108,7 @@ class _LibraryWithVisibility {
   /// analyzer-0.39.4/lib/src/dart/element/element.dart:5230
   List<_LibraryWithVisibility> get exportedLibraries {
     final libraries = <_LibraryWithVisibility>{};
-    for (final export in library.exports) {
+    for (final export in library.libraryExports) {
       final library = export.exportedLibrary;
       if (library != null) {
         libraries.add(_LibraryWithVisibility(

--- a/packages/freezed/lib/src/tools/type.dart
+++ b/packages/freezed/lib/src/tools/type.dart
@@ -24,7 +24,7 @@ String resolveFullTypeStringFrom(
 }) {
   final owner = originLibrary.prefixes.firstWhereOrNull(
     (e) {
-      return e.imports.any((l) {
+      return e.imports2.any((l) {
         return l.importedLibrary!.anyTransitiveExport((library) {
           return library.id == _getElementForType(type)?.library?.id;
         });


### PR DESCRIPTION
To fix the latest failed [Build](https://github.com/rrousselGit/freezed/runs/7487099047?check_suite_focus=true#analyze) Actions
- Applied the fixes for deprecated methods in `analyzer: 4.3.0`
