### PR TITLE
Set default_author to github_actions

### DIFF
--- a/.github/workflows/sponsor.yml
+++ b/.github/workflows/sponsor.yml
@@ -31,9 +31,10 @@ jobs:
       - run: ls sponsorkit
 
       - name: Commit
-        uses: EndBug/add-and-commit@v4
+        uses: EndBug/add-and-commit@v9
         with:
           message: "chore: update sponsors.svg"
           add: "./sponsorkit/sponsors.*"
+          default_author: github_actions
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently `add-and-commit` doesn't find a commit (because workflow runs on `schedule` not on push/pr/commit) and falls back to who ever made the last commit in the repo:
```sh
Unable to get commit from workflow event: trying with the GitHub API...
Using 'David Wimmer <david.wimmer@ffuf.de>' as author.
```
[example-action-log](https://github.com/rrousselGit/freezed/runs/7830166714?check_suite_focus=true#step:8:11)

Newer versions of add-and-commit (added v7.2.0) allow setting a [`default_author`](https://github.com/marketplace/actions/add-commit#different-authorcommitter-configurations)
