### PR TITLE
feat: add common properties with different nullability to base mixin

### DIFF
--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -135,6 +135,7 @@ ${copyWith?.abstractCopyWithGetter ?? ''}
         doc: '',
         isPossiblyDartCollection: false,
         showDefaultValue: false,
+        isCommonWithDifferentNullability: false,
       );
 
       parameters = ParametersTemplate(

--- a/packages/freezed/lib/src/templates/copy_with.dart
+++ b/packages/freezed/lib/src/templates/copy_with.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:freezed/src/templates/parameter_template.dart';
 import 'package:freezed/src/templates/properties.dart';
 
@@ -65,23 +66,28 @@ ${_abstractDeepCopyMethods().join()}
       final body = _copyWithMethodBody(
         parametersTemplate: ParametersTemplate(
           const [],
-          namedParameters: commonProperties.map((e) {
-            return Parameter(
-              decorators: e.decorators,
-              name: e.name,
-              isNullable: false,
-              isFinal: false,
-              isDartList: false,
-              isDartMap: false,
-              isDartSet: false,
-              showDefaultValue: false,
-              isRequired: false,
-              defaultValueSource: '',
-              type: e.type,
-              doc: e.doc,
-              isPossiblyDartCollection: e.isPossiblyDartCollection,
-            );
-          }).toList(),
+          namedParameters: commonProperties
+              .map((e) {
+                return Parameter(
+                  decorators: e.decorators,
+                  name: e.name,
+                  isNullable: false,
+                  isFinal: false,
+                  isDartList: false,
+                  isDartMap: false,
+                  isDartSet: false,
+                  showDefaultValue: false,
+                  isRequired: false,
+                  defaultValueSource: '',
+                  type: e.type,
+                  doc: e.doc,
+                  isPossiblyDartCollection: e.isPossiblyDartCollection,
+                  isCommonWithDifferentNullability:
+                      e.isCommonWithDifferentNullability,
+                );
+              })
+              .whereNot((element) => element.isCommonWithDifferentNullability)
+              .toList(),
         ),
         returnType: '_value.copyWith',
       );

--- a/packages/freezed/lib/src/templates/parameter_template.dart
+++ b/packages/freezed/lib/src/templates/parameter_template.dart
@@ -82,6 +82,7 @@ class ParametersTemplate {
         doc: await documentationOfParameter(e, buildStep),
         isPossiblyDartCollection: e.type.isPossiblyDartCollection,
         showDefaultValue: true,
+        isCommonWithDifferentNullability: false,
       );
 
       if (isAssignedToThis) return LocalParameter.fromParameter(value);
@@ -184,6 +185,7 @@ class Parameter {
     required this.isFinal,
     required this.isPossiblyDartCollection,
     required this.showDefaultValue,
+    required this.isCommonWithDifferentNullability,
   });
 
   Parameter.fromParameter(Parameter p)
@@ -201,6 +203,7 @@ class Parameter {
           showDefaultValue: p.showDefaultValue,
           doc: p.doc,
           isPossiblyDartCollection: p.isPossiblyDartCollection,
+          isCommonWithDifferentNullability: p.isCommonWithDifferentNullability,
         );
 
   final String? type;
