### PR TITLE
Replace deprecated `JsonKey` annotation for hashCode and copyWith

### DIFF
--- a/benchmarks/lib/src/copy_with.freezed.dart
+++ b/benchmarks/lib/src/copy_with.freezed.dart
@@ -18,7 +18,7 @@ final _privateConstructorUsedError = UnsupportedError(
 mixin _$Model {
   int get counter => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ModelCopyWith<Model> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -110,7 +110,7 @@ class _$ModelImpl implements _Model {
   @override
   int get hashCode => Object.hash(runtimeType, counter);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ModelImplCopyWith<_$ModelImpl> get copyWith =>
@@ -123,7 +123,7 @@ abstract class _Model implements Model {
   @override
   int get counter;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ModelImplCopyWith<_$ModelImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -132,7 +132,7 @@ abstract class _Model implements Model {
 mixin _$ModelWrapper {
   Model get model => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ModelWrapperCopyWith<ModelWrapper> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -240,7 +240,7 @@ class _$ModelWrapperImpl implements _ModelWrapper {
   @override
   int get hashCode => Object.hash(runtimeType, model);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ModelWrapperImplCopyWith<_$ModelWrapperImpl> get copyWith =>
@@ -253,7 +253,7 @@ abstract class _ModelWrapper implements ModelWrapper {
   @override
   Model get model;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ModelWrapperImplCopyWith<_$ModelWrapperImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/benchmarks/lib/src/equal.freezed.dart
+++ b/benchmarks/lib/src/equal.freezed.dart
@@ -19,7 +19,7 @@ mixin _$ModelWithList {
   List<int> get someList => throw _privateConstructorUsedError;
   int get counter => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ModelWithListCopyWith<ModelWithList> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -138,7 +138,7 @@ class _$ModelWithListImpl implements _ModelWithList {
   int get hashCode => Object.hash(
       runtimeType, const DeepCollectionEquality().hash(_someList), counter);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ModelWithListImplCopyWith<_$ModelWithListImpl> get copyWith =>
@@ -154,7 +154,7 @@ abstract class _ModelWithList implements ModelWithList {
   @override
   int get counter;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ModelWithListImplCopyWith<_$ModelWithListImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/_internal/lib/models.freezed.dart
+++ b/packages/_internal/lib/models.freezed.dart
@@ -23,7 +23,7 @@ mixin _$DeepCloneableProperty {
   GenericsParameterTemplate get genericParameters =>
       throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $DeepCloneablePropertyCopyWith<DeepCloneableProperty> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -192,7 +192,7 @@ class _$DeepCloneablePropertyImpl implements _DeepCloneableProperty {
   int get hashCode => Object.hash(
       runtimeType, name, typeName, type, nullable, genericParameters);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$DeepCloneablePropertyImplCopyWith<_$DeepCloneablePropertyImpl>
@@ -220,7 +220,7 @@ abstract class _DeepCloneableProperty implements DeepCloneableProperty {
   @override
   GenericsParameterTemplate get genericParameters;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$DeepCloneablePropertyImplCopyWith<_$DeepCloneablePropertyImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -245,7 +245,7 @@ mixin _$ConstructorDetails {
       throw _privateConstructorUsedError;
   List<AssertTemplate> get asserts => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ConstructorDetailsCopyWith<ConstructorDetails> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -658,7 +658,7 @@ class _$ConstructorDetailsImpl extends _ConstructorDetails {
       const DeepCollectionEquality().hash(_cloneableProperties),
       const DeepCollectionEquality().hash(_asserts));
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ConstructorDetailsImplCopyWith<_$ConstructorDetailsImpl> get copyWith =>
@@ -719,7 +719,7 @@ abstract class _ConstructorDetails extends ConstructorDetails {
   @override
   List<AssertTemplate> get asserts;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ConstructorDetailsImplCopyWith<_$ConstructorDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -730,7 +730,7 @@ mixin _$MapConfig {
   bool get mapOrNull => throw _privateConstructorUsedError;
   bool get maybeMap => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $MapConfigCopyWith<MapConfig> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -853,7 +853,7 @@ class _$MapConfigImpl implements _MapConfig {
   @override
   int get hashCode => Object.hash(runtimeType, map, mapOrNull, maybeMap);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MapConfigImplCopyWith<_$MapConfigImpl> get copyWith =>
@@ -873,7 +873,7 @@ abstract class _MapConfig implements MapConfig {
   @override
   bool get maybeMap;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MapConfigImplCopyWith<_$MapConfigImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -884,7 +884,7 @@ mixin _$WhenConfig {
   bool get whenOrNull => throw _privateConstructorUsedError;
   bool get maybeWhen => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $WhenConfigCopyWith<WhenConfig> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1008,7 +1008,7 @@ class _$WhenConfigImpl implements _WhenConfig {
   @override
   int get hashCode => Object.hash(runtimeType, when, whenOrNull, maybeWhen);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$WhenConfigImplCopyWith<_$WhenConfigImpl> get copyWith =>
@@ -1028,7 +1028,7 @@ abstract class _WhenConfig implements WhenConfig {
   @override
   bool get maybeWhen;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$WhenConfigImplCopyWith<_$WhenConfigImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1055,7 +1055,7 @@ mixin _$Data {
   bool get shouldUseExtends => throw _privateConstructorUsedError;
   bool get genericArgumentFactories => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $DataCopyWith<Data> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -1464,7 +1464,7 @@ class _$DataImpl implements _Data {
       shouldUseExtends,
       genericArgumentFactories);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$DataImplCopyWith<_$DataImpl> get copyWith =>
@@ -1523,7 +1523,7 @@ abstract class _Data implements Data {
   @override
   bool get genericArgumentFactories;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$DataImplCopyWith<_$DataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1533,7 +1533,7 @@ mixin _$GlobalData {
   bool get hasJson => throw _privateConstructorUsedError;
   bool get hasDiagnostics => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GlobalDataCopyWith<GlobalData> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1642,7 +1642,7 @@ class _$GlobalDataImpl implements _GlobalData {
   @override
   int get hashCode => Object.hash(runtimeType, hasJson, hasDiagnostics);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GlobalDataImplCopyWith<_$GlobalDataImpl> get copyWith =>
@@ -1659,7 +1659,7 @@ abstract class _GlobalData implements GlobalData {
   @override
   bool get hasDiagnostics;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GlobalDataImplCopyWith<_$GlobalDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/freezed/CHANGELOG.md
+++ b/packages/freezed/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Stop using `JsonKey(ignore: true)` in favour of `JsonKey(includeFromJson: false, includeToJson: false)`
   (thanks to @lrsvmb)
+- Require json_annotation ^6.8.0
 
 ## 2.5.4 - 2024-07-02
 

--- a/packages/freezed/CHANGELOG.md
+++ b/packages/freezed/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased patch
+
+- Stop using `JsonKey(ignore: true)` in favour of `JsonKey(includeFromJson: false, includeToJson: false)`
+  (thanks to @lrsvmb)
+
 ## 2.5.4 - 2024-07-02
 
 - Require Dart >=3.0.0

--- a/packages/freezed/lib/src/models.freezed.dart
+++ b/packages/freezed/lib/src/models.freezed.dart
@@ -23,7 +23,7 @@ mixin _$DeepCloneableProperty {
   GenericsParameterTemplate get genericParameters =>
       throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $DeepCloneablePropertyCopyWith<DeepCloneableProperty> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -192,7 +192,7 @@ class _$DeepCloneablePropertyImpl implements _DeepCloneableProperty {
   int get hashCode => Object.hash(
       runtimeType, name, typeName, type, nullable, genericParameters);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$DeepCloneablePropertyImplCopyWith<_$DeepCloneablePropertyImpl>
@@ -220,7 +220,7 @@ abstract class _DeepCloneableProperty implements DeepCloneableProperty {
   @override
   GenericsParameterTemplate get genericParameters;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$DeepCloneablePropertyImplCopyWith<_$DeepCloneablePropertyImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -245,7 +245,7 @@ mixin _$ConstructorDetails {
       throw _privateConstructorUsedError;
   List<AssertTemplate> get asserts => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ConstructorDetailsCopyWith<ConstructorDetails> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -658,7 +658,7 @@ class _$ConstructorDetailsImpl extends _ConstructorDetails {
       const DeepCollectionEquality().hash(_cloneableProperties),
       const DeepCollectionEquality().hash(_asserts));
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ConstructorDetailsImplCopyWith<_$ConstructorDetailsImpl> get copyWith =>
@@ -719,7 +719,7 @@ abstract class _ConstructorDetails extends ConstructorDetails {
   @override
   List<AssertTemplate> get asserts;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ConstructorDetailsImplCopyWith<_$ConstructorDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -730,7 +730,7 @@ mixin _$MapConfig {
   bool get mapOrNull => throw _privateConstructorUsedError;
   bool get maybeMap => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $MapConfigCopyWith<MapConfig> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -853,7 +853,7 @@ class _$MapConfigImpl implements _MapConfig {
   @override
   int get hashCode => Object.hash(runtimeType, map, mapOrNull, maybeMap);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MapConfigImplCopyWith<_$MapConfigImpl> get copyWith =>
@@ -873,7 +873,7 @@ abstract class _MapConfig implements MapConfig {
   @override
   bool get maybeMap;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MapConfigImplCopyWith<_$MapConfigImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -884,7 +884,7 @@ mixin _$WhenConfig {
   bool get whenOrNull => throw _privateConstructorUsedError;
   bool get maybeWhen => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $WhenConfigCopyWith<WhenConfig> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1008,7 +1008,7 @@ class _$WhenConfigImpl implements _WhenConfig {
   @override
   int get hashCode => Object.hash(runtimeType, when, whenOrNull, maybeWhen);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$WhenConfigImplCopyWith<_$WhenConfigImpl> get copyWith =>
@@ -1028,7 +1028,7 @@ abstract class _WhenConfig implements WhenConfig {
   @override
   bool get maybeWhen;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$WhenConfigImplCopyWith<_$WhenConfigImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1055,7 +1055,7 @@ mixin _$Data {
   bool get shouldUseExtends => throw _privateConstructorUsedError;
   bool get genericArgumentFactories => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $DataCopyWith<Data> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -1464,7 +1464,7 @@ class _$DataImpl implements _Data {
       shouldUseExtends,
       genericArgumentFactories);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$DataImplCopyWith<_$DataImpl> get copyWith =>
@@ -1523,7 +1523,7 @@ abstract class _Data implements Data {
   @override
   bool get genericArgumentFactories;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$DataImplCopyWith<_$DataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1533,7 +1533,7 @@ mixin _$GlobalData {
   bool get hasJson => throw _privateConstructorUsedError;
   bool get hasDiagnostics => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GlobalDataCopyWith<GlobalData> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1642,7 +1642,7 @@ class _$GlobalDataImpl implements _GlobalData {
   @override
   int get hashCode => Object.hash(runtimeType, hasJson, hasDiagnostics);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GlobalDataImplCopyWith<_$GlobalDataImpl> get copyWith =>
@@ -1659,7 +1659,7 @@ abstract class _GlobalData implements GlobalData {
   @override
   bool get hasDiagnostics;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GlobalDataImplCopyWith<_$GlobalDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -488,7 +488,7 @@ bool operator ==(Object other) {
     if (!data.generateEqual) return '';
 
     final jsonKey = data.generateFromJson || data.generateToJson
-        ? '@JsonKey(ignore: true)'
+        ? '@JsonKey(includeFromJson: false, includeToJson: false)'
         : '';
 
     final hashedProperties = [

--- a/packages/freezed/lib/src/templates/copy_with.dart
+++ b/packages/freezed/lib/src/templates/copy_with.dart
@@ -63,7 +63,7 @@ ${_abstractDeepCopyMethods().join()}
 
     return _maybeOverride(
       '''
-@JsonKey(ignore: true)
+@JsonKey(includeFromJson: false, includeToJson: false)
 $_abstractClassName${genericsParameter.append('$clonedClassName$genericsParameter')} get copyWith => throw $privConstUsedErrorVarName;
 ''',
     );
@@ -72,7 +72,7 @@ $_abstractClassName${genericsParameter.append('$clonedClassName$genericsParamete
   String get concreteCopyWithGetter {
     if (cloneableProperties.isEmpty) return '';
     return '''
-@JsonKey(ignore: true)
+@JsonKey(includeFromJson: false, includeToJson: false)
 @override
 @pragma('vm:prefer-inline')
 $_abstractClassName${genericsParameter.append('$clonedClassName$genericsParameter')} get copyWith => $_implClassName${genericsParameter.append('$clonedClassName$genericsParameter')}(this, _\$identity);

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   meta: ^1.9.1
   source_gen: ^1.4.0
   freezed_annotation: ^2.4.2
-  json_annotation: ^4.6.0
+  json_annotation: ^4.8.0
   # Indirect dependency, but fixes a compiler error when using `pub downgrade`
   dart_style: ^2.3.6
 

--- a/packages/freezed_annotation/CHANGELOG.md
+++ b/packages/freezed_annotation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased patch
+
+- Stop using `JsonKey(ignore: true)` in favour of `JsonKey(includeFromJson: false, includeToJson: false)`
+  (thanks to @lrsvmb)
+
 ## 2.4.2 - 2024-07-02
 
 - Require Dart >=3.0.0

--- a/packages/freezed_annotation/CHANGELOG.md
+++ b/packages/freezed_annotation/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Stop using `JsonKey(ignore: true)` in favour of `JsonKey(includeFromJson: false, includeToJson: false)`
   (thanks to @lrsvmb)
+- Require json_annotation ^6.8.0
 
 ## 2.4.2 - 2024-07-02
 

--- a/packages/freezed_lint/example/lib/missing_mixin.freezed.dart
+++ b/packages/freezed_lint/example/lib/missing_mixin.freezed.dart
@@ -139,7 +139,7 @@ abstract class _WithMixin implements WithMixin {
 mixin _$FooModel {
   int get id => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $FooModelCopyWith<FooModel> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -232,7 +232,7 @@ class _$_FooModel extends _FooModel {
   @override
   int get hashCode => Object.hash(runtimeType, id);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$_FooModelCopyWith<_$_FooModel> get copyWith =>
@@ -246,7 +246,7 @@ abstract class _FooModel extends FooModel {
   @override
   int get id;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$_FooModelCopyWith<_$_FooModel> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -255,7 +255,7 @@ abstract class _FooModel extends FooModel {
 mixin _$BarModel {
   int get id => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $BarModelCopyWith<BarModel> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -348,7 +348,7 @@ class _$_BarModel extends _BarModel {
   @override
   int get hashCode => Object.hash(runtimeType, id);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$_BarModelCopyWith<_$_BarModel> get copyWith =>
@@ -362,7 +362,7 @@ abstract class _BarModel extends BarModel {
   @override
   int get id;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$_BarModelCopyWith<_$_BarModel> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/freezed_lint/example/lib/missing_private_empty_ctor.freezed.dart
+++ b/packages/freezed_lint/example/lib/missing_private_empty_ctor.freezed.dart
@@ -142,7 +142,7 @@ abstract class _HasPrivateCtor extends HasPrivateCtor {
 mixin _$HasAccessor {
   int get id => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $HasAccessorCopyWith<HasAccessor> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -237,7 +237,7 @@ class _$_HasAccessor extends _HasAccessor {
   @override
   int get hashCode => Object.hash(runtimeType, id);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$_HasAccessorCopyWith<_$_HasAccessor> get copyWith =>
@@ -251,7 +251,7 @@ abstract class _HasAccessor extends HasAccessor {
   @override
   int get id;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$_HasAccessorCopyWith<_$_HasAccessor> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -260,7 +260,7 @@ abstract class _HasAccessor extends HasAccessor {
 mixin _$WithIdMixin {
   int get id => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $WithIdMixinCopyWith<WithIdMixin> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -355,7 +355,7 @@ class _$_WithIdMixin implements _WithIdMixin {
   @override
   int get hashCode => Object.hash(runtimeType, id);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$_WithIdMixinCopyWith<_$_WithIdMixin> get copyWith =>
@@ -368,7 +368,7 @@ abstract class _WithIdMixin implements WithIdMixin {
   @override
   int get id;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$_WithIdMixinCopyWith<_$_WithIdMixin> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -377,7 +377,7 @@ abstract class _WithIdMixin implements WithIdMixin {
 mixin _$ExtendsIdClass {
   int get id => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ExtendsIdClassCopyWith<ExtendsIdClass> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -472,7 +472,7 @@ class _$_ExtendsIdClass extends _ExtendsIdClass {
   @override
   int get hashCode => Object.hash(runtimeType, id);
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$_ExtendsIdClassCopyWith<_$_ExtendsIdClass> get copyWith =>
@@ -486,7 +486,7 @@ abstract class _ExtendsIdClass extends ExtendsIdClass {
   @override
   int get id;
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$_ExtendsIdClassCopyWith<_$_ExtendsIdClass> get copyWith =>
       throw _privateConstructorUsedError;
 }


### PR DESCRIPTION
Replaces old `@JsonKey(ignore: true)` annotations in `*.freezed.dart` files with `@JsonKey(includeFromJson: false, includeToJson: false)`. This has been deprecated since `json_serializable: ^6.6.0`.

Closes #1043.

Local tests passing.