### PR TITLE
upgrade deps in freezed_lint

### DIFF
--- a/packages/freezed_lint/pubspec.yaml
+++ b/packages/freezed_lint/pubspec.yaml
@@ -7,10 +7,10 @@ environment:
 dependencies:
   analyzer: ^5.0.0
   analyzer_plugin: ^0.11.2
-  custom_lint_builder: ^0.2.0
+  custom_lint_builder: ^0.3.2
   freezed_annotation: ^2.2.0
 
 dev_dependencies:
-  custom_lint: ^0.2.0
+  custom_lint: ^0.3.2
   build_verify: ^3.1.0
   test: ^1.22.2


### PR DESCRIPTION
**build** failed because of freezed_lint
https://github.com/rrousselGit/freezed/actions/runs/4582569559/jobs/8092882210
So I'm upgrading `custom_lint_builder` and `custom_lint` to `^0.3.2` to resolve this.
