### PR TITLE
feat: Add NameOf class to lookup property names as string constants

### DIFF
--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -110,6 +110,7 @@ class FreezedGenerator extends ParserGenerator<GlobalData, Data, Freezed> {
       generateEqual: configs.equal ?? !_hasCustomEquals(element),
       generateFromJson: configs.fromJson ?? await needsJsonSerializable,
       generateToJson: configs.toJson ?? await needsJsonSerializable,
+      generateNameOf: configs.nameOf!,
       genericArgumentFactories: configs.genericArgumentFactories,
       map: MapConfig(
         map: configs.map?.map ?? shouldGenerateUnions,
@@ -612,6 +613,11 @@ Read here: https://github.com/rrousselGit/freezed/blob/master/packages/freezed/C
         decode: (obj) => obj.toBoolValue(),
         orElse: () => _buildYamlConfigs.toJson,
       ),
+      nameOf: annotation.decodeField(
+        'nameOf',
+        decode: (obj) => obj.toBoolValue(),
+        orElse: () => _buildYamlConfigs.nameOf,
+      ),
       genericArgumentFactories: annotation.decodeField(
         'genericArgumentFactories',
         decode: (obj) => obj.toBoolValue()!,
@@ -715,10 +721,11 @@ Read here: https://github.com/rrousselGit/freezed/blob/master/packages/freezed/C
             data: data,
           );
 
-    yield NameOf(
-      data: data,
-      commonProperties: commonProperties.readableProperties,
-    );
+    if (data.generateNameOf)
+      yield NameOf(
+        data: data,
+        commonProperties: commonProperties.readableProperties,
+      );
 
     yield Abstract(
       data: data,

--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -7,6 +7,7 @@ import 'package:build/build.dart';
 import 'package:collection/collection.dart';
 import 'package:freezed/src/templates/assert.dart';
 import 'package:freezed/src/templates/copy_with.dart';
+import 'package:freezed/src/templates/nameof_template.dart';
 import 'package:freezed/src/templates/parameter_template.dart';
 import 'package:freezed/src/templates/properties.dart';
 import 'package:freezed/src/templates/prototypes.dart';
@@ -713,6 +714,11 @@ Read here: https://github.com/rrousselGit/freezed/blob/master/packages/freezed/C
             genericsParameter: data.genericsParameterTemplate,
             data: data,
           );
+
+    yield NameOf(
+      data: data,
+      commonProperties: commonProperties.readableProperties,
+    );
 
     yield Abstract(
       data: data,

--- a/packages/freezed/lib/src/models.dart
+++ b/packages/freezed/lib/src/models.dart
@@ -92,6 +92,7 @@ class Data with _$Data {
     required GenericsParameterTemplate genericsParameterTemplate,
     required bool shouldUseExtends,
     required bool genericArgumentFactories,
+    required bool generateNameOf,
   }) = _Data;
 }
 

--- a/packages/freezed/lib/src/models.freezed.dart
+++ b/packages/freezed/lib/src/models.freezed.dart
@@ -1051,6 +1051,7 @@ mixin _$Data {
       throw _privateConstructorUsedError;
   bool get shouldUseExtends => throw _privateConstructorUsedError;
   bool get genericArgumentFactories => throw _privateConstructorUsedError;
+  bool get generateNameOf => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $DataCopyWith<Data> get copyWith => throw _privateConstructorUsedError;
@@ -1077,7 +1078,8 @@ abstract class $DataCopyWith<$Res> {
       GenericsDefinitionTemplate genericsDefinitionTemplate,
       GenericsParameterTemplate genericsParameterTemplate,
       bool shouldUseExtends,
-      bool genericArgumentFactories});
+      bool genericArgumentFactories,
+      bool generateNameOf});
 
   $MapConfigCopyWith<$Res> get map;
   $WhenConfigCopyWith<$Res> get when;
@@ -1112,6 +1114,7 @@ class _$DataCopyWithImpl<$Res, $Val extends Data>
     Object? genericsParameterTemplate = null,
     Object? shouldUseExtends = null,
     Object? genericArgumentFactories = null,
+    Object? generateNameOf = null,
   }) {
     return _then(_value.copyWith(
       name: null == name
@@ -1178,6 +1181,10 @@ class _$DataCopyWithImpl<$Res, $Val extends Data>
           ? _value.genericArgumentFactories
           : genericArgumentFactories // ignore: cast_nullable_to_non_nullable
               as bool,
+      generateNameOf: null == generateNameOf
+          ? _value.generateNameOf
+          : generateNameOf // ignore: cast_nullable_to_non_nullable
+              as bool,
     ) as $Val);
   }
 
@@ -1220,7 +1227,8 @@ abstract class _$$_DataCopyWith<$Res> implements $DataCopyWith<$Res> {
       GenericsDefinitionTemplate genericsDefinitionTemplate,
       GenericsParameterTemplate genericsParameterTemplate,
       bool shouldUseExtends,
-      bool genericArgumentFactories});
+      bool genericArgumentFactories,
+      bool generateNameOf});
 
   @override
   $MapConfigCopyWith<$Res> get map;
