### PR TITLE
Test pub downgrade via matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
   pull_request:
   schedule:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
         dependencies:
           - get
           - downgrade
+        exclude:
+          - channel: master
+            dependencies: downgrade
 
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +35,7 @@ jobs:
         with:
           channel: ${{ matrix.channel }}
 
-      # It is executed separatly
+      # It is executed separately
       - name: Removing example folder
         run: rm -rf example
         working-directory: ${{ matrix.package }}
@@ -43,6 +46,7 @@ jobs:
         working-directory: ${{ matrix.package }}
 
       - name: Check format
+        # Check format only on master
         if: matrix.channel == 'master'
         run: flutter format --set-exit-if-changed .
         working-directory: ${{ matrix.package }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
           # - packages/freezed/example
         channel:
           - master
+          - stable
         dependencies:
           - get
           - downgrade
@@ -38,11 +39,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          flutter pub get
           flutter pub ${{ matrix.dependencies }}
         working-directory: ${{ matrix.package }}
 
       - name: Check format
+        if: ${{ matrix.channel }} == 'master'
         run: flutter format --set-exit-if-changed .
         working-directory: ${{ matrix.package }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           - packages/freezed_annotation
           # - packages/freezed/example
         channel:
-          - stable
+          - master
         dependencies:
           - get
           - downgrade
@@ -42,9 +42,9 @@ jobs:
           flutter pub ${{ matrix.dependencies }}
         working-directory: ${{ matrix.package }}
 
-#      - name: Check format
-#        run: flutter format --set-exit-if-changed .
-#        working-directory: ${{ matrix.package }}
+      - name: Check format
+        run: flutter format --set-exit-if-changed .
+        working-directory: ${{ matrix.package }}
 
       - name: Generate
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         working-directory: ${{ matrix.package }}
 
       - name: Check format
-        if: ${{ matrix.channel }} == 'master'
+        if: matrix.channel == 'master'
         run: flutter format --set-exit-if-changed .
         working-directory: ${{ matrix.package }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,13 +39,12 @@ jobs:
       - name: Install dependencies
         run: |
           flutter pub get
-          flutter pub upgrade
           flutter pub ${{ matrix.dependencies }}
         working-directory: ${{ matrix.package }}
 
-      - name: Check format
-        run: flutter format --set-exit-if-changed .
-        working-directory: ${{ matrix.package }}
+#      - name: Check format
+#        run: flutter format --set-exit-if-changed .
+#        working-directory: ${{ matrix.package }}
 
       - name: Generate
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: Build
 
 on:
-  workflow_dispatch:
   push:
   pull_request:
   schedule:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           - packages/freezed_annotation
           # - packages/freezed/example
         channel:
-          - master
+          - stable
         dependencies:
           - get
           - downgrade

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           flutter pub get
-          flutter pub deps -s compact
+          flutter pub upgrade
           flutter pub ${{ matrix.dependencies }}
         working-directory: ${{ matrix.package }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ jobs:
           # - packages/freezed/example
         channel:
           - master
+        dependencies:
+          - get
+          - downgrade
 
     steps:
       - uses: actions/checkout@v2
@@ -33,7 +36,7 @@ jobs:
         working-directory: ${{ matrix.package }}
 
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub ${{ matrix.dependencies }}
         working-directory: ${{ matrix.package }}
 
       - name: Check format

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,10 @@ jobs:
         working-directory: ${{ matrix.package }}
 
       - name: Install dependencies
-        run: flutter pub ${{ matrix.dependencies }}
+        run: |
+          flutter pub get
+          flutter pub deps -s compact
+          flutter pub ${{ matrix.dependencies }}
         working-directory: ${{ matrix.package }}
 
       - name: Check format

--- a/packages/freezed/example/pubspec.yaml
+++ b/packages/freezed/example/pubspec.yaml
@@ -2,19 +2,19 @@ name: example
 description: A new Flutter project.
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
   freezed_annotation:
     path: ../../freezed_annotation
-  json_annotation: ^4.4.0
+  json_annotation: ^4.6.0
 
 dev_dependencies:
   freezed:
     path: ../
-  json_serializable: ^6.1.3
+  json_serializable: ^6.3.2
   build_runner:
   flutter_test:
     sdk: flutter

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -27,9 +27,3 @@ dev_dependencies:
   matcher: ^0.12.11
   source_gen_test: ^1.0.4
 
-dependency_overrides:
-  # pub downgrade:
-  # build_runner 2.2.0 => glob 2.0.0 => file 6.0.0
-  # but we need minimum 6.1.3
-  file: ^6.1.3
-

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -11,18 +11,25 @@ environment:
 
 dependencies:
   analyzer: ^5.0.0
-  build: ^2.0.0
-  build_config: ^1.0.0
+  build: ^2.3.1
+  build_config: ^1.1.0
   collection: ^1.15.0
   meta: ^1.7.0
-  source_gen: ^1.2.0
+  source_gen: ^1.2.3
   freezed_annotation: ^2.1.0
-  json_annotation: ^4.4.0
+  json_annotation: ^4.6.0
 
 dev_dependencies:
-  json_serializable: ^6.1.3
+  json_serializable: ^6.3.2
   build_test: ^2.1.5
   build_runner: ^2.2.0
-  test: ^1.20.1
+  test: ^1.21.0
   matcher: ^0.12.11
-  source_gen_test: ^1.0.2
+  source_gen_test: ^1.0.4
+
+dependency_overrides:
+  # pub downgrade:
+  # build_runner 2.2.0 => glob 2.0.0 => file 6.0.0
+  # but we need minimum 6.1.3
+  file: ^6.1.3
+

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  analyzer: ^5.0.0
+  analyzer: ">=4.6.0 <6.0.0"
   build: ^2.3.1
   build_config: ^1.1.0
   collection: ^1.15.0

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
 dev_dependencies:
   json_serializable: ^6.1.3
   build_test: ^2.1.5
-  build_runner: ^2.1.7
+  build_runner: ^2.2.0
   test: ^1.20.1
   matcher: ^0.12.11
   source_gen_test: ^1.0.2

--- a/packages/freezed/pubspec_overrides.yaml
+++ b/packages/freezed/pubspec_overrides.yaml
@@ -1,3 +1,4 @@
 dependency_overrides:
   freezed_annotation:
     path: ../freezed_annotation
+  file: ^6.1.3

--- a/packages/freezed/pubspec_overrides.yaml
+++ b/packages/freezed/pubspec_overrides.yaml
@@ -1,4 +1,7 @@
 dependency_overrides:
   freezed_annotation:
     path: ../freezed_annotation
+  # pub downgrade:
+  # build_runner 2.2.0 => glob 2.0.0 => file 6.0.0
+  # but we need minimum 6.1.3
   file: ^6.1.3

--- a/packages/freezed_annotation/pubspec.yaml
+++ b/packages/freezed_annotation/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
   meta: ^1.7.0
 
 dev_dependencies:
-  build_runner: ^2.1.7
+  build_runner: ^2.2.0
   json_serializable: ^6.1.3
   test: ^1.21.0

--- a/packages/freezed_annotation/pubspec.yaml
+++ b/packages/freezed_annotation/pubspec.yaml
@@ -7,14 +7,20 @@ repository: https://github.com/rrousselGit/freezed
 issue_tracker: https://github.com/rrousselGit/freezed/issues
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   collection: ^1.15.0
-  json_annotation: ^4.4.0
+  json_annotation: ^4.6.0
   meta: ^1.7.0
 
 dev_dependencies:
   build_runner: ^2.2.0
-  json_serializable: ^6.1.3
+  json_serializable: ^6.3.2
   test: ^1.21.0
+
+dependency_overrides:
+  # pub downgrade:
+  # build_runner 2.2.0 => glob 2.0.0 => file 6.0.0
+  # but we need minimum 6.1.3
+  file: ^6.1.3


### PR DESCRIPTION
Hey @rrousselGit , this PR is in regard of your [comment](https://github.com/rrousselGit/freezed/pull/772#issuecomment-1269683090) on #772 .

I did a lot a lot of testing of all possible combinations of version-constraints, so that all tests still succeed.
Also always cross-checking locally with `dart pub deps` which transitive dependencies make the tests fail when they downgrade to "low".
You can have a look at the [actions on my fork](https://github.com/SunlightBro/freezed/actions/workflows/build.yml)

I had to introduce a dependency_override `file` 😞 as build_runner will fail below `file: ^6.1.3`
```yaml
  # pub downgrade:
  # build_runner 2.2.0 => glob 2.0.0 => file 6.0.0
  # but we need minimum 6.1.3
  file: ^6.1.3
```

For now I did not do any changes to the `_internal` package , cause I don't think we have to.

Let me know if want some more comments/explanations on my changes.