### PR TITLE
Allow specifying `none`, `all`, `true` and `false` for `when` and `map` options

### DIFF
--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -151,6 +151,62 @@ class FreezedWhenOptions {
   final bool? maybeWhen;
 }
 
+class _FreezedWhenOptionsConverter
+    implements JsonConverter<FreezedWhenOptions?, Object?> {
+  const _FreezedWhenOptionsConverter();
+
+  @override
+  FreezedWhenOptions? fromJson(Object? json) {
+    switch (json) {
+      case true || 'all':
+        return FreezedWhenOptions.all;
+      case false || 'none':
+        return FreezedWhenOptions.none;
+      case null:
+        return null;
+      case final Map whenOptions:
+        return FreezedWhenOptions.fromJson(whenOptions);
+      default:
+        throw ArgumentError.value(
+          json,
+          'json',
+          'Expected a bool or a Map, got ${json.runtimeType}',
+        );
+    }
+  }
+
+  @override
+  Object? toJson(FreezedWhenOptions? object) => null;
+}
+
+class _FreezedMapOptionsConverter
+    implements JsonConverter<FreezedMapOptions?, Object?> {
+  const _FreezedMapOptionsConverter();
+
+  @override
+  FreezedMapOptions? fromJson(Object? json) {
+    switch (json) {
+      case true || 'all':
+        return FreezedMapOptions.all;
+      case false || 'none':
+        return FreezedMapOptions.none;
+      case null:
+        return null;
+      case final Map mapOptions:
+        return FreezedMapOptions.fromJson(mapOptions);
+      default:
+        throw ArgumentError.value(
+          json,
+          'json',
+          'Expected a bool or a Map, got ${json.runtimeType}',
+        );
+    }
+  }
+
+  @override
+  Object? toJson(FreezedMapOptions? object) => null;
+}
+
 /// {@template freezed_annotation.freezed}
 /// Flags a class as needing to be processed by Freezed and allows passing options.
 /// {@endtemplate}
@@ -436,12 +492,14 @@ class Freezed {
   ///
   /// If null, picks up the default values from the project's `build.yaml`.
   /// If that value is null too, defaults to [FreezedMapOptions.all].
+  @_FreezedMapOptionsConverter()
   final FreezedMapOptions? map;
 
   /// Options for customizing the generation of `when` functions
   ///
   /// If null, picks up the default values from the project's `build.yaml`
   /// If that value is null too, defaults to [FreezedWhenOptions.all].
+  @_FreezedWhenOptionsConverter()
   final FreezedWhenOptions? when;
 }
 

--- a/packages/freezed_annotation/lib/freezed_annotation.g.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.g.dart
@@ -30,12 +30,8 @@ Freezed _$FreezedFromJson(Map json) => Freezed(
       toStringOverride: json['to_string_override'] as bool?,
       fromJson: json['from_json'] as bool?,
       toJson: json['to_json'] as bool?,
-      map: json['map'] == null
-          ? null
-          : FreezedMapOptions.fromJson(json['map'] as Map),
-      when: json['when'] == null
-          ? null
-          : FreezedWhenOptions.fromJson(json['when'] as Map),
+      map: const _FreezedMapOptionsConverter().fromJson(json['map']),
+      when: const _FreezedWhenOptionsConverter().fromJson(json['when']),
       makeCollectionsUnmodifiable:
           json['make_collections_unmodifiable'] as bool? ?? true,
       addImplicitFinal: json['add_implicit_final'] as bool? ?? true,

--- a/packages/freezed_annotation/pubspec.yaml
+++ b/packages/freezed_annotation/pubspec.yaml
@@ -7,7 +7,7 @@ repository: https://github.com/rrousselGit/freezed
 issue_tracker: https://github.com/rrousselGit/freezed/issues
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   collection: ^1.15.0


### PR DESCRIPTION
This should allows to do like this:
```yaml
targets:
  $default:
    builders:
      freezed:
        options:
          map: all
          when: none
```