@@ -1253,6 +1261,7 @@ class __$$_DataCopyWithImpl<$Res> extends _$DataCopyWithImpl<$Res, _$_Data>
     Object? genericsParameterTemplate = null,
     Object? shouldUseExtends = null,
     Object? genericArgumentFactories = null,
+    Object? generateNameOf = null,
   }) {
     return _then(_$_Data(
       name: null == name
@@ -1319,6 +1328,10 @@ class __$$_DataCopyWithImpl<$Res> extends _$DataCopyWithImpl<$Res, _$_Data>
           ? _value.genericArgumentFactories
           : genericArgumentFactories // ignore: cast_nullable_to_non_nullable
               as bool,
+      generateNameOf: null == generateNameOf
+          ? _value.generateNameOf
+          : generateNameOf // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -1342,7 +1355,8 @@ class _$_Data implements _Data {
       required this.genericsDefinitionTemplate,
       required this.genericsParameterTemplate,
       required this.shouldUseExtends,
-      required this.genericArgumentFactories})
+      required this.genericArgumentFactories,
+      required this.generateNameOf})
       : assert(constructors.isNotEmpty),
         _concretePropertiesName = concretePropertiesName,
         _constructors = constructors;
@@ -1392,10 +1406,12 @@ class _$_Data implements _Data {
   final bool shouldUseExtends;
   @override
   final bool genericArgumentFactories;
+  @override
+  final bool generateNameOf;
 
   @override
   String toString() {
-    return 'Data(name: $name, unionKey: $unionKey, generateCopyWith: $generateCopyWith, generateEqual: $generateEqual, generateToString: $generateToString, map: $map, when: $when, generateFromJson: $generateFromJson, generateToJson: $generateToJson, makeCollectionsImmutable: $makeCollectionsImmutable, concretePropertiesName: $concretePropertiesName, constructors: $constructors, genericsDefinitionTemplate: $genericsDefinitionTemplate, genericsParameterTemplate: $genericsParameterTemplate, shouldUseExtends: $shouldUseExtends, genericArgumentFactories: $genericArgumentFactories)';
+    return 'Data(name: $name, unionKey: $unionKey, generateCopyWith: $generateCopyWith, generateEqual: $generateEqual, generateToString: $generateToString, map: $map, when: $when, generateFromJson: $generateFromJson, generateToJson: $generateToJson, makeCollectionsImmutable: $makeCollectionsImmutable, concretePropertiesName: $concretePropertiesName, constructors: $constructors, genericsDefinitionTemplate: $genericsDefinitionTemplate, genericsParameterTemplate: $genericsParameterTemplate, shouldUseExtends: $shouldUseExtends, genericArgumentFactories: $genericArgumentFactories, generateNameOf: $generateNameOf)';
   }
 
   @override
@@ -1436,7 +1452,9 @@ class _$_Data implements _Data {
                 other.shouldUseExtends == shouldUseExtends) &&
             (identical(
                     other.genericArgumentFactories, genericArgumentFactories) ||
-                other.genericArgumentFactories == genericArgumentFactories));
+                other.genericArgumentFactories == genericArgumentFactories) &&
+            (identical(other.generateNameOf, generateNameOf) ||
+                other.generateNameOf == generateNameOf));
   }
 
   @override
@@ -1457,7 +1475,8 @@ class _$_Data implements _Data {
       genericsDefinitionTemplate,
       genericsParameterTemplate,
       shouldUseExtends,
-      genericArgumentFactories);
+      genericArgumentFactories,
+      generateNameOf);
 
   @JsonKey(ignore: true)
   @override
@@ -1483,7 +1502,8 @@ abstract class _Data implements Data {
       required final GenericsDefinitionTemplate genericsDefinitionTemplate,
       required final GenericsParameterTemplate genericsParameterTemplate,
       required final bool shouldUseExtends,
-      required final bool genericArgumentFactories}) = _$_Data;
+      required final bool genericArgumentFactories,
+      required final bool generateNameOf}) = _$_Data;
 
   @override
   String get name;
