### PR TITLE
fix: deep copy now correctly handles cases where a property is a Freezed class with disabled `copyWith`

### DIFF
--- a/packages/freezed/CHANGELOG.md
+++ b/packages/freezed/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Fixes copyWith not working with `null` on some scenarios.
 - Fixes a stackoverflow error when continuously passing unmodifiable collections as parameter to freezed classes
-
+- fix: Deep copy now correctly handles cases where a property is a Freezed class with disabled `copyWith`
 # 2.2.1
 
 Upgrade analyzer

--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -424,19 +424,24 @@ Read here: https://github.com/rrousselGit/freezed/blob/master/packages/freezed/C
 
       final parameterType = parameter.type;
       if (parameterType is! InterfaceType) continue;
-      final element = parameterType.element;
-      if (element is! ClassElement) continue;
+      final typeElement = parameterType.element;
+      if (typeElement is! ClassElement) continue;
 
-      final classElement = element;
+      final freezedAnnotation = typeChecker.firstAnnotationOf(typeElement);
 
-      if (!typeChecker.hasAnnotationOf(classElement)) continue;
+      /// Handles classes annotated with Freezed
+      if (freezedAnnotation == null) continue;
+
+      final configs = _parseConfig(typeElement);
+      // copyWith not enabled, so the property is not cloneable
+      if (configs.copyWith != true) continue;
 
       yield CloneableProperty(
         name: parameter.name,
         type: type!,
         nullable:
             parameter.type.nullabilitySuffix == NullabilitySuffix.question,
-        typeName: classElement.name,
+        typeName: typeElement.name,
         genericParameters: GenericsParameterTemplate(
           (parameter.type as InterfaceType)
               .typeArguments

--- a/packages/freezed/test/integration/deep_copy.dart
+++ b/packages/freezed/test/integration/deep_copy.dart
@@ -49,3 +49,13 @@ class Generic<T> with _$Generic<T> {
 class Recursive with _$Recursive {
   factory Recursive([Recursive? value]) = _Recursive;
 }
+
+@freezed
+class DisabledDeepCopyWith with _$DisabledDeepCopyWith {
+  factory DisabledDeepCopyWith(DisabledCopy disabled) = _DisabledDeepCopyWith;
+}
+
+@Freezed(copyWith: false)
+class DisabledCopy with _$DisabledCopy {
+  factory DisabledCopy(DisabledCopy disabled) = _DisabledCopy;
+}


### PR DESCRIPTION
fixes #747