### PR TITLE
fix `DartType.isDynamic` deprecation 

### DIFF
--- a/packages/freezed/CHANGELOG.md
+++ b/packages/freezed/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased fix
+
+- Fix deprecated warning with analyzer 5.12.0
+
 ## 2.3.3
 
 - Fixed an issue with the generated code when classes contains a `$` in

--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -167,7 +167,7 @@ Read here: https://github.com/rrousselGit/freezed/blob/master/packages/freezed/C
       if (parameter.type.nullabilitySuffix != NullabilitySuffix.question &&
           parameter.isOptional &&
           parameter.defaultValue == null &&
-          !(parameter.type is DynamicType)) {
+          parameter.type is! DynamicType) {
         final ctorName =
             constructor.isDefaultConstructor ? '' : '.${constructor.name}';
 

--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -167,7 +167,7 @@ Read here: https://github.com/rrousselGit/freezed/blob/master/packages/freezed/C
       if (parameter.type.nullabilitySuffix != NullabilitySuffix.question &&
           parameter.isOptional &&
           parameter.defaultValue == null &&
-          parameter.type is! DynamicType) {
+          !parameter.type.isDynamic2) {
         final ctorName =
             constructor.isDefaultConstructor ? '' : '.${constructor.name}';
 

--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -167,7 +167,7 @@ Read here: https://github.com/rrousselGit/freezed/blob/master/packages/freezed/C
       if (parameter.type.nullabilitySuffix != NullabilitySuffix.question &&
           parameter.isOptional &&
           parameter.defaultValue == null &&
-          !parameter.type.isDynamic) {
+          !(parameter.type is DynamicType)) {
         final ctorName =
             constructor.isDefaultConstructor ? '' : '.${constructor.name}';
 

--- a/packages/freezed/lib/src/templates/properties.dart
+++ b/packages/freezed/lib/src/templates/properties.dart
@@ -223,7 +223,7 @@ extension IsDartCollection on DartType {
     final interface = safeCast<InterfaceType>();
 
     return _isDartCollectionType ||
-        isDynamic ||
+        this is DynamicType ||
         isDartCoreObject ||
         this is TypeParameterType ||
         (interface != null &&

--- a/packages/freezed/lib/src/templates/properties.dart
+++ b/packages/freezed/lib/src/templates/properties.dart
@@ -223,7 +223,7 @@ extension IsDartCollection on DartType {
     final interface = safeCast<InterfaceType>();
 
     return _isDartCollectionType ||
-        this is DynamicType ||
+        isDynamic2 ||
         isDartCoreObject ||
         this is TypeParameterType ||
         (interface != null &&

--- a/packages/freezed/lib/src/tools/type.dart
+++ b/packages/freezed/lib/src/tools/type.dart
@@ -11,7 +11,8 @@ extension DartTypeX on DartType {
     if (that is TypeParameterType) {
       return that.bound.isNullable;
     }
-    return isDynamic || nullabilitySuffix == NullabilitySuffix.question;
+    return this is DynamicType ||
+        nullabilitySuffix == NullabilitySuffix.question;
   }
 }
 

--- a/packages/freezed/lib/src/tools/type.dart
+++ b/packages/freezed/lib/src/tools/type.dart
@@ -6,13 +6,16 @@ import 'package:collection/collection.dart';
 import 'imports.dart';
 
 extension DartTypeX on DartType {
+  bool get isDynamic2 {
+    return this is DynamicType || this is InvalidType;
+  }
+
   bool get isNullable {
     final that = this;
     if (that is TypeParameterType) {
       return that.bound.isNullable;
     }
-    return this is DynamicType ||
-        nullabilitySuffix == NullabilitySuffix.question;
+    return isDynamic2 || nullabilitySuffix == NullabilitySuffix.question;
   }
 }
 

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -22,8 +22,8 @@ dependencies:
 dev_dependencies:
   json_serializable: ^6.3.2
   build_test: ^2.1.5
-  build_runner: ^2.2.0
+  build_runner: ^2.3.3
   test: ^1.21.0
-  matcher: ^0.12.11
+  matcher: ^0.12.14
   source_gen_test: ^1.0.4
   expect_error: ^1.0.4

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  analyzer: ^5.2.0
+  analyzer: ^5.12.0
   build: ^2.3.1
   build_config: ^1.1.0
   collection: ^1.15.0

--- a/packages/freezed/pubspec_overrides.yaml
+++ b/packages/freezed/pubspec_overrides.yaml
@@ -3,5 +3,11 @@ dependency_overrides:
     path: ../freezed_annotation
   # pub downgrade:
   # build_runner 2.2.0 => glob 2.0.0 => file 6.0.0
-  # but we need minimum 6.1.3
+  # freezed requires file: ^6.1.3
   file: ^6.1.3
+  # analyzer 5.2.0 => pub_semver 2.0.0
+  # freezed requires pub_semver: ^2.1.3
+  pub_semver: ^2.1.3
+  # expect_error 1.0.4 => pubspec 2.0.1 => uri 1.0.0 => quiver 3.0.0
+  # freezed requires quiver: ^3.2.0
+  quiver: ^3.2.0

--- a/packages/freezed/test/integration/json.dart
+++ b/packages/freezed/test/integration/json.dart
@@ -529,7 +529,7 @@ class EnumJson with _$EnumJson {
       required: true,
       unknownEnumValue: JsonKey.nullForUndefinedEnumValue,
     )
-        Enum? status,
+    Enum? status,
   }) = _EnumJson;
 
   factory EnumJson.fromJson(Map<String, dynamic> json) =>

--- a/packages/freezed/test/integration/single_class_constructor.dart
+++ b/packages/freezed/test/integration/single_class_constructor.dart
@@ -442,7 +442,7 @@ class DefaultNonLitteralAlreadyConst with _$DefaultNonLitteralAlreadyConst {
       // ignore: unnecessary_const
       const Object(),
     )
-        Object listObject,
+    Object listObject,
   }) = _DefaultNonLitteralAlreadyConst;
 }
 

--- a/packages/freezed/test/multiple_constructors_test.dart
+++ b/packages/freezed/test/multiple_constructors_test.dart
@@ -29,7 +29,7 @@ Future<void> main() async {
   test('recursive class does not generate dynamic', () async {
     final recursiveClass = _getClassElement('_RecursiveNext');
 
-    expect(recursiveClass.getField('value')!.type is DynamicType, isFalse);
+    expect(recursiveClass.getField('value')!.type, isA<InterfaceType>());
   });
 
   test('Regression358', () {

--- a/packages/freezed/test/multiple_constructors_test.dart
+++ b/packages/freezed/test/multiple_constructors_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
@@ -28,7 +29,7 @@ Future<void> main() async {
   test('recursive class does not generate dynamic', () async {
     final recursiveClass = _getClassElement('_RecursiveNext');
 
-    expect(recursiveClass.getField('value')!.type.isDynamic, isFalse);
+    expect(recursiveClass.getField('value')!.type is DynamicType, isFalse);
   });
 
   test('Regression358', () {

--- a/packages/freezed_annotation/pubspec.yaml
+++ b/packages/freezed_annotation/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
   meta: ^1.7.0
 
 dev_dependencies:
-  build_runner: ^2.2.0
+  build_runner: ^2.3.3
   json_serializable: ^6.3.2
   test: ^1.21.0

--- a/packages/freezed_annotation/pubspec_overrides.yaml
+++ b/packages/freezed_annotation/pubspec_overrides.yaml
@@ -1,5 +1,11 @@
 dependency_overrides:
   # pub downgrade:
   # build_runner 2.2.0 => glob 2.0.0 => file 6.0.0
-  # but we need minimum 6.1.3
+  # freezed requires file: ^6.1.3
   file: ^6.1.3
+  # build_runner 2.3.3 => code_builder 4.2.0 => matcher 0.12.11
+  # freezed requires matcher: ^0.12.14
+  matcher: ^0.12.14
+  # build_runner 2.3.3 => pub_semver 2.0.0
+  # freezed requires pub_semver: ^2.1.3
+  pub_semver: ^2.1.3

--- a/packages/freezed_lint/lib/src/missing_mixin.dart
+++ b/packages/freezed_lint/lib/src/missing_mixin.dart
@@ -32,7 +32,7 @@ class MissingMixin extends DartLintRule {
       }
 
       final mixins = withClause.mixinTypes;
-      if (mixins.any((m) => name == m.name.name)) return;
+      if (mixins.any((m) => name == m.name2.lexeme)) return;
       reporter.reportErrorForElement(code, element, [name]);
     });
   }

--- a/packages/freezed_lint/pubspec.yaml
+++ b/packages/freezed_lint/pubspec.yaml
@@ -5,12 +5,12 @@ environment:
   sdk: ">=2.16.0 <3.0.0"
 
 dependencies:
-  analyzer: ^5.0.0
+  analyzer: ^5.12.0
   analyzer_plugin: ^0.11.2
-  custom_lint_builder: ^0.3.2
+  custom_lint_builder: ^0.4.0
   freezed_annotation: ^2.2.0
 
 dev_dependencies:
-  custom_lint: ^0.3.2
+  custom_lint: ^0.4.0
   build_verify: ^3.1.0
   test: ^1.22.2


### PR DESCRIPTION
With analyzer 5.12.0 
`DartType.isDynamic` got deprecated,
instead use `this is DynamicType`.