### PR TITLE
Update pub.dev links

### DIFF
--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -3,7 +3,8 @@ description: >
   Code generation for immutable classes that has a simple syntax/API without
   compromising on the features.
 version: 2.1.0+1
-homepage: https://github.com/rrousselGit/freezed
+repository: https://github.com/rrousselGit/freezed
+issue_tracker: https://github.com/rrousselGit/freezed/issues
 
 environment:
   sdk: '>=2.17.0 <3.0.0'

--- a/packages/freezed_annotation/pubspec.yaml
+++ b/packages/freezed_annotation/pubspec.yaml
@@ -3,7 +3,8 @@ description: >
   Annotations for the freezed code-generator.
   This package does nothing without freezed too.
 version: 2.1.0
-homepage: https://github.com/rrousselGit/freezed
+repository: https://github.com/rrousselGit/freezed
+issue_tracker: https://github.com/rrousselGit/freezed/issues
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
With this PR, the right section on pub.dev will show the View/report issues link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).

FYI with the issue_tracker link, you could also directly select issue labels (like `freezed` or `freezed_annotation`) when opening the link, if desired, like [here](https://pub.dev/packages/device_info_plus).