### PR TITLE
fix deprecations from analyzer: 4.4.0

### DIFF
--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -412,11 +412,12 @@ Read here: https://github.com/rrousselGit/freezed/blob/master/packages/freezed/C
     for (final parameter in constructor.parameters) {
       final type = parseTypeSource(parameter);
 
-      final parameterTypeElement = parameter.type.element;
-      if (parameterTypeElement == null) continue;
-      if (parameterTypeElement is! ClassElement) continue;
+      final parameterType = parameter.type;
+      if (parameterType is! InterfaceType) continue;
+      final element = parameterType.element2;
+      if (element is! ClassElement) continue;
 
-      final classElement = parameterTypeElement;
+      final classElement = element;
 
       if (!typeChecker.hasAnnotationOf(classElement)) continue;
 
@@ -425,7 +426,7 @@ Read here: https://github.com/rrousselGit/freezed/blob/master/packages/freezed/C
         type: type!,
         nullable:
             parameter.type.nullabilitySuffix == NullabilitySuffix.question,
-        typeName: parameter.type.element!.name!,
+        typeName: classElement.name,
         genericParameters: GenericsParameterTemplate(
           (parameter.type as InterfaceType)
               .typeArguments
@@ -648,8 +649,8 @@ Read here: https://github.com/rrousselGit/freezed/blob/master/packages/freezed/C
     for (final type in [
       element,
       ...element.allSupertypes
-          .map((e) => e.element)
           .where((e) => !e.isDartCoreObject)
+          .map((e) => e.element2)
     ]) {
       for (final method in type.methods) {
         if (method.name == 'toString') {
@@ -665,8 +666,8 @@ Read here: https://github.com/rrousselGit/freezed/blob/master/packages/freezed/C
     for (final type in [
       element,
       ...element.allSupertypes
-          .map((e) => e.element)
           .where((e) => !e.isDartCoreObject)
+          .map((e) => e.element2)
     ]) {
       for (final method in type.methods.where((e) => e.isOperator)) {
         if (method.name == '==') {

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
 import 'package:freezed/src/models.dart';
 import 'package:freezed/src/templates/properties.dart';
 import 'package:freezed/src/tools/type.dart';
@@ -552,12 +553,11 @@ String? parseTypeSource(VariableElement element) {
   if (type.contains('dynamic') && element.nameOffset > 0) {
     final source =
         element.source!.contents.data.substring(0, element.nameOffset);
-    if (element.type.element != null &&
-        element.type.isDynamic &&
-        element.type.element!.isSynthetic) {
+    final eleType = element.type;
+    if (eleType is DynamicType) {
       final match = RegExp(r'(\w+\??)\s+$').firstMatch(source);
       return match?.group(1);
-    } else if (element.type.element != null) {
+    } else if (eleType is InterfaceType) {
       final match = RegExp(r'(\w+<.+?>\??)\s+$').firstMatch(source);
       return match?.group(1) ?? type;
     }

--- a/packages/freezed/lib/src/tools/type.dart
+++ b/packages/freezed/lib/src/tools/type.dart
@@ -10,10 +10,13 @@ import 'imports.dart';
 /// this is usually type.element, except if it is a typedef then it is
 /// type.alias.element
 Element? _getElementForType(DartType type) {
-  if (type.element != null) {
-    return type.element;
+  if (type is InterfaceType) {
+    return type.element2;
   }
-  return type.alias?.element;
+  if (type is FunctionType) {
+    return type.alias?.element;
+  }
+  return null;
 }
 
 /// Renders a type based on its string + potential import alias

--- a/packages/freezed/test/integration/multiple_constructors.dart
+++ b/packages/freezed/test/integration/multiple_constructors.dart
@@ -77,7 +77,6 @@ class Complex with _$Complex {
   const factory Complex.first(
     /// World
     String a, {
-
     /// B
     bool? b,
     double? d,
@@ -85,7 +84,6 @@ class Complex with _$Complex {
 
   const factory Complex.second(
     String a, [
-
     /// C
     int? c,
     double? d,

--- a/packages/freezed/test/integration/single_class_constructor.dart
+++ b/packages/freezed/test/integration/single_class_constructor.dart
@@ -244,7 +244,6 @@ class Doc with _$Doc {
     /// line
     /// positional
     int positional, {
-
     /// Single line named
     int? named,
 


### PR DESCRIPTION
analyzer: **4.4.0** [changelog](https://pub.dev/packages/analyzer/changelog#440)
> - Deprecated DartType.element, check for InterfaceType, TypeParameterType, and then ask the element.

No breaking changes in analyzer: **4.5.0** that effect freezed.
