### PR TITLE
feat: add finalize parameter to Freezed config

### DIFF
--- a/packages/_internal/lib/models.dart
+++ b/packages/_internal/lib/models.dart
@@ -102,6 +102,7 @@ class Data with _$Data {
     required GenericsParameterTemplate genericsParameterTemplate,
     required bool shouldUseExtends,
     required bool genericArgumentFactories,
+    required bool shouldMarkSealedOrFinal,
   }) = _Data;
 }
 

--- a/packages/_internal/lib/models.freezed.dart
+++ b/packages/_internal/lib/models.freezed.dart
@@ -1098,6 +1098,7 @@ mixin _$Data {
       throw _privateConstructorUsedError;
   bool get shouldUseExtends => throw _privateConstructorUsedError;
   bool get genericArgumentFactories => throw _privateConstructorUsedError;
+  bool get shouldMarkSealedOrFinal => throw _privateConstructorUsedError;
 
   /// Create a copy of Data
   /// with the given fields replaced by the non-null parameter values.
@@ -1126,7 +1127,8 @@ abstract class $DataCopyWith<$Res> {
       GenericsDefinitionTemplate genericsDefinitionTemplate,
       GenericsParameterTemplate genericsParameterTemplate,
       bool shouldUseExtends,
-      bool genericArgumentFactories});
+      bool genericArgumentFactories,
+      bool shouldMarkSealedOrFinal});
 
   $MapConfigCopyWith<$Res> get map;
   $WhenConfigCopyWith<$Res> get when;
@@ -1163,6 +1165,7 @@ class _$DataCopyWithImpl<$Res, $Val extends Data>
     Object? genericsParameterTemplate = null,
     Object? shouldUseExtends = null,
     Object? genericArgumentFactories = null,
+    Object? shouldMarkSealedOrFinal = null,
   }) {
     return _then(_value.copyWith(
       name: null == name
@@ -1229,6 +1232,10 @@ class _$DataCopyWithImpl<$Res, $Val extends Data>
           ? _value.genericArgumentFactories
           : genericArgumentFactories // ignore: cast_nullable_to_non_nullable
               as bool,
+      shouldMarkSealedOrFinal: null == shouldMarkSealedOrFinal
+          ? _value.shouldMarkSealedOrFinal
+          : shouldMarkSealedOrFinal // ignore: cast_nullable_to_non_nullable
+              as bool,
     ) as $Val);
   }
 
@@ -1276,7 +1283,8 @@ abstract class _$$DataImplCopyWith<$Res> implements $DataCopyWith<$Res> {
       GenericsDefinitionTemplate genericsDefinitionTemplate,
       GenericsParameterTemplate genericsParameterTemplate,
       bool shouldUseExtends,
-      bool genericArgumentFactories});
+      bool genericArgumentFactories,
+      bool shouldMarkSealedOrFinal});
 
   @override
   $MapConfigCopyWith<$Res> get map;
@@ -1312,6 +1320,7 @@ class __$$DataImplCopyWithImpl<$Res>
     Object? genericsParameterTemplate = null,
     Object? shouldUseExtends = null,
     Object? genericArgumentFactories = null,
+    Object? shouldMarkSealedOrFinal = null,
   }) {
     return _then(_$DataImpl(
       name: null == name
@@ -1378,6 +1387,10 @@ class __$$DataImplCopyWithImpl<$Res>
           ? _value.genericArgumentFactories
           : genericArgumentFactories // ignore: cast_nullable_to_non_nullable
               as bool,
+      shouldMarkSealedOrFinal: null == shouldMarkSealedOrFinal
+          ? _value.shouldMarkSealedOrFinal
+          : shouldMarkSealedOrFinal // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -1401,7 +1414,8 @@ class _$DataImpl implements _Data {
       required this.genericsDefinitionTemplate,
       required this.genericsParameterTemplate,
       required this.shouldUseExtends,
-      required this.genericArgumentFactories})
+      required this.genericArgumentFactories,
+      required this.shouldMarkSealedOrFinal})
       : assert(constructors.isNotEmpty),
         _concretePropertiesName = concretePropertiesName,
         _constructors = constructors;
