### PR TITLE
Fix the line ending symbol in JSON in this Doc comment

### DIFF
--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -471,7 +471,7 @@ class Freezed {
   /// class Example<T> with _$Example<T> {
   ///   factory Example<T>(T a) = _Example;
   ///
-  ///   factory Example.fromJson(Map<String, Object?> json, T Function(Object?) fromJsonT) => _$ExampleFromJson(json, fromJsonT)`
+  ///   factory Example.fromJson(Map<String, Object?> json, T Function(Object?) fromJsonT) => _$ExampleFromJson(json, fromJsonT);
   /// }
   /// ```
   final bool genericArgumentFactories;


### PR DESCRIPTION
Thanks again for the great package!

There was a minor error in the Doc comments that has been corrected.