### PR TITLE
fix: a stackoverflow error when continuously passing unmodifiable collections as parameter to freezed classes

### DIFF
--- a/packages/freezed/CHANGELOG.md
+++ b/packages/freezed/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [Unreleased fix]
 
-Fixes copyWith not working with `null` on some scenarios.
+- Fixes copyWith not working with `null` on some scenarios.
+- Fixes a stackoverflow error when continuously passing unmodifiable collections as parameter to freezed classes
 
 # 2.2.1
 

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -235,15 +235,22 @@ ${copyWith?.abstractCopyWithGetter ?? ''}
         }
 
         if (viewType != null) {
+          // If the collection is already unmodifiable, we don't want to wrap
+          // it in an unmodifiable view again.
+          final isAlreadyUnmodifiableCheck =
+              'if (_${p.name} is $viewType) return _${p.name};';
+
           return [
             p.copyWith(name: '_${p.name}', decorators: const []),
             if (p.isNullable) annotatedProperty.asGetter(''' {
   final value = _${p.name};
   if (value == null) return null;
+  $isAlreadyUnmodifiableCheck
   // ignore: implicit_dynamic_type
   return $viewType(value);
 }
 ''') else annotatedProperty.asGetter(''' {
+  $isAlreadyUnmodifiableCheck
   // ignore: implicit_dynamic_type
   return $viewType(_${p.name});
 }

--- a/packages/freezed/test/single_class_constructor_test.dart
+++ b/packages/freezed/test/single_class_constructor_test.dart
@@ -80,6 +80,12 @@ Future<void> main() async {
       UnmodifiableSetEqual({42}).hashCode,
       UnmodifiableSetEqual({42}).hashCode,
     );
+
+    final immutableCollection = UnmodifiableSetEqual({42}).dartSet;
+    expect(
+      UnmodifiableSetEqual(immutableCollection).dartSet,
+      same(immutableCollection),
+    );
   });
 
   test('CustomListEqual', () {
@@ -122,6 +128,12 @@ Future<void> main() async {
       UnmodifiableListEqual([42]).hashCode,
       UnmodifiableListEqual([42]).hashCode,
     );
+
+    final immutableCollection = UnmodifiableListEqual([42]).list;
+    expect(
+      UnmodifiableListEqual(immutableCollection).list,
+      same(immutableCollection),
+    );
   });
 
   test('CustomMapEqual', () {
@@ -163,6 +175,12 @@ Future<void> main() async {
     expect(
       UnmodifiableMapEqual({'a': 42}).hashCode,
       UnmodifiableMapEqual({'a': 42}).hashCode,
+    );
+
+    final immutableCollection = UnmodifiableMapEqual({'a': 42}).map;
+    expect(
+      UnmodifiableMapEqual(immutableCollection).map,
+      same(immutableCollection),
     );
   });
 


### PR DESCRIPTION
fixes #793