@@ -1451,10 +1465,12 @@ class _$DataImpl implements _Data {
   final bool shouldUseExtends;
   @override
   final bool genericArgumentFactories;
+  @override
+  final bool shouldMarkSealedOrFinal;
 
   @override
   String toString() {
-    return 'Data(name: $name, unionKey: $unionKey, generateCopyWith: $generateCopyWith, generateEqual: $generateEqual, generateToString: $generateToString, map: $map, when: $when, generateFromJson: $generateFromJson, generateToJson: $generateToJson, makeCollectionsImmutable: $makeCollectionsImmutable, concretePropertiesName: $concretePropertiesName, constructors: $constructors, genericsDefinitionTemplate: $genericsDefinitionTemplate, genericsParameterTemplate: $genericsParameterTemplate, shouldUseExtends: $shouldUseExtends, genericArgumentFactories: $genericArgumentFactories)';
+    return 'Data(name: $name, unionKey: $unionKey, generateCopyWith: $generateCopyWith, generateEqual: $generateEqual, generateToString: $generateToString, map: $map, when: $when, generateFromJson: $generateFromJson, generateToJson: $generateToJson, makeCollectionsImmutable: $makeCollectionsImmutable, concretePropertiesName: $concretePropertiesName, constructors: $constructors, genericsDefinitionTemplate: $genericsDefinitionTemplate, genericsParameterTemplate: $genericsParameterTemplate, shouldUseExtends: $shouldUseExtends, genericArgumentFactories: $genericArgumentFactories, shouldMarkSealedOrFinal: $shouldMarkSealedOrFinal)';
   }
 
   @override
@@ -1495,7 +1511,10 @@ class _$DataImpl implements _Data {
                 other.shouldUseExtends == shouldUseExtends) &&
             (identical(
                     other.genericArgumentFactories, genericArgumentFactories) ||
-                other.genericArgumentFactories == genericArgumentFactories));
+                other.genericArgumentFactories == genericArgumentFactories) &&
+            (identical(
+                    other.shouldMarkSealedOrFinal, shouldMarkSealedOrFinal) ||
+                other.shouldMarkSealedOrFinal == shouldMarkSealedOrFinal));
   }
 
   @override
@@ -1516,7 +1535,8 @@ class _$DataImpl implements _Data {
       genericsDefinitionTemplate,
       genericsParameterTemplate,
       shouldUseExtends,
-      genericArgumentFactories);
+      genericArgumentFactories,
+      shouldMarkSealedOrFinal);
 
   /// Create a copy of Data
   /// with the given fields replaced by the non-null parameter values.
@@ -1544,7 +1564,8 @@ abstract class _Data implements Data {
       required final GenericsDefinitionTemplate genericsDefinitionTemplate,
       required final GenericsParameterTemplate genericsParameterTemplate,
       required final bool shouldUseExtends,
-      required final bool genericArgumentFactories}) = _$DataImpl;
+      required final bool genericArgumentFactories,
+      required final bool shouldMarkSealedOrFinal}) = _$DataImpl;
 
   @override
   String get name;
@@ -1578,6 +1599,8 @@ abstract class _Data implements Data {
   bool get shouldUseExtends;
   @override
   bool get genericArgumentFactories;
+  @override
+  bool get shouldMarkSealedOrFinal;
 
   /// Create a copy of Data
   /// with the given fields replaced by the non-null parameter values.

--- a/packages/freezed/lib/src/models.dart
+++ b/packages/freezed/lib/src/models.dart
@@ -92,6 +92,7 @@ class Data with _$Data {
     required GenericsParameterTemplate genericsParameterTemplate,
     required bool shouldUseExtends,
     required bool genericArgumentFactories,
+    required bool shouldMarkSealedOrFinal,
   }) = _Data;
 }
 

--- a/packages/freezed/lib/src/models.freezed.dart
+++ b/packages/freezed/lib/src/models.freezed.dart
@@ -1054,6 +1054,7 @@ mixin _$Data {
       throw _privateConstructorUsedError;
   bool get shouldUseExtends => throw _privateConstructorUsedError;
   bool get genericArgumentFactories => throw _privateConstructorUsedError;
+  bool get shouldMarkSealedOrFinal => throw _privateConstructorUsedError;
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   $DataCopyWith<Data> get copyWith => throw _privateConstructorUsedError;
@@ -1080,7 +1081,8 @@ abstract class $DataCopyWith<$Res> {
       GenericsDefinitionTemplate genericsDefinitionTemplate,
       GenericsParameterTemplate genericsParameterTemplate,
       bool shouldUseExtends,
-      bool genericArgumentFactories});
+      bool genericArgumentFactories,
+      bool shouldMarkSealedOrFinal});
 
   $MapConfigCopyWith<$Res> get map;
   $WhenConfigCopyWith<$Res> get when;
