### PR TITLE
Replace "dart pub add --dev" with "dev:"

### DIFF
--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -74,22 +74,22 @@ For a Flutter project:
 
 ```console
 flutter pub add freezed_annotation
-flutter pub add --dev build_runner
-flutter pub add --dev freezed
+flutter pub add dev:build_runner
+flutter pub add dev:freezed
 # if using freezed to generate fromJson/toJson, also add:
 flutter pub add json_annotation
-flutter pub add --dev json_serializable
+flutter pub add dev:json_serializable
 ```
 
 For a Dart project:
 
 ```console
 dart pub add freezed_annotation
-dart pub add --dev build_runner
-dart pub add --dev freezed
+dart pub add dev:build_runner
+dart pub add dev:freezed
 # if using freezed to generate fromJson/toJson, also add:
 dart pub add json_annotation
-dart pub add --dev json_serializable
+dart pub add dev:json_serializable
 ```
 
 This installs three packages:

--- a/packages/freezed_lint/README.md
+++ b/packages/freezed_lint/README.md
@@ -7,8 +7,8 @@ Written with [custom_lint] to help with miss-typed/configured freezed classes.
 Add freezed_lint and custom_lint to your projects `pubspec.yaml`.
 
 ```console
-flutter pub add --dev custom_lint
-flutter pub add --dev freezed_lint
+flutter pub add dev:custom_lint
+flutter pub add dev:freezed_lint
 ```
 
 And add custom_lint as a plugin in the `analysis_options.yaml`

--- a/resources/translations/ko_KR/README.md
+++ b/resources/translations/ko_KR/README.md
@@ -76,22 +76,22 @@ Dart는 훌륭합니다. 그런데 우리가 "모델"을 정의하는 것은 지
 
 ```console
 flutter pub add freezed_annotation
-flutter pub add --dev build_runner
-flutter pub add --dev freezed
+flutter pub add dev:build_runner
+flutter pub add dev:freezed
 # fromJson/toJson 생성도 사용하려면 아래를 추가하세요:
 flutter pub add json_annotation
-flutter pub add --dev json_serializable
+flutter pub add dev:json_serializable
 ```
 
 만약에 `Dart`프로젝트를 생성하는 경우에는 아래와 같이 진행합니다.
 
 ```console
 dart pub add freezed_annotation
-dart pub add --dev build_runner
-dart pub add --dev freezed
+dart pub add dev:build_runner
+dart pub add dev:freezed
 # fromJson/toJson 생성도 사용하려면 아래를 추가하세요:
 dart pub add json_annotation
-dart pub add --dev json_serializable
+dart pub add dev:json_serializable
 ```
 
 이렇게 하면 3개의 패키지(freezed_annotation, build_runner, freezed)가 설치됩니다.

--- a/resources/translations/zh_CN/README.md
+++ b/resources/translations/zh_CN/README.md
@@ -76,22 +76,22 @@ For a Flutter project:
 
 ```console
 flutter pub add freezed_annotation
-flutter pub add --dev build_runner
-flutter pub add --dev freezed
+flutter pub add dev:build_runner
+flutter pub add dev:freezed
 # 如果你要使用 freezed 来生成 fromJson/toJson，则执行：
 flutter pub add json_annotation
-flutter pub add --dev json_serializable
+flutter pub add dev:json_serializable
 ```
 
 对于 Dart 项目:
 
 ```console
 dart pub add freezed_annotation
-dart pub add --dev build_runner
-dart pub add --dev freezed
+dart pub add dev:build_runner
+dart pub add dev:freezed
 # 如果你要使用 freezed 来生成 fromJson/toJson，则执行：
 dart pub add json_annotation
-dart pub add --dev json_serializable
+dart pub add dev:json_serializable
 ```
 
 以上代码安装了三个包:


### PR DESCRIPTION
This pull request is to replace `dart pub add --dev` with `dart pub add dev:` as this is the newer way.
https://dart.dev/tools/pub/cmd/pub-add#dev-dependency

Also, this pull request replaces `flutter pub add —dev` with `flutter pub add dev:` as used in the Flutter documentation.
https://docs.flutter.dev/data-and-backend/serialization/json#setting-up-json_serializable-in-a-project