### PR TITLE
Allow analyzer < 5.0.0

### DIFF
--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  analyzer: ^5.0.0
+  analyzer: ">=4.2.0 <6.0.0"
   build: ^2.0.0
   build_config: ^1.0.0
   collection: ^1.15.0


### PR DESCRIPTION
Forcing analyzer to  ^5.0.0 leads to conflicts with other packages, e.g. intl_utils