### PR TITLE
Add support for manually defining fields

### DIFF
--- a/packages/freezed/CHANGELOG.md
+++ b/packages/freezed/CHANGELOG.md
@@ -1,6 +1,34 @@
 ## Unreleased 3.0.0
 
 - **Breaking**: Removed `map/when` and variants. These have been discouraged since Dart got pattern matching.
+- **Breaking**: Freezed classes should now either be `abstract`, `sealed`, or manually implements `_$MyClass`.
+- Inheritance and dynamic default values are now supported by specifying them in the `MyClass._()` constructor.  
+  Inheritance example:
+  ```dart
+  class BaseClass {
+    BaseClass.name(this.value);
+    final int value;
+  }
+  @freezed
+  abstract class Example extends BaseClass with _$Example {
+    // We can pass super values through the ._ constructor.
+    Example._(super.value): super.name();
+
+    factory Example(int value, String name) = _Example;
+  }
+  ```
+  Dynamic default values example:
+  ```dart
+  @freezed
+  abstract class Example with _$Example {
+    Example._(Duration? duration)
+      : duration ??= DateTime.now();
+
+    factory Example({Duration? duration}) = _Example;
+
+    final Duration? duration;
+  }
+  ```
 
 ## 2.5.8 - 2025-01-06
 

--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -35,7 +35,7 @@ class FreezedGenerator extends ParserGenerator<Freezed> {
 
   final Freezed _buildYamlConfigs;
 
-  UserDefinedClass _parseDeclaration(
+  Class _parseDeclaration(
     Library globalData,
     Declaration declaration,
     DartObject annotation,
@@ -54,8 +54,7 @@ class FreezedGenerator extends ParserGenerator<Freezed> {
       library: globalData,
     );
 
-    return UserDefinedClass.from(declaration, configs,
-        globalConfigs: _buildYamlConfigs);
+    return Class.from(declaration, configs, globalConfigs: _buildYamlConfigs);
   }
 
   CommonProperties _commonParametersBetweenAllConstructors(
@@ -232,7 +231,7 @@ class FreezedGenerator extends ParserGenerator<Freezed> {
 
   Iterable<Object> _generateForData(
     Library globalData,
-    UserDefinedClass data,
+    Class data,
   ) sync* {
     if (data.options.fromJson) yield FromJson(data);
 

--- a/packages/freezed/lib/src/models.dart
+++ b/packages/freezed/lib/src/models.dart
@@ -420,8 +420,8 @@ class AssertAnnotation {
   }
 }
 
-class UserDefinedClass {
-  UserDefinedClass({
+class Class {
+  Class({
     required this.name,
     required this.options,
     required this.concretePropertiesName,
@@ -439,7 +439,7 @@ class UserDefinedClass {
   final GenericsParameterTemplate genericsParameterTemplate;
   final bool shouldUseExtends;
 
-  static UserDefinedClass from(
+  static Class from(
     ClassDeclaration declaration,
     ClassConfig configs, {
     required Freezed globalConfigs,
@@ -458,7 +458,7 @@ class UserDefinedClass {
       globalConfigs: globalConfigs,
     );
 
-    return UserDefinedClass(
+    return Class(
       name: declaration.name.lexeme,
       shouldUseExtends: shouldUseExtends,
       options: configs,

--- a/packages/freezed/lib/src/models.dart
+++ b/packages/freezed/lib/src/models.dart
@@ -201,7 +201,7 @@ When specifying fields in MyClass._(), either:
 - the parameter should be named
 - or all constructors in the class should specify that parameter.
 ''',
-              node: ctor,
+              element: constructor.declaredElement,
             );
           }
         }

--- a/packages/freezed/lib/src/models.dart
+++ b/packages/freezed/lib/src/models.dart
@@ -420,8 +420,8 @@ class AssertAnnotation {
   }
 }
 
-class Data {
-  Data({
+class UserDefinedClass {
+  UserDefinedClass({
     required this.name,
     required this.options,
     required this.concretePropertiesName,
@@ -429,7 +429,6 @@ class Data {
     required this.genericsDefinitionTemplate,
     required this.genericsParameterTemplate,
     required this.shouldUseExtends,
-    required this.genericArgumentFactories,
   }) : assert(constructors.isNotEmpty);
 
   final String name;
@@ -439,9 +438,8 @@ class Data {
   final GenericsDefinitionTemplate genericsDefinitionTemplate;
   final GenericsParameterTemplate genericsParameterTemplate;
   final bool shouldUseExtends;
-  final bool genericArgumentFactories;
 
-  static Data from(
+  static UserDefinedClass from(
     ClassDeclaration declaration,
     ClassConfig configs, {
     required Freezed globalConfigs,
@@ -460,11 +458,10 @@ class Data {
       globalConfigs: globalConfigs,
     );
 
-    return Data(
+    return UserDefinedClass(
       name: declaration.name.lexeme,
       shouldUseExtends: shouldUseExtends,
       options: configs,
-      genericArgumentFactories: configs.genericArgumentFactories,
       constructors: constructors,
       concretePropertiesName: [
         for (final p in declaration.declaredElement!.fields)
@@ -513,8 +510,8 @@ class Data {
   }
 }
 
-class LibraryData {
-  LibraryData({
+class Library {
+  Library({
     required this.hasJson,
     required this.hasDiagnostics,
   });
@@ -522,8 +519,8 @@ class LibraryData {
   final bool hasJson;
   final bool hasDiagnostics;
 
-  static LibraryData from(List<CompilationUnit> units) {
-    return LibraryData(
+  static Library from(List<CompilationUnit> units) {
+    return Library(
       hasJson: units.any(
         (unit) => unit.declaredElement!.library.importsJsonSerializable,
       ),
@@ -549,7 +546,7 @@ class ClassConfig {
     DartObject annotation,
     ClassDeclaration declaration,
     Freezed globalConfigs, {
-    required LibraryData library,
+    required Library library,
   }) {
     final resolvedAnnotation = parseAnnotation(annotation, globalConfigs);
 
@@ -649,7 +646,7 @@ extension ClassDeclarationX on ClassDeclaration {
     return members.whereType<ConstructorDeclaration>();
   }
 
-  bool needsJsonSerializable(LibraryData library) {
+  bool needsJsonSerializable(Library library) {
     if (!library.hasJson) return false;
 
     for (final constructor in constructors) {

--- a/packages/freezed/lib/src/templates/abstract_template.dart
+++ b/packages/freezed/lib/src/templates/abstract_template.dart
@@ -12,7 +12,7 @@ class Abstract {
     required this.commonProperties,
   });
 
-  final Data data;
+  final UserDefinedClass data;
   final CopyWith? copyWith;
   final List<Property> commonProperties;
 
@@ -41,7 +41,7 @@ ${copyWith?.commonConcreteImpl ?? ''}
 
   String get _toJsonParams => toJsonParameters(
         data.genericsParameterTemplate,
-        data.genericArgumentFactories,
+        data.options.genericArgumentFactories,
       );
   String get _toJson {
     if (!data.options.toJson) return '';

--- a/packages/freezed/lib/src/templates/abstract_template.dart
+++ b/packages/freezed/lib/src/templates/abstract_template.dart
@@ -12,7 +12,7 @@ class Abstract {
     required this.commonProperties,
   });
 
-  final UserDefinedClass data;
+  final Class data;
   final CopyWith? copyWith;
   final List<Property> commonProperties;
 

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -34,20 +34,7 @@ class Concrete {
 
   @override
   String toString() {
-    var jsonSerializable = '';
-    if (!constructor.hasJsonSerializable) {
-      if (data.options.fromJson || data.options.toJson) {
-        final params = [
-          if (data.options.toJson == false) 'createToJson: false',
-          if (data.options.fromJson == false) 'createFactory: false',
-          if (data.genericsParameterTemplate.typeParameters.isNotEmpty &&
-              data.genericArgumentFactories == true)
-            'genericArgumentFactories: true',
-        ].join(',');
-
-        jsonSerializable = '@JsonSerializable($params)';
-      }
-    }
+    final jsonSerializable = _jsonSerializable();
 
     return '''
 ${copyWith?.interface ?? ''}
@@ -70,6 +57,24 @@ $_hashCodeMethod
 $_toStringMethod
 }
 // ''';
+  }
+
+  String _jsonSerializable() {
+    var jsonSerializable = '';
+    if (!constructor.hasJsonSerializable) {
+      if (data.options.fromJson || data.options.toJson) {
+        final params = [
+          if (data.options.toJson == false) 'createToJson: false',
+          if (data.options.fromJson == false) 'createFactory: false',
+          if (data.genericsParameterTemplate.typeParameters.isNotEmpty &&
+              data.genericArgumentFactories == true)
+            'genericArgumentFactories: true',
+        ].join(',');
+
+        jsonSerializable = '@JsonSerializable($params)';
+      }
+    }
+    return jsonSerializable;
   }
 
   String get _concreteConstructor {
@@ -132,31 +137,6 @@ $_toStringMethod
     }
 
     return '$_isConst ${constructor.redirectedName}($parameters)$trailing;';
-  }
-
-  String get interfaces {
-    if (constructor.withDecorators.isEmpty &&
-        constructor.implementsDecorators.isEmpty) {
-      return '';
-    }
-
-    final interfaces = [
-      ...constructor.implementsDecorators.map((e) => e.type),
-      ...constructor.withDecorators.map((e) => e.type),
-    ].join(', ');
-
-    final buffer = StringBuffer();
-
-    if (interfaces.isNotEmpty) {
-      if (data.shouldUseExtends) {
-        buffer.write(' implements ');
-      } else {
-        buffer.write(', ');
-      }
-      buffer.write(interfaces);
-    }
-
-    return buffer.toString();
   }
 
   String get _superConstructor {

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -22,8 +22,8 @@ class Concrete {
 
   final ConstructorDetails constructor;
   final List<Property> commonProperties;
-  final Data data;
-  final LibraryData globalData;
+  final UserDefinedClass data;
+  final Library globalData;
   final CopyWith? copyWith;
 
   late final bool _hasUnionKeyProperty =
@@ -67,7 +67,7 @@ $_toStringMethod
           if (data.options.toJson == false) 'createToJson: false',
           if (data.options.fromJson == false) 'createFactory: false',
           if (data.genericsParameterTemplate.typeParameters.isNotEmpty &&
-              data.genericArgumentFactories == true)
+              data.options.genericArgumentFactories == true)
             'genericArgumentFactories: true',
         ].join(',');
 
@@ -233,10 +233,12 @@ final String \$type;
   }
 
   String get _fromJsonArgs => fromJsonArguments(
-      data.genericsParameterTemplate, data.genericArgumentFactories);
+        data.genericsParameterTemplate,
+        data.options.genericArgumentFactories,
+      );
 
   String get _fromJsonParams => fromJsonParameters(
-      data.genericsParameterTemplate, data.genericArgumentFactories);
+      data.genericsParameterTemplate, data.options.genericArgumentFactories);
 
   String get _concreteFromJsonConstructor {
     if (!data.options.fromJson) return '';
@@ -245,10 +247,10 @@ final String \$type;
   }
 
   String get _toJsonParams => toJsonParameters(
-      data.genericsParameterTemplate, data.genericArgumentFactories);
+      data.genericsParameterTemplate, data.options.genericArgumentFactories);
 
   String get _toJsonArgs => toJsonArguments(
-      data.genericsParameterTemplate, data.genericArgumentFactories);
+      data.genericsParameterTemplate, data.options.genericArgumentFactories);
 
   String get _toJson {
     if (!data.options.toJson) return '';

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -56,7 +56,7 @@ $_operatorEqualMethod
 $_hashCodeMethod
 $_toStringMethod
 }
-// ''';
+''';
   }
 
   String _jsonSerializable() {

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -22,7 +22,7 @@ class Concrete {
 
   final ConstructorDetails constructor;
   final List<Property> commonProperties;
-  final UserDefinedClass data;
+  final Class data;
   final Library globalData;
   final CopyWith? copyWith;
 

--- a/packages/freezed/lib/src/templates/copy_with.dart
+++ b/packages/freezed/lib/src/templates/copy_with.dart
@@ -39,7 +39,7 @@ class CopyWith {
 
   /// When collections are wrapped in an UnmodifiableView, this bool determines
   /// if the raw collection can be accessed instead.
-  bool get canAccessRawCollection => parent != null;
+  bool get _canAccessRawCollection => parent != null;
 
   String get interface => _deepCopyInterface(appendGenericToFactory: false);
 
@@ -257,7 +257,7 @@ $s''';
       required Parameter to,
     }) {
       var propertyName = to.name;
-      if (canAccessRawCollection &&
+      if (_canAccessRawCollection &&
           (to.isDartList || to.isDartMap || to.isDartSet) &&
           data.options.asUnmodifiableCollections) {
         propertyName = '_$propertyName';

--- a/packages/freezed/lib/src/templates/copy_with.dart
+++ b/packages/freezed/lib/src/templates/copy_with.dart
@@ -35,7 +35,7 @@ class CopyWith {
   final List<Property> readableProperties;
   final List<DeepCloneableProperty> deepCloneableProperties;
   final CopyWith? parent;
-  final UserDefinedClass data;
+  final Class data;
 
   /// When collections are wrapped in an UnmodifiableView, this bool determines
   /// if the raw collection can be accessed instead.

--- a/packages/freezed/lib/src/templates/copy_with.dart
+++ b/packages/freezed/lib/src/templates/copy_with.dart
@@ -279,8 +279,11 @@ $s''';
     }
 
     String parameterToValue(Parameter p) {
-      final propertyGetterForCopyWithParameter =
-          readableProperties.firstWhere((element) => element.name == p.name);
+      final propertyGetterForCopyWithParameter = <Property>[]
+          .followedBy(readableProperties)
+          // Read this.p before cloneable properties, as they might have a different nullability
+          .followedBy(cloneableProperties)
+          .firstWhere((element) => element.name == p.name);
 
       final condition =
           '${_defaultValue(isNullable: p.isNullable)} == ${p.name}';

--- a/packages/freezed/lib/src/templates/copy_with.dart
+++ b/packages/freezed/lib/src/templates/copy_with.dart
@@ -35,7 +35,7 @@ class CopyWith {
   final List<Property> readableProperties;
   final List<DeepCloneableProperty> deepCloneableProperties;
   final CopyWith? parent;
-  final Data data;
+  final UserDefinedClass data;
 
   /// When collections are wrapped in an UnmodifiableView, this bool determines
   /// if the raw collection can be accessed instead.

--- a/packages/freezed/lib/src/templates/from_json_template.dart
+++ b/packages/freezed/lib/src/templates/from_json_template.dart
@@ -8,7 +8,7 @@ import 'prototypes.dart';
 class FromJson {
   FromJson(this.clazz);
 
-  final UserDefinedClass clazz;
+  final Class clazz;
 
   @override
   String toString() {

--- a/packages/freezed/lib/src/templates/from_json_template.dart
+++ b/packages/freezed/lib/src/templates/from_json_template.dart
@@ -1,50 +1,39 @@
 import 'package:collection/collection.dart';
 import 'package:freezed/src/freezed_generator.dart';
-import 'package:freezed/src/templates/parameter_template.dart';
 import 'package:source_gen/source_gen.dart';
 
 import '../models.dart';
 import 'prototypes.dart';
 
 class FromJson {
-  FromJson({
-    required this.name,
-    required this.unionKey,
-    required this.constructors,
-    required this.genericParameters,
-    required this.genericDefinitions,
-    required this.genericArgumentFactories,
-  });
+  FromJson(this.clazz);
 
-  final String name;
-  final String unionKey;
-  final List<ConstructorDetails> constructors;
-  final GenericsParameterTemplate genericParameters;
-  final GenericsDefinitionTemplate genericDefinitions;
-  final bool genericArgumentFactories;
+  final UserDefinedClass clazz;
 
   @override
   String toString() {
-    final conflictCtor = constructors
-        .where((c) => c.redirectedName.public == name.public)
+    final conflictCtor = clazz.constructors
+        .where((c) => c.redirectedName.public == clazz.name.public)
         .firstOrNull;
 
     if (conflictCtor != null) {
-      if (constructors.length == 1) return '';
+      if (clazz.constructors.length == 1) return '';
 
       throw InvalidGenerationSourceError('''
-Could not generate _\$${name}FromJson because both $name and ${conflictCtor.redirectedName} would want to generate it.
+Could not generate _\$${clazz.name}FromJson because both ${clazz.name} and ${conflictCtor.redirectedName} would want to generate it.
 Rename one or the other, such that they don't conflict.
 ''');
     }
 
     String content;
 
-    if (constructors.length == 1) {
-      content =
-          'return ${constructors.first.redirectedName}$genericParameters.fromJson(json${fromJsonArguments(genericParameters, genericArgumentFactories)});';
+    if (clazz.constructors.length == 1) {
+      content = '''
+    return ${clazz.constructors.first.redirectedName}${clazz.genericsParameterTemplate}.fromJson(
+      json${fromJsonArguments(clazz.genericsParameterTemplate, clazz.options.genericArgumentFactories)}
+    );''';
     } else {
-      final cases = constructors
+      final cases = clazz.constructors
           .where((element) => !element.isFallback)
           .map((constructor) {
         final caseName = constructor.unionValue;
@@ -52,22 +41,31 @@ Rename one or the other, such that they don't conflict.
 
         return '''
         case '$caseName':
-          return $concreteName$genericParameters.fromJson(json${fromJsonArguments(genericParameters, genericArgumentFactories)});
+          return $concreteName${clazz.genericsParameterTemplate}.fromJson(
+            json${fromJsonArguments(clazz.genericsParameterTemplate, clazz.options.genericArgumentFactories)}
+          );
         ''';
       }).join();
 
       // TODO(rrousselGit): update logic once https://github.com/rrousselGit/freezed/pull/370 lands
-      var defaultCase =
-          'throw CheckedFromJsonException(json, \'$unionKey\', \'$name\', \'Invalid union type "\${json[\'$unionKey\']}"!\');';
+      var defaultCase = '''
+throw CheckedFromJsonException(
+  json,
+  \'${clazz.options.annotation.unionKey}\',
+  \'${clazz.name}\',
+  \'Invalid union type "\${json[\'${clazz.options.annotation.unionKey}\']}"!\'
+);''';
       final fallbackConstructor =
-          constructors.singleWhereOrNull((element) => element.isFallback);
+          clazz.constructors.singleWhereOrNull((element) => element.isFallback);
       if (fallbackConstructor != null) {
-        defaultCase =
-            'return ${fallbackConstructor.redirectedName}$genericParameters.fromJson(json${fromJsonArguments(genericParameters, genericArgumentFactories)});';
+        defaultCase = '''
+return ${fallbackConstructor.redirectedName}${clazz.genericsParameterTemplate}.fromJson(
+  json${fromJsonArguments(clazz.genericsParameterTemplate, clazz.options.genericArgumentFactories)}
+);''';
       }
 
       content = '''
-        switch (json['$unionKey']) {
+        switch (json['${clazz.options.annotation.unionKey}']) {
           $cases
           default:
             $defaultCase
@@ -76,7 +74,9 @@ Rename one or the other, such that they don't conflict.
     }
 
     return '''
-$name$genericParameters _\$${name.public}FromJson$genericDefinitions(Map<String, dynamic> json${fromJsonParameters(genericParameters, genericArgumentFactories)}) {
+${clazz.name}${clazz.genericsParameterTemplate} _\$${clazz.name.public}FromJson${clazz.genericsDefinitionTemplate}(
+  Map<String, dynamic> json${fromJsonParameters(clazz.genericsParameterTemplate, clazz.options.genericArgumentFactories)}
+) {
 $content
 }
 ''';

--- a/packages/freezed/lib/src/templates/parameter_template.dart
+++ b/packages/freezed/lib/src/templates/parameter_template.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:collection/collection.dart';
 import 'package:freezed/src/ast.dart';
 import 'package:freezed/src/templates/concrete_template.dart';
 import 'package:freezed/src/templates/properties.dart';
@@ -137,6 +138,51 @@ class ParametersTemplate {
       optionalPositionalParameters:
           optionalPositionalParameters.map(cb).toList(),
       namedParameters: namedParameters.map(cb).toList(),
+    );
+  }
+
+  ParametersTemplate mapParameters2(
+    (
+      Parameter, {
+      bool isNamed,
+      bool isRequired,
+    })
+        Function(
+      Parameter parameter, {
+      required bool isNamed,
+      required bool isRequired,
+      required int? index,
+    }) cb,
+  ) {
+    final parameters = [
+      ...requiredPositionalParameters.mapIndexed((index, e) => cb(
+            e,
+            isNamed: false,
+            isRequired: true,
+            index: index,
+          )),
+      ...optionalPositionalParameters.mapIndexed((index, e) => cb(
+            e,
+            isNamed: false,
+            isRequired: false,
+            index: index,
+          )),
+      ...namedParameters.map(
+        (e) => cb(e, isNamed: true, isRequired: e.isRequired, index: null),
+      ),
+    ];
+
+    return ParametersTemplate(
+      parameters
+          .where((e) => e.isNamed == false && e.isRequired == true)
+          .map((e) => e.$1)
+          .toList(),
+      optionalPositionalParameters: parameters
+          .where((e) => e.isNamed == false && e.isRequired == false)
+          .map((e) => e.$1)
+          .toList(),
+      namedParameters:
+          parameters.where((e) => e.isNamed == true).map((e) => e.$1).toList(),
     );
   }
 

--- a/packages/freezed/lib/src/templates/parameter_template.dart
+++ b/packages/freezed/lib/src/templates/parameter_template.dart
@@ -277,37 +277,72 @@ class Parameter {
   }
 }
 
+class SuperParameter extends Parameter {
+  SuperParameter({
+    required super.name,
+    required super.type,
+    required super.defaultValueSource,
+    required super.isFinal,
+    required super.isNullable,
+    required super.isRequired,
+    required super.isDartList,
+    required super.isDartMap,
+    required super.isDartSet,
+    required super.decorators,
+    required super.doc,
+    required super.isPossiblyDartCollection,
+    required super.parameterElement,
+  }) : super(showDefaultValue: true);
+
+  SuperParameter.fromParameter(Parameter p)
+      : this(
+          name: p.name,
+          type: p.type,
+          isNullable: p.isNullable,
+          defaultValueSource: p.defaultValueSource,
+          isFinal: p.isFinal,
+          isRequired: p.isRequired,
+          isDartList: p.isDartList,
+          isDartMap: p.isDartMap,
+          isDartSet: p.isDartSet,
+          decorators: p.decorators,
+          doc: p.doc,
+          isPossiblyDartCollection: p.isPossiblyDartCollection,
+          parameterElement: p.parameterElement,
+        );
+
+  @override
+  String toString() {
+    var res = 'super.$name';
+    if (isRequired) {
+      res = 'required $res';
+    }
+    if (decorators.isNotEmpty) {
+      res = '${decorators.join()} $res';
+    }
+    if (showDefaultValue && defaultValueSource != null) {
+      res = '$res = $defaultValueSource';
+    }
+    return res;
+  }
+}
+
 class LocalParameter extends Parameter {
   LocalParameter({
-    required String name,
-    required String? type,
-    required String? defaultValueSource,
-    required bool isFinal,
-    required bool isNullable,
-    required bool isRequired,
-    required bool isDartList,
-    required bool isDartMap,
-    required bool isDartSet,
-    required List<String> decorators,
-    required String doc,
-    required bool isPossiblyDartCollection,
-    required ParameterElement? parameterElement,
-  }) : super(
-          name: name,
-          type: type,
-          isFinal: isFinal,
-          isNullable: isNullable,
-          showDefaultValue: true,
-          isRequired: isRequired,
-          isDartList: isDartList,
-          isDartMap: isDartMap,
-          isDartSet: isDartSet,
-          decorators: decorators,
-          defaultValueSource: defaultValueSource,
-          doc: doc,
-          isPossiblyDartCollection: isPossiblyDartCollection,
-          parameterElement: parameterElement,
-        );
+    required super.name,
+    required super.type,
+    required super.defaultValueSource,
+    required super.isFinal,
+    required super.isNullable,
+    required super.isRequired,
+    required super.isDartList,
+    required super.isDartMap,
+    required super.isDartSet,
+    required super.decorators,
+    required super.doc,
+    required super.isPossiblyDartCollection,
+    required super.parameterElement,
+  }) : super(showDefaultValue: true);
 
   LocalParameter.fromParameter(Parameter p)
       : this(
@@ -344,36 +379,21 @@ class LocalParameter extends Parameter {
 
 class CallbackParameter extends Parameter {
   CallbackParameter({
-    required String name,
-    required String defaultValueSource,
-    required String type,
-    required bool isRequired,
-    required bool isFinal,
-    required bool isDartList,
-    required bool isDartMap,
-    required bool isDartSet,
-    required bool isNullable,
-    required List<String> decorators,
     required this.parameters,
-    required String doc,
-    required bool isPossiblyDartCollection,
-    required ParameterElement? parameterElement,
-  }) : super(
-          name: name,
-          type: type,
-          isNullable: isNullable,
-          showDefaultValue: false,
-          isRequired: isRequired,
-          isFinal: isFinal,
-          isDartList: isDartList,
-          isDartMap: isDartMap,
-          isDartSet: isDartSet,
-          decorators: decorators,
-          defaultValueSource: defaultValueSource,
-          doc: doc,
-          isPossiblyDartCollection: isPossiblyDartCollection,
-          parameterElement: parameterElement,
-        );
+    required super.name,
+    required super.defaultValueSource,
+    required super.type,
+    required super.isRequired,
+    required super.isFinal,
+    required super.isDartList,
+    required super.isDartMap,
+    required super.isDartSet,
+    required super.isNullable,
+    required super.decorators,
+    required super.doc,
+    required super.isPossiblyDartCollection,
+    required super.parameterElement,
+  }) : super(showDefaultValue: false);
 
   final ParametersTemplate parameters;
 

--- a/packages/freezed/test/deep_copy_test.dart
+++ b/packages/freezed/test/deep_copy_test.dart
@@ -450,6 +450,15 @@ void main() {
     });
   });
 
+  test('DeepWithManualField', () {
+    final value = DeepWithManualField(ManualField(42));
+
+    expect(
+      value.copyWith.manual(value: 21),
+      DeepWithManualField(ManualField(21)),
+    );
+  });
+
   group('Company', () {
     group('From subclass, copyWith parameters are not typed as Object', () {
       test('Company.copyWith', () async {

--- a/packages/freezed/test/integration/deep_copy.dart
+++ b/packages/freezed/test/integration/deep_copy.dart
@@ -3,6 +3,19 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'deep_copy.freezed.dart';
 
 @freezed
+abstract class DeepWithManualField with _$DeepWithManualField {
+  const factory DeepWithManualField(ManualField manual) = _DeepWithManualField;
+}
+
+@freezed
+abstract class ManualField with _$ManualField {
+  const ManualField._(this.value);
+  const factory ManualField(int value) = _ManualField;
+
+  final int value;
+}
+
+@freezed
 abstract class Company with _$Company {
   factory Company({String? name, Director? director}) = CompanySubclass;
 }

--- a/packages/freezed/test/integration/deep_copy.dart
+++ b/packages/freezed/test/integration/deep_copy.dart
@@ -9,7 +9,7 @@ abstract class DeepWithManualField with _$DeepWithManualField {
 
 @freezed
 abstract class ManualField with _$ManualField {
-  const ManualField._(this.value);
+  const ManualField._({required this.value});
   const factory ManualField(int value) = _ManualField;
 
   final int value;

--- a/packages/freezed/test/integration/multiple_constructors.dart
+++ b/packages/freezed/test/integration/multiple_constructors.dart
@@ -3,12 +3,33 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'multiple_constructors.freezed.dart';
 
 @freezed
+abstract class ManualPositionInAnyOrder with _$ManualPositionInAnyOrder {
+  const ManualPositionInAnyOrder._(this.a, this.b);
+  const factory ManualPositionInAnyOrder(String a, int b) =
+      _ManualPositionInAnyOrder;
+  const factory ManualPositionInAnyOrder.other(int b, String a) =
+      _ManualPositionInAnyOrder2;
+
+  final String a;
+  final int b;
+}
+
+@freezed
+abstract class ManualNamedOptionalProperty with _$ManualNamedOptionalProperty {
+  const ManualNamedOptionalProperty._({this.value = 0});
+  const factory ManualNamedOptionalProperty(int value) = _ManualNamedProperty;
+  const factory ManualNamedOptionalProperty.a() = _ManualNamedPropertyA;
+
+  final int value;
+}
+
+@freezed
 abstract class Subclass with _$Subclass {
-  const Subclass._(this.value);
+  const Subclass._({required this.value});
   const factory Subclass.a(int value) = _SubclassA;
   const factory Subclass.b(int value) = _SubclassB;
 
-  // Check that no @override is needed
+  // Check that no @override is nu
   final int value;
 }
 

--- a/packages/freezed/test/integration/multiple_constructors.dart
+++ b/packages/freezed/test/integration/multiple_constructors.dart
@@ -2,6 +2,16 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'multiple_constructors.freezed.dart';
 
+@freezed
+abstract class Subclass with _$Subclass {
+  const Subclass._(this.value);
+  const factory Subclass.a(int value) = _SubclassA;
+  const factory Subclass.b(int value) = _SubclassB;
+
+  // Check that no @override is needed
+  final int value;
+}
+
 @unfreezed
 abstract class UnfreezedImmutableUnion with _$UnfreezedImmutableUnion {
   factory UnfreezedImmutableUnion(final String a) =

--- a/packages/freezed/test/integration/single_class_constructor.dart
+++ b/packages/freezed/test/integration/single_class_constructor.dart
@@ -14,7 +14,7 @@ class Base {
 
 @freezed
 abstract class Subclass extends Base with _$Subclass {
-  Subclass._(super.value) : super.named();
+  const Subclass._(super.value) : super.named();
   const factory Subclass(int value) = _Subclass;
 }
 

--- a/packages/freezed/test/integration/single_class_constructor.dart
+++ b/packages/freezed/test/integration/single_class_constructor.dart
@@ -7,6 +7,17 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'single_class_constructor.freezed.dart';
 
+class Base {
+  const Base.named(this.value);
+  final int value;
+}
+
+@freezed
+abstract class Subclass extends Base with _$Subclass {
+  Subclass._(super.value) : super.named();
+  const factory Subclass(int value) = _Subclass;
+}
+
 @freezed
 abstract class Dynamic with _$Dynamic {
   factory Dynamic({

--- a/packages/freezed/test/integration/single_class_constructor.dart
+++ b/packages/freezed/test/integration/single_class_constructor.dart
@@ -8,13 +8,14 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'single_class_constructor.freezed.dart';
 
 class Base {
-  const Base.named(this.value);
+  const Base.named(this.value, {required this.named});
   final int value;
+  final String named;
 }
 
 @freezed
 abstract class Subclass extends Base with _$Subclass {
-  const Subclass._(super.value) : super.named();
+  const Subclass._(super.value, {super.named = ''}) : super.named();
   const factory Subclass(int value) = _Subclass;
 }
 

--- a/packages/freezed/test/single_class_constructor_test.dart
+++ b/packages/freezed/test/single_class_constructor_test.dart
@@ -184,6 +184,28 @@ Future<void> main() async {
     );
   });
 
+  test('Subclass', () {
+    expect(
+      Subclass(42),
+      Subclass(42),
+    );
+
+    expect(
+      Subclass(42).hashCode,
+      Subclass(42).hashCode,
+    );
+
+    expect(
+      Subclass(42).copyWith(value: 21),
+      Subclass(21),
+    );
+
+    expect(
+      Subclass(42).toString(),
+      'Subclass(value: 42)',
+    );
+  });
+
   test('WithAlias', () {
     // ignore: unused_local_variable
     Some<Complex<Type>> value = WithAliasFirst();

--- a/packages/freezed/test/source_gen_src.dart
+++ b/packages/freezed/test/source_gen_src.dart
@@ -105,7 +105,7 @@ abstract class Mixed {
 
 @ShouldThrow(
   'Classes decorated with @freezed can only have a single non-factory'
-  ', without parameters, and named MyClass._()',
+  ', and must be named MyClass._()',
 )
 @freezed
 abstract class MultipleConcreteConstructors {
@@ -115,20 +115,32 @@ abstract class MultipleConcreteConstructors {
 
 @ShouldThrow(
   'Classes decorated with @freezed can only have a single non-factory'
-  ', without parameters, and named MyClass._()',
+  ', and must be named MyClass._()',
 )
 @freezed
 abstract class SingleConcreteConstructorInvalidName {
   SingleConcreteConstructorInvalidName();
 }
 
-@ShouldThrow(
-  'Classes decorated with @freezed can only have a single non-factory'
-  ', without parameters, and named MyClass._()',
-)
+@ShouldThrow('''
+The constructor MyClass._() specified a positional parameter named a,
+but at least one constructor does not have a matching parameter.
+
+When specifying fields in MyClass._(), either:
+- the parameter should be named
+- or all constructors in the class should specify that parameter.
+''')
 @freezed
 abstract class ConcreteConstructorWithParameters {
-  ConcreteConstructorWithParameters(int a);
+  ConcreteConstructorWithParameters._(int a);
+
+  factory ConcreteConstructorWithParameters() =
+      _ConcreteConstructorWithParameters;
+}
+
+class _ConcreteConstructorWithParameters
+    implements ConcreteConstructorWithParameters {
+  _ConcreteConstructorWithParameters();
 }
 
 @ShouldThrow(


### PR DESCRIPTION
First steps toward inheritance & dynamic default values.

This adds support for defining values in the `._()` constructor:

```dart
@freezed
abstract class Example with _$Example {
  Example._(Duration? duration)
    : duration ??= DateTime.now();

  factory Example({Duration? duration}) = _Example;
  <... other constructors if need be>

  final Duration? duration;
}
```





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced breaking changes requiring Freezed classes to be defined as abstract, sealed, or explicitly implementing an interface.
	- Added support for inheritance with dynamic default values, expanding the capabilities for immutable data models.
	- New immutable data structures and flexible constructor patterns have been incorporated.

- **Refactor**
	- Refined API signatures and streamlined parameter and property management for improved consistency.

- **Tests**
	- Expanded test coverage to verify enhanced copy functionality and ensure predictable behavior of new structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->