### PR TITLE
correct readme for freezed generics with dart sdk '>=2.17.0 <3.0.0'

### DIFF
--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -1081,11 +1081,11 @@ All you need to do is to change the signature of the `fromJson` method and add `
 
 ```dart
 @Freezed(genericArgumentFactories: true)
-class ApiResponse<T> with _$ApiResponse {
-  const factory ApiResponse<T>.data(T data) = ApiResponseData;
-  const factory ApiResponse<T>.error(String message) = ApiResponseError;
+class ApiResponse<T> with _$ApiResponse<T> {
+  const factory ApiResponse.data(T data) = ApiResponseData;
+  const factory ApiResponse.error(String message) = ApiResponseError;
 
-  factory ApiResponse<T>.fromJson(Map<String, dynamic> json, T Function(Object?) fromJsonT) => _$ApiResponseFromJson(json, fromJsonT);
+  factory ApiResponse.fromJson(Map<String, dynamic> json, T Function(Object?) fromJsonT) => _$ApiResponseFromJson(json, fromJsonT);
 }
 ```
 


### PR DESCRIPTION
## Description
Old readme's snippet does not built-runnable:
```dart
@Freezed(genericArgumentFactories: true)
class ApiResponse<T> with _$ApiResponse {
  const factory ApiResponse<T>.data(T data) = ApiResponseData;
  const factory ApiResponse<T>.error(String message) = ApiResponseError;

  factory ApiResponse<T>.fromJson(Map<String, dynamic> json, T Function(Object?) fromJsonT) => _$ApiResponseFromJson(json, fromJsonT);
}
```
Analyzis: 
![image](https://user-images.githubusercontent.com/8981380/188086665-37b3be22-84df-4f3a-9e64-562fe54d4605.png)

Errors:
```
[SEVERE] freezed:freezed on lib/api_response.dart:

This builder requires Dart inputs without syntax errors.
However, package:freezed_collections/api_response.dart (or an existing part) contains the following errors.
api_response.dart:8:31: Functions must have an explicit list of parameters.
api_response.dart:8:3: Only redirecting factory constructors can be declared to be 'const'.
api_response.dart:8:31: A function body must be provided.
And 13 more...
```

## Solution
```dart
@Freezed(genericArgumentFactories: true)
class ApiResponse<T> with _$ApiResponse<T> {
  const factory ApiResponse.data(T data) = ApiResponseData;
  const factory ApiResponse.error(String message) = ApiResponseError;

  factory ApiResponse.fromJson(Map<String, dynamic> json, T Function(Object?) fromJsonT) => _$ApiResponseFromJson(json, fromJsonT);
}
```