@@ -216,6 +219,7 @@ class Parameter {
   final bool isPossiblyDartCollection;
   final bool isFinal;
   final String doc;
+  final bool isCommonWithDifferentNullability;
 
   Parameter copyWith({
     String? type,
@@ -232,6 +236,7 @@ class Parameter {
     bool? isDartMap,
     bool? isDartSet,
     bool? isFinal,
+    bool? isCommonWithDifferentNullability,
   }) =>
       Parameter(
         type: type ?? this.type,
@@ -248,6 +253,8 @@ class Parameter {
         isFinal: isFinal ?? this.isFinal,
         isPossiblyDartCollection:
             isPossiblyDartCollection ?? this.isPossiblyDartCollection,
+        isCommonWithDifferentNullability: isCommonWithDifferentNullability ??
+            this.isCommonWithDifferentNullability,
       );
 
   @override
@@ -283,6 +290,7 @@ class LocalParameter extends Parameter {
     required List<String> decorators,
     required String doc,
     required bool isPossiblyDartCollection,
+    required bool isCommonWithDifferentNullability,
   }) : super(
           name: name,
           type: type,
@@ -297,6 +305,7 @@ class LocalParameter extends Parameter {
           defaultValueSource: defaultValueSource,
           doc: doc,
           isPossiblyDartCollection: isPossiblyDartCollection,
+          isCommonWithDifferentNullability: isCommonWithDifferentNullability,
         );
 
   LocalParameter.fromParameter(Parameter p)
@@ -313,6 +322,7 @@ class LocalParameter extends Parameter {
           decorators: p.decorators,
           doc: p.doc,
           isPossiblyDartCollection: p.isPossiblyDartCollection,
+          isCommonWithDifferentNullability: p.isCommonWithDifferentNullability,
         );
 
   @override
@@ -346,6 +356,7 @@ class CallbackParameter extends Parameter {
     required this.parameters,
     required String doc,
     required bool isPossiblyDartCollection,
+    required bool isCommonWithDifferentNullability,
   }) : super(
           name: name,
           type: type,
@@ -360,6 +371,7 @@ class CallbackParameter extends Parameter {
           defaultValueSource: defaultValueSource,
           doc: doc,
           isPossiblyDartCollection: isPossiblyDartCollection,
+          isCommonWithDifferentNullability: isCommonWithDifferentNullability,
         );
 
   final ParametersTemplate parameters;

--- a/packages/freezed/lib/src/templates/properties.dart
+++ b/packages/freezed/lib/src/templates/properties.dart
@@ -31,6 +31,7 @@ class Property {
     required this.isDartMap,
     required this.isDartSet,
     required this.isPossiblyDartCollection,
+    required this.isCommonWithDifferentNullability,
   }) : type = type ?? 'dynamic';
 
   static Future<Property> fromParameter(
@@ -60,6 +61,7 @@ class Property {
       defaultValueSource: defaultValue,
       hasJsonKey: element.hasJsonKey,
       isPossiblyDartCollection: element.type.isPossiblyDartCollection,
+      isCommonWithDifferentNullability: false,
     );
   }
 
@@ -75,6 +77,7 @@ class Property {
   final bool hasJsonKey;
   final String doc;
   final bool isPossiblyDartCollection;
+  final bool isCommonWithDifferentNullability;
 
   @override
   String toString() {
@@ -135,6 +138,7 @@ class Property {
     bool? hasJsonKey,
     String? doc,
     bool? isPossiblyDartCollection,
+    bool? isCommonWithDifferentNullability,
   }) {
     return Property(
       type: type ?? this.type,
@@ -150,6 +154,8 @@ class Property {
       isDartSet: isDartSet ?? this.isDartSet,
       isPossiblyDartCollection:
           isPossiblyDartCollection ?? this.isPossiblyDartCollection,
+      isCommonWithDifferentNullability: isCommonWithDifferentNullability ??
+          this.isCommonWithDifferentNullability,
     );
   }
 }

--- a/packages/freezed/lib/src/templates/prototypes.dart
+++ b/packages/freezed/lib/src/templates/prototypes.dart
@@ -127,6 +127,7 @@ String _mapPrototype(
           // TODO: do we want to support freezed classes that implements MapView/ListView?
           isPossiblyDartCollection: false,
           showDefaultValue: false,
+          isCommonWithDifferentNullability: false,
         ),
       ]);
     },
@@ -191,6 +192,7 @@ String _unionPrototype(
       defaultValueSource: '',
       doc: '',
       isPossiblyDartCollection: false,
+      isCommonWithDifferentNullability: false,
     );
 
     if (constructor.isDefault) {

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -6,10 +6,10 @@ version: 2.1.0+1
 homepage: https://github.com/rrousselGit/freezed
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=4.2.0 <5.0.0"
+  analyzer: ">=4.6.0 <5.0.0"
   build: ^2.0.0
   build_config: ^1.0.0
   collection: ^1.15.0

--- a/packages/freezed/test/integration/multiple_constructors.dart
+++ b/packages/freezed/test/integration/multiple_constructors.dart
@@ -65,6 +65,14 @@ class SharedParam with _$SharedParam {
 }
 
 @freezed
+class SharedParamNullable with _$SharedParamNullable {
+  const factory SharedParamNullable(String a, String b, int c) =
+      SharedParamNullable0;
+  const factory SharedParamNullable.named(String? a, String b, int d) = 
+      SharedParamNullable1;
+}
+
+@freezed
 class Complex with _$Complex {
   @Assert("a != ''", '"Hello"')
   const factory Complex(

--- a/packages/freezed/test/multiple_constructors_test.dart
+++ b/packages/freezed/test/multiple_constructors_test.dart
@@ -504,8 +504,48 @@ void main() {
 }
 '''), throwsCompileError);
     });
+  });
 
-    // TODO: shared property name but different type
+  group('SharedParamNullable', () {
+    test('has the common properties available', () {
+      SharedParamNullable value = SharedParamNullable('a', 'b', 42);
+      expect(value.a, 'a');
+
+      value = SharedParamNullable.named('b', 'c', 24);
+      expect(value.a, 'b');
+    });
+
+    test(
+      "copy doesn't have shared params with different nullability",
+      () async {
+        await expectLater(compile(r'''
+import 'multiple_constructors.dart';
+
+void main() {
+  final param = SharedParamNullable('a', 'b', 42);
+  param.copyWith(a: '2');
+}
+'''), throwsCompileError);
+
+        await expectLater(compile(r'''
+import 'multiple_constructors.dart';
+
+void main() {
+  final param = SharedParamNullable('a', 'b', 42);
+  param.copyWith(b: '1');
+}
+'''), completes);
+
+        await expectLater(compile(r'''
+import 'multiple_constructors.dart';
+
+void main() {
+  final param = SharedParamNullable('a', 'b', 42);
+  param.copyWith(c: 42);
+}
+'''), throwsCompileError);
+      },
+    );
   });
 
   test('Can have a named constructor and a property using the same name', () {


### PR DESCRIPTION
The new field `isCommonWithDifferentNullability` might not be perfect but it was the best way I could come up with to propagate the information.

Close #715