### PR TITLE
Cache flutter sdk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
+      # eval matrix.channel 1
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.channel }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.channel }}
-          cache: true
+          cache: matrix.channel == 'stable'
 
       # It is executed separately
       - name: Removing example folder

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,12 @@ jobs:
             dependencies: downgrade
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.channel }}
+          cache: true
 
       # It is executed separately
       - name: Removing example folder

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      # eval matrix.channel 1
+
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.channel }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.channel }}
-          cache: matrix.channel == 'stable'
+          cache: ${{ matrix.channel == 'stable' }}
 
       # It is executed separately
       - name: Removing example folder


### PR DESCRIPTION
Added cache to the `subosito/flutter-action@v2` step.
Only on `stable` though, because on master the **cache-key** always looked the same.

- `stable`cache-key `flutter-linux-stable-3.3.4-x64-eb6d86ee27deecba4a83536aa20f366a6044895c`
- `master`cache-key `flutter-linux-master-master-x64-master`

Also updated all 'uses' steps to their latest version