@@ -1115,6 +1117,7 @@ class _$DataCopyWithImpl<$Res, $Val extends Data>
     Object? genericsParameterTemplate = null,
     Object? shouldUseExtends = null,
     Object? genericArgumentFactories = null,
+    Object? shouldMarkSealedOrFinal = null,
   }) {
     return _then(_value.copyWith(
       name: null == name
@@ -1181,6 +1184,10 @@ class _$DataCopyWithImpl<$Res, $Val extends Data>
           ? _value.genericArgumentFactories
           : genericArgumentFactories // ignore: cast_nullable_to_non_nullable
               as bool,
+      shouldMarkSealedOrFinal: null == shouldMarkSealedOrFinal
+          ? _value.shouldMarkSealedOrFinal
+          : shouldMarkSealedOrFinal // ignore: cast_nullable_to_non_nullable
+              as bool,
     ) as $Val);
   }
 
@@ -1224,7 +1231,8 @@ abstract class _$$DataImplCopyWith<$Res> implements $DataCopyWith<$Res> {
       GenericsDefinitionTemplate genericsDefinitionTemplate,
       GenericsParameterTemplate genericsParameterTemplate,
       bool shouldUseExtends,
-      bool genericArgumentFactories});
+      bool genericArgumentFactories,
+      bool shouldMarkSealedOrFinal});
 
   @override
   $MapConfigCopyWith<$Res> get map;
@@ -1258,6 +1266,7 @@ class __$$DataImplCopyWithImpl<$Res>
     Object? genericsParameterTemplate = null,
     Object? shouldUseExtends = null,
     Object? genericArgumentFactories = null,
+    Object? shouldMarkSealedOrFinal = null,
   }) {
     return _then(_$DataImpl(
       name: null == name
@@ -1324,6 +1333,10 @@ class __$$DataImplCopyWithImpl<$Res>
           ? _value.genericArgumentFactories
           : genericArgumentFactories // ignore: cast_nullable_to_non_nullable
               as bool,
+      shouldMarkSealedOrFinal: null == shouldMarkSealedOrFinal
+          ? _value.shouldMarkSealedOrFinal
+          : shouldMarkSealedOrFinal // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -1347,7 +1360,8 @@ class _$DataImpl implements _Data {
       required this.genericsDefinitionTemplate,
       required this.genericsParameterTemplate,
       required this.shouldUseExtends,
-      required this.genericArgumentFactories})
+      required this.genericArgumentFactories,
+      required this.shouldMarkSealedOrFinal})
       : assert(constructors.isNotEmpty),
         _concretePropertiesName = concretePropertiesName,
         _constructors = constructors;
@@ -1397,10 +1411,12 @@ class _$DataImpl implements _Data {
   final bool shouldUseExtends;
   @override
   final bool genericArgumentFactories;
+  @override
+  final bool shouldMarkSealedOrFinal;
 
   @override
   String toString() {
-    return 'Data(name: $name, unionKey: $unionKey, generateCopyWith: $generateCopyWith, generateEqual: $generateEqual, generateToString: $generateToString, map: $map, when: $when, generateFromJson: $generateFromJson, generateToJson: $generateToJson, makeCollectionsImmutable: $makeCollectionsImmutable, concretePropertiesName: $concretePropertiesName, constructors: $constructors, genericsDefinitionTemplate: $genericsDefinitionTemplate, genericsParameterTemplate: $genericsParameterTemplate, shouldUseExtends: $shouldUseExtends, genericArgumentFactories: $genericArgumentFactories)';
+    return 'Data(name: $name, unionKey: $unionKey, generateCopyWith: $generateCopyWith, generateEqual: $generateEqual, generateToString: $generateToString, map: $map, when: $when, generateFromJson: $generateFromJson, generateToJson: $generateToJson, makeCollectionsImmutable: $makeCollectionsImmutable, concretePropertiesName: $concretePropertiesName, constructors: $constructors, genericsDefinitionTemplate: $genericsDefinitionTemplate, genericsParameterTemplate: $genericsParameterTemplate, shouldUseExtends: $shouldUseExtends, genericArgumentFactories: $genericArgumentFactories, shouldMarkSealedOrFinal: $shouldMarkSealedOrFinal)';
   }
 
   @override
@@ -1441,7 +1457,10 @@ class _$DataImpl implements _Data {
                 other.shouldUseExtends == shouldUseExtends) &&
             (identical(
                     other.genericArgumentFactories, genericArgumentFactories) ||
-                other.genericArgumentFactories == genericArgumentFactories));
+                other.genericArgumentFactories == genericArgumentFactories) &&
+            (identical(
+                    other.shouldMarkSealedOrFinal, shouldMarkSealedOrFinal) ||
+                other.shouldMarkSealedOrFinal == shouldMarkSealedOrFinal));
   }
 
   @override
