### PR TITLE
Fixed equality comparison and toString bugs in inherited child classes

### DIFF
--- a/packages/freezed/lib/src/models.dart
+++ b/packages/freezed/lib/src/models.dart
@@ -505,9 +505,10 @@ class Class {
     required this.superCall,
     required this.properties,
     required this.copyWithTarget,
-    required ClassDeclaration node,
-  }) : _node = node,
-       assert(constructors.isNotEmpty);
+    required this.node,
+  }) {
+    assert(constructors.isNotEmpty);
+  }
 
   final String name;
   final ClassConfig options;
@@ -518,7 +519,7 @@ class Class {
   final ConstructorInvocation? superCall;
   final CopyWithTarget? copyWithTarget;
   final PropertyList properties;
-  final ClassDeclaration _node;
+  final ClassDeclaration node;
   final Set<Class> parents = {};
 
   static Class _from(
@@ -687,9 +688,9 @@ class Class {
 
       // If a Freezed class extends another Freezed class, mark it as a parent
       final superTypes = [
-        if (clazz._node.extendsClause case final extend?) extend.superclass,
-        ...?clazz._node.implementsClause?.interfaces,
-        ...?clazz._node.withClause?.mixinTypes,
+        if (clazz.node.extendsClause case final extend?) extend.superclass,
+        ...?clazz.node.implementsClause?.interfaces,
+        ...?clazz.node.withClause?.mixinTypes,
       ].map((e) => e.name2.lexeme);
 
       for (final superType in superTypes) {


### PR DESCRIPTION
Hello.

I am using this plugin very well.
I am very happy that inheritance was added after upgrading to 3.0.

However, there was a problem that I could not use the parent class for equality comparison and toString().

I saw an issue and someone had the same problem.(#1194)

I modified the code. Can you check it for me?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the object initialization process for more consistent property handling.
- **New Features**
  - Enhanced output behaviors to include parent class details, resulting in clearer object representations and more robust equality comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->