### PR TITLE
Bump json_serializable/json_annotation versions

### DIFF
--- a/benchmarks/pubspec.yaml
+++ b/benchmarks/pubspec.yaml
@@ -9,12 +9,12 @@ dependencies:
     sdk: flutter
   freezed_annotation:
     path: ../packages/freezed_annotation
-  json_annotation: ^4.4.0
+  json_annotation: ^4.9.0
 
 dev_dependencies:
   freezed:
     path: ../packages/freezed
-  json_serializable: ^6.1.3
+  json_serializable: ^6.8.0
   build_runner:
   flutter_test:
     sdk: flutter

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -17,12 +17,12 @@ dependencies:
   meta: ^1.9.1
   source_gen: ^1.4.0
   freezed_annotation: ^2.4.3
-  json_annotation: ^4.8.0
+  json_annotation: ^4.9.0
   # Indirect dependency, but fixes a compiler error when using `pub downgrade`
   dart_style: ^2.3.6
 
 dev_dependencies:
-  json_serializable: ^6.3.2
+  json_serializable: ^6.8.0
   build_test: ^2.1.5
   build_runner: ^2.3.3
   test: ^1.21.0

--- a/packages/freezed_annotation/pubspec.yaml
+++ b/packages/freezed_annotation/pubspec.yaml
@@ -11,10 +11,10 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  json_annotation: ^4.6.0
+  json_annotation: ^4.9.0
   meta: ^1.7.0
 
 dev_dependencies:
   build_runner: ^2.3.3
-  json_serializable: ^6.3.2
+  json_serializable: ^6.8.0
   test: ^1.21.0


### PR DESCRIPTION
Closes #1105. 

Maybe modify the changelog as well?

Local tests passing.