### PR TITLE
remove addDebugFillProperties in mixin

### DIFF
--- a/packages/freezed/lib/src/templates/abstract_template.dart
+++ b/packages/freezed/lib/src/templates/abstract_template.dart
@@ -41,7 +41,7 @@ mixin _\$${data.name.public}${data.genericsDefinitionTemplate} {
 
 $abstractProperties
 ${copyWith?.copyWithGetter(needsCast: true) ?? ''}
-${methods(data, globalData, properties: commonProperties, name: data.name, escapedName: data.escapedName, source: Source.mixin)}
+${methods(data, globalData, properties: commonProperties, name: data.name, escapedName: data.escapedName, source: Source.mixin, addDebugFillProperties: false)}
 }
 
 ${copyWith?.commonInterface ?? ''}

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -326,10 +326,11 @@ String methods(
   required String name,
   required String escapedName,
   required Source source,
+  bool addDebugFillProperties = true,
 }) {
   return '''
 ${toJson(data, name: name, source: source)}
-${debugFillProperties(data, globalData, properties, escapedClassName: escapedName)}
+${addDebugFillProperties ? debugFillProperties(data, globalData, properties, escapedClassName: escapedName) : ''}
 ${operatorEqualMethod(data, properties, className: name, source: source)}
 ${hashCodeMethod(data, properties, source: source)}
 ${toStringMethod(data, globalData, escapedClassName: escapedName, properties: properties)}

--- a/packages/freezed_lint/example/pubspec.yaml
+++ b/packages/freezed_lint/example/pubspec.yaml
@@ -16,3 +16,4 @@ dev_dependencies:
 dependency_overrides:
   freezed_lint:
     path: ../
+  freezed_annotation: ^3.0.0

--- a/packages/freezed_lint/pubspec.yaml
+++ b/packages/freezed_lint/pubspec.yaml
@@ -14,6 +14,9 @@ dependencies:
   custom_lint_builder: ^0.7.3
   freezed_annotation: ^3.0.0
 
+dependency_overrides: 
+  freezed_annotation: ^3.0.0
+
 dev_dependencies:
   custom_lint: ^0.7.3
   build_verify: ^3.1.0

--- a/packages/freezed_lint/pubspec.yaml
+++ b/packages/freezed_lint/pubspec.yaml
@@ -11,10 +11,10 @@ environment:
 dependencies:
   analyzer: ^7.0.0
   analyzer_plugin: ^0.12.0
-  custom_lint_builder: ^0.7.1
+  custom_lint_builder: ^0.7.3
   freezed_annotation: ^3.0.0
 
 dev_dependencies:
-  custom_lint: ^0.7.1
+  custom_lint: ^0.7.3
   build_verify: ^3.1.0
   test: ^1.22.2


### PR DESCRIPTION
![Ảnh màn hình 2025-02-26 lúc 09 29 53](https://github.com/user-attachments/assets/7c95eea0-de6a-42db-b9e9-a7be56ebcc26)

Hi . im using freezed 3.0.0 and saw it was generate `addDebugFillProperties` inside mixin class and it cause error

Maybe fixed : https://github.com/rrousselGit/freezed/issues/1163 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced an optional parameter to control debug output in object representations, allowing developers to customize the level of debugging information shown.
- **Refactor**
  - Enhanced the handling of debug details for a more flexible debugging experience. 
- **Chores**
  - Updated dependency versions for improved performance and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->