@@ -1517,6 +1537,8 @@ abstract class _Data implements Data {
   bool get shouldUseExtends;
   @override
   bool get genericArgumentFactories;
+  @override
+  bool get generateNameOf;
   @override
   @JsonKey(ignore: true)
   _$$_DataCopyWith<_$_Data> get copyWith => throw _privateConstructorUsedError;

--- a/packages/freezed/lib/src/templates/abstract_template.dart
+++ b/packages/freezed/lib/src/templates/abstract_template.dart
@@ -1,4 +1,5 @@
 import 'package:freezed/src/models.dart';
+import 'package:freezed/src/templates/nameof_template.dart';
 
 import 'copy_with.dart';
 import 'properties.dart';
@@ -29,6 +30,7 @@ class Abstract {
 mixin _\$${data.name}${data.genericsDefinitionTemplate} {
 
 $abstractProperties
+$_nameof
 $_when
 $_whenOrNull
 $_maybeWhen
@@ -81,5 +83,9 @@ ${copyWith?.commonConcreteImpl ?? ''}
   String get _maybeMap {
     if (!data.map.maybeMap) return '';
     return '${maybeMapPrototype(data.constructors, data.genericsParameterTemplate)} => throw $privConstUsedErrorVarName;';
+  }
+
+  String get _nameof {
+    return '  // ignore: unused_field\n static late final _\$${data.name}NameOf nameOf = _\$${data.name}NameOf();';
   }
 }

--- a/packages/freezed/lib/src/templates/abstract_template.dart
+++ b/packages/freezed/lib/src/templates/abstract_template.dart
@@ -86,6 +86,7 @@ ${copyWith?.commonConcreteImpl ?? ''}
   }
 
   String get _nameof {
+    if (!data.generateNameOf) return '';
     return '  // ignore: unused_field\n static late final _\$${data.name}NameOf nameOf = _\$${data.name}NameOf();';
   }
 }

--- a/packages/freezed/lib/src/templates/nameof_template.dart
+++ b/packages/freezed/lib/src/templates/nameof_template.dart
@@ -1,0 +1,32 @@
+import 'package:freezed/src/models.dart';
+
+import 'properties.dart';
+
+class NameOf {
+  NameOf({
+    required this.data,
+    required this.commonProperties,
+  });
+
+  final Data data;
+  final List<Property> commonProperties;
+
+  @override
+  String toString() {
+    final properties = commonProperties
+        .map((e) => 'String get ${e.name} => "${e.name}";')
+        .join();
+
+    return '''
+/// @nodoc
+class $className {
+$properties
+}
+''';
+  }
+
+  String get className {
+    return '_\$${data.name}NameOf';
+  }
+
+}

--- a/packages/freezed/lib/src/templates/nameof_template.dart
+++ b/packages/freezed/lib/src/templates/nameof_template.dart
@@ -28,5 +28,4 @@ $properties
   String get className {
     return '_\$${data.name}NameOf';
   }
-
 }

--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -175,6 +175,7 @@ class Freezed {
     this.makeCollectionsUnmodifiable,
     this.addImplicitFinal = true,
     this.genericArgumentFactories = false,
+    this.nameOf,
   });
 
   /// Decode the options from a build.yaml
@@ -431,6 +432,15 @@ class Freezed {
   /// }
   /// ```
   final bool genericArgumentFactories;
+
+  
+  /// Whether to generate a `nameOf` class or not
+  ///
+  /// If null, picks up the default values from the project's `build.yaml`.
+  /// If that value is null too, defaults to false.
+  @JsonKey(defaultValue: false)
+  final bool? nameOf;
+
 
   /// Options for customizing the generation of `map` functions
   ///

--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -433,14 +433,12 @@ class Freezed {
   /// ```
   final bool genericArgumentFactories;
 
-  
   /// Whether to generate a `nameOf` class or not
   ///
   /// If null, picks up the default values from the project's `build.yaml`.
   /// If that value is null too, defaults to false.
   @JsonKey(defaultValue: false)
   final bool? nameOf;
-
 
   /// Options for customizing the generation of `map` functions
   ///

--- a/packages/freezed_annotation/lib/freezed_annotation.g.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.g.dart
@@ -41,6 +41,7 @@ Freezed _$FreezedFromJson(Map json) => Freezed(
       addImplicitFinal: json['add_implicit_final'] as bool? ?? true,
       genericArgumentFactories:
           json['generic_argument_factories'] as bool? ?? false,
+      nameOf: json['name_of'] as bool? ?? false,
     );
 
 const _$FreezedUnionCaseEnumMap = {


### PR DESCRIPTION
Hi @rrousselGit,  I suggest making the following changes to implement #254.

You can use it like this:

main.dart:
```dart
@freezed
class MyClass with _$MyClass {
  factory MyClass({String? a, int? b}) = _MyClass;
}

void main() {
  // nameOf
  print(_$MyClass.nameOf.a);
  print(_$MyClass.nameOf.b);
}
```

main.freezed.dart:
```dart
/// @nodoc
class _$MyClassNameOf {
  String get a => "a";
  String get b => "b";
}

/// @nodoc
mixin _$MyClass {
  String? get a => throw _privateConstructorUsedError;
  int? get b => throw _privateConstructorUsedError;
  // ignore: unused_field
  static late final _$MyClassNameOf nameOf = _$MyClassNameOf();

  @JsonKey(ignore: true)
  $MyClassCopyWith<MyClass> get copyWith => throw _privateConstructorUsedError;
}
```

There is an option to enable/disable the code generation of the NameOf class. Since the issue has been open for a while, it appears that there is not much demand for this feature. Therefore, I have decided to disable the feature by default.

Please let me know your thoughts on this. 
If you are open to the feature and the proposed implementation, I will also add a test case.