### PR TITLE
Docs: update error message information link

### DIFF
--- a/benchmarks/lib/src/copy_with.freezed.dart
+++ b/benchmarks/lib/src/copy_with.freezed.dart
@@ -12,7 +12,7 @@ part of 'copy_with.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$Model {

--- a/benchmarks/lib/src/equal.freezed.dart
+++ b/benchmarks/lib/src/equal.freezed.dart
@@ -12,7 +12,7 @@ part of 'equal.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$ModelWithList {

--- a/packages/_internal/lib/models.freezed.dart
+++ b/packages/_internal/lib/models.freezed.dart
@@ -12,7 +12,7 @@ part of 'models.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$DeepCloneableProperty {

--- a/packages/freezed/lib/src/models.freezed.dart
+++ b/packages/freezed/lib/src/models.freezed.dart
@@ -12,7 +12,7 @@ part of 'models.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$DeepCloneableProperty {

--- a/packages/freezed/lib/src/templates/properties.dart
+++ b/packages/freezed/lib/src/templates/properties.dart
@@ -14,7 +14,7 @@ const privConstUsedErrorString =
     'This constructor is only meant to be used by freezed '
     'and you are not supposed to need it nor use it.'
     '\\nPlease check the documentation here for more information: '
-    'https://github.com/rrousselGit/freezed#custom-getters-and-methods';
+    'https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models';
 
 const privConstUsedErrorVarName = '_privateConstructorUsedError';
 

--- a/packages/freezed_lint/example/lib/missing_mixin.freezed.dart
+++ b/packages/freezed_lint/example/lib/missing_mixin.freezed.dart
@@ -12,7 +12,7 @@ part of 'missing_mixin.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$MissingMixin {}

--- a/packages/freezed_lint/example/lib/missing_private_empty_ctor.freezed.dart
+++ b/packages/freezed_lint/example/lib/missing_private_empty_ctor.freezed.dart
@@ -12,7 +12,7 @@ part of 'missing_private_empty_ctor.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$RequiresPrivateCtor {}


### PR DESCRIPTION
The links no longer work properly due to changes in the headings.