### PR TITLE
analyzer <6.5.0 

### DIFF
--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=5.13.0 <7.0.0"
+  analyzer: ">=5.13.0 <6.5.0"
   build: ^2.3.1
   build_config: ^1.1.0
   collection: ^1.15.0

--- a/packages/freezed_lint/pubspec.yaml
+++ b/packages/freezed_lint/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: ^6.0.0
+  analyzer: ">=6.0.0 <6.5.0"
   analyzer_plugin: ^0.11.2
   custom_lint_builder: ^0.6.0
   freezed_annotation: ^2.3.0


### PR DESCRIPTION
analyzer 6.5.0 adds initial support for macros and has a bunch of deprecations.
So that the github-actions don't fail using flutter-master for now,
I added an upper-bound for package analyzer.