### PR TITLE
Clarify `unfreezed` documention

### DIFF
--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -499,7 +499,7 @@ const freezed = Freezed();
 /// Defines a potentially mutable data-class.
 ///
 /// As opposed to [freezed], properties of the object can be mutable.
-/// On the other hand, a data class will not implement ==.
+/// On the other hand, they will not implement ==.
 const unfreezed = Freezed(
   equal: false,
   addImplicitFinal: false,


### PR DESCRIPTION
Just a minor copyedit. I was looking at the source to see if `@freezed` implied `@immutable` (which I assumed it did, but it doesn't), and noted that the docs were a bit unclear.