@@ -1462,7 +1481,8 @@ class _$DataImpl implements _Data {
       genericsDefinitionTemplate,
       genericsParameterTemplate,
       shouldUseExtends,
-      genericArgumentFactories);
+      genericArgumentFactories,
+      shouldMarkSealedOrFinal);
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
@@ -1488,7 +1508,8 @@ abstract class _Data implements Data {
       required final GenericsDefinitionTemplate genericsDefinitionTemplate,
       required final GenericsParameterTemplate genericsParameterTemplate,
       required final bool shouldUseExtends,
-      required final bool genericArgumentFactories}) = _$DataImpl;
+      required final bool genericArgumentFactories,
+      required final bool shouldMarkSealedOrFinal}) = _$DataImpl;
 
   @override
   String get name;
@@ -1522,6 +1543,8 @@ abstract class _Data implements Data {
   bool get shouldUseExtends;
   @override
   bool get genericArgumentFactories;
+  @override
+  bool get shouldMarkSealedOrFinal;
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
   _$$DataImplCopyWith<_$DataImpl> get copyWith =>

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -64,7 +64,7 @@ ${copyWith?.concreteImpl(constructor.parameters) ?? ''}
 /// @nodoc
 $jsonSerializable
 ${constructor.decorators.join('\n')}
-class $concreteName${data.genericsDefinitionTemplate} $_concreteSuper {
+${data.shouldMarkSealedOrFinal ? 'final' : ''} class $concreteName${data.genericsDefinitionTemplate} $_concreteSuper {
   $_concreteConstructor
 
   $_concreteFromJsonConstructor
@@ -86,7 +86,7 @@ $_toJson
 }
 
 
-abstract class ${constructor.redirectedName}${data.genericsDefinitionTemplate} $_superKeyword ${data.name}${data.genericsParameterTemplate}$interfaces {
+${data.shouldMarkSealedOrFinal ? 'sealed' : 'abstract'} class ${constructor.redirectedName}${data.genericsDefinitionTemplate} $_superKeyword ${data.name}${data.genericsParameterTemplate}$interfaces {
   $_isConst factory ${constructor.redirectedName}(${constructor.parameters.asExpandedDefinition}) = $concreteName${data.genericsParameterTemplate};
   $_privateConcreteConstructor
 

--- a/packages/freezed/test/finalized_test.dart
+++ b/packages/freezed/test/finalized_test.dart
@@ -1,0 +1,84 @@
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/error/error.dart';
+import 'package:build_test/build_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('single constructor', () {
+    test(
+        'causes pattern_never_matches_value_type warning when trying to match on pattern that can never match',
+        () async {
+      final main = await resolveSources(
+        {
+          'freezed|test/integration/main.dart': r'''
+library main;
+import 'finalized.dart';
+
+void main() {
+  switch (const FinalizedFoo()) {
+    case FinalizedBar():
+      break;
+
+    case FinalizedFoo():
+      break;
+  }
+}
+''',
+        },
+        (r) => r.findLibraryByName('main'),
+      );
+
+      final errorResult = await main!.session
+          .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
+
+      expect(errorResult.errors, hasLength(1));
+
+      final [error] = errorResult.errors;
+
+      expect(error.errorCode.errorSeverity, ErrorSeverity.WARNING);
+      expect(error.errorCode.name, 'PATTERN_NEVER_MATCHES_VALUE_TYPE');
+    });
+  });
+
+  group('multiple constructors', () {
+    test(
+        'causes pattern_never_matches_value_type warning when trying to match on pattern that can never match',
+        () async {
+      final main = await resolveSources(
+        {
+          'freezed|test/integration/main.dart': r'''
+library main;
+import 'finalized.dart';
+
+void main() {
+  switch (const FinalizedMultiple.b()) {
+    case FinalizedBar():
+      break;
+
+    case FinalizedMultipleA():
+      break;
+
+    case FinalizedMultipleB():
+      break;
+
+    case FinalizedMultipleC():
+      break;
+  }
+}
+''',
+        },
+        (r) => r.findLibraryByName('main'),
+      );
+
+      final errorResult = await main!.session
+          .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
+
+      expect(errorResult.errors, hasLength(1));
+
+      final [error] = errorResult.errors;
+
+      expect(error.errorCode.errorSeverity, ErrorSeverity.WARNING);
+      expect(error.errorCode.name, 'PATTERN_NEVER_MATCHES_VALUE_TYPE');
+    });
+  });
+}

--- a/packages/freezed/test/integration/finalized.dart
+++ b/packages/freezed/test/integration/finalized.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'finalized.freezed.dart';
+
+@Freezed(finalize: true)
+sealed class FinalizedFoo with _$FinalizedFoo {
+  const FinalizedFoo._();
+  const factory FinalizedFoo() = _FinalizedFoo;
+}
+
+@Freezed(finalize: true)
+sealed class FinalizedBar with _$FinalizedBar {
+  const FinalizedBar._();
+  const factory FinalizedBar() = _FinalizedBar;
+}
+
+@Freezed(finalize: true)
+sealed class FinalizedMultiple with _$FinalizedMultiple {
+  const FinalizedMultiple._();
+
+  const factory FinalizedMultiple.a() = FinalizedMultipleA;
+  const factory FinalizedMultiple.b() = FinalizedMultipleB;
+  const factory FinalizedMultiple.c() = FinalizedMultipleC;
+}

--- a/packages/freezed/test/source_gen_src.dart
+++ b/packages/freezed/test/source_gen_src.dart
@@ -224,3 +224,30 @@ abstract class AstractClass {
 class _AstractClass implements AstractClass {
   const _AstractClass();
 }
+
+@ShouldThrow(
+  '@freezed classes configured with [finalize: true] must be sealed',
+)
+@Freezed(finalize: true)
+class FinalizedClassWithoutSealedKeyword {
+  FinalizedClassWithoutSealedKeyword._();
+  factory FinalizedClassWithoutSealedKeyword() =
+      _FinalizedClassWithoutSealedKeyword;
+}
+
+class _FinalizedClassWithoutSealedKeyword
+    implements FinalizedClassWithoutSealedKeyword {
+  _FinalizedClassWithoutSealedKeyword();
+}
+
+@ShouldThrow(
+  '@freezed classes configured with [finalize: true] require a MyClass._() constructor',
+)
+@Freezed(finalize: true)
+sealed class FinalizedClassWithoutPrivateConstructor {
+  factory FinalizedClassWithoutPrivateConstructor() =
+      _FinalizedClassWithoutPrivateConstructor;
+}
+
+class _FinalizedClassWithoutPrivateConstructor
+    implements FinalizedClassWithoutPrivateConstructor {}

--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -219,6 +219,7 @@ class Freezed {
     this.makeCollectionsUnmodifiable,
     this.addImplicitFinal = true,
     this.genericArgumentFactories = false,
+    this.finalize = false,
   });
 
   /// Decode the options from a build.yaml
@@ -475,6 +476,46 @@ class Freezed {
   /// }
   /// ```
   final bool genericArgumentFactories;
+
+  /// Whether to add `sealed`/`final` modifiers to the generated classes.
+  ///
+  /// Defaults to false.
+  ///
+  /// This makes the generated classes `sealed` and `final` by default,
+  /// so when using them in a switch statement, the analzyer will warn you
+  /// if you try to match agains a pattern that will never match the type.
+  ///
+  /// When configuring a class with `finalize: true`, it also needs to be
+  /// `sealed` and have a private no-args constructor.
+  ///
+  /// ```dart
+  /// @Freezed(finalize: true)
+  /// sealed class Foo with _$Foo {
+  ///   const Foo._();
+  ///   const factory Foo() = _Foo;
+  /// }
+  ///
+  /// @Freezed(finalize: true)
+  /// sealed class Bar with _$Bar {
+  ///   const Bar._();
+  ///   const factory Bar() = _Bar;
+  /// }
+  ///
+  /// void main() {
+  ///   switch (Foo()) {
+  ///     // The analyzer will yield a warning that this case can never match,
+  ///     // because all subclasses of Foo are sealed/final, so it is guaranteed
+  ///     // that instances of type Bar can never also be of type Foo.
+  ///     case Bar():
+  ///       // ...
+  ///       break;
+  ///
+  ///     case Foo():
+  ///       // ...
+  ///       break;
+  ///   }
+  /// ```
+  final bool finalize;
 
   /// Options for customizing the generation of `map` functions
   ///

--- a/packages/freezed_annotation/lib/freezed_annotation.g.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.g.dart
@@ -37,6 +37,7 @@ Freezed _$FreezedFromJson(Map json) => Freezed(
       addImplicitFinal: json['add_implicit_final'] as bool? ?? true,
       genericArgumentFactories:
           json['generic_argument_factories'] as bool? ?? false,
+      finalize: json['finalize'] as bool? ?? false,
     );
 
 const _$FreezedUnionCaseEnumMap = {


### PR DESCRIPTION
Adds a new configuration parameter `finalize: bool` that allows to mark generated classes as `final` in the case of concrete classes or `sealed` in the case of abstract classes. It is disabled by default.

Enabling it allows the Dart analyzer/compiler to report patterns that will never match the type of a freezed class at compile time.

For example:

```dart
@Freezed(finalize: true)
sealed class Foo with _$Foo {
  const Foo._();
  const factory Foo() = _Foo;
}

@Freezed(finalize: true)
sealed class Bar with _$Bar {
  const Bar._();
  const factory Bar() = Bar;
}

void main() {
  switch (Foo()) {
    // This will now cause an analyzer warning: pattern_never_matches_value_type.
    // Without finalize: true it would not cause any warning/error at all.
    case Bar():
      print("matched Bar()");
      return;

    case Foo():
      print("matched Foo()");
      return;
  }
}
```

# Why do I think this is a good idea?

I have recently had an issue in one of my projects where I have a `@freezed sealed class DataFromApi` and I introduced a new `@freezed sealed class DataFromDatabase` that was intended to be used in many but not all cases where `DataFromApi` was being used so far.

It was a normal change, but I messed up due to the heavy use of pattern matching like

```dart
switch (data) {
  case DataFromApi(someCondition: true):
    // ...
    break;

  case DataFromApi(someCondition: false):
    // ...
    break;

  default:
    // ...
    break;
}
```

The changes mostly looked like this

```diff
- final data = await loadDataFromApi();
+ final data = await loadDataFromDatabase();

switch (data) {
  case DataFromApi(someCondition: true):
    // ...
    break;

    // ...
}
```

I was expecting the Dart analyzer/compiler to yell at me when changing the type of `data` in the example above to `DataFromDatabase`, but that was not the case. So I had to find all the now broken patterns by hand. Naturally I overlooked one case and the tests didn't catch it, so I got a Bug in production 😅. 

IMHO the Dart analyzer/compiler should be able to help me in this case no matter if I use freezed or not, since the classes in question were marked as `sealed`. So I opened an issue over there: https://github.com/dart-lang/sdk/issues/56616

However, since this might never be implemented or maybe is completely impossible, I thought it should be possible and rather simple to make freezed help me out in that case. All that needs to be done is mark the generated classes as `final` or `sealed`, and then the analyzer will step in and report any pattern that can never match at compile time.

# What needs to be done before it might be merged?

Good question, I think first of all someone needs to decide if this even is a good idea or if it would mess things up. In case it should be merged, I assume a few more tests need to be written to make sure the `finalize` flag works well with other configuration options. However, so far I have a hard time figuring out what even might break due to this change, so I would need help to decide what special/edge cases to consider when writing tests.