### PR TITLE
Fix  (#1223) Classic class copyWith Adds Unnecessary Bang Operator Nullable Unspecified Generic Types, Causing Runtime Exceptions

### DIFF
--- a/packages/freezed/lib/src/templates/copy_with.dart
+++ b/packages/freezed/lib/src/templates/copy_with.dart
@@ -286,7 +286,31 @@ $s''';
       }
 
       var cast = '';
-      if (propertyGetterForCopyWithParameter.type != to.type) cast = '!';
+      final fieldType = propertyGetterForCopyWithParameter.type;
+      final paramType = to.type;
+      final fieldIsNullable = propertyGetterForCopyWithParameter.isNullable;
+      final paramIsNullable = to.isNullable;
+
+      if (paramType == null) {
+        if (!fieldIsNullable) cast = '!';
+      } else {
+        final fieldBaseType = fieldType.endsWith('?')
+            ? fieldType.substring(0, fieldType.length - 1)
+            : fieldType;
+        final paramBaseType = paramType.endsWith('?')
+            ? paramType.substring(0, paramType.length - 1)
+            : paramType;
+
+        if (fieldIsNullable && !paramIsNullable) {
+          cast = '!';
+        } else if (!fieldIsNullable && paramIsNullable) {
+          cast = '';
+        } else if (!fieldIsNullable &&
+            !paramIsNullable &&
+            fieldBaseType != paramBaseType) {
+          cast = '!';
+        }
+      }
 
       return '$accessor.$propertyName$cast';
     }

--- a/packages/freezed/test/generic_test.dart
+++ b/packages/freezed/test/generic_test.dart
@@ -130,4 +130,11 @@ void main() {
       throwsCompileError,
     );
   });
+
+  test(
+      'copyWith null innerData does not throw when using classic class style, unspecified generic',
+      () {
+    final state = ClassicUnspecifiedOuter(innerData: null);
+    expect(() => state.copyWith(), returnsNormally);
+  });
 }

--- a/packages/freezed/test/integration/generic.dart
+++ b/packages/freezed/test/integration/generic.dart
@@ -66,3 +66,17 @@ abstract class Inner<I> with _$Inner<I> {
 abstract class Outer with _$Outer {
   const factory Outer({Inner<int>? innerData}) = _Outer;
 }
+
+@freezed
+abstract class InnerExtends<I extends Object> with _$InnerExtends<I> {
+  const factory InnerExtends({I? data}) = _InnerExtends<I>;
+}
+
+@freezed
+class ClassicUnspecifiedOuter with _$ClassicUnspecifiedOuter {
+  @override
+  // ignore: strict_raw_type
+  final InnerExtends? innerData;
+
+  const ClassicUnspecifiedOuter({this.innerData});
+}


### PR DESCRIPTION
Fixes #1223 

Please see issue for full details.

I have done it in two commits, so you can check out the first commit to see the failing tests with original code, then check out the second commit and run the generator, then run the tests to see the passing tests. 

**_BTW, if the inner generic does not extend anything, the generated code doesn't specify the `<dynamic>` and it creates a lint warning for strict_raw_type in the generated file, which is why i added `<I extends Object>` to get the build passing._**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new abstract class, `InnerExtends`, and a new immutable data class, `ClassicUnspecifiedOuter`, enhancing handling of optional inner values.

- **Refactor**
  - Improved the internal logic for managing type conversions and null-safety, ensuring more accurate behavior.

- **Tests**
  - Added test cases to verify that the `copyWith` method correctly handles scenarios with null inner data without triggering errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->