### PR TITLE
docs: simplify dependency installation commands by grouping packages

### DIFF
--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -83,7 +83,10 @@ First, install [build_runner] and [Freezed] by adding them to your `pubspec.yaml
 For a Flutter project:
 
 ```console
-flutter pub add dev:build_runner freezed_annotation dev:freezed
+flutter pub add \
+  dev:build_runner \
+  freezed_annotation \
+  dev:freezed
 # if using freezed to generate fromJson/toJson, also add:
 flutter pub add json_annotation dev:json_serializable
 ```
@@ -91,7 +94,10 @@ flutter pub add json_annotation dev:json_serializable
 For a Dart project:
 
 ```console
-dart pub add dev:build_runner freezed_annotation dev:freezed
+dart pub add \
+  dev:build_runner \
+  freezed_annotation \
+  dev:freezed
 # if using freezed to generate fromJson/toJson, also add:
 dart pub add json_annotation dev:json_serializable
 ```

--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -83,23 +83,17 @@ First, install [build_runner] and [Freezed] by adding them to your `pubspec.yaml
 For a Flutter project:
 
 ```console
-flutter pub add freezed_annotation
-flutter pub add dev:build_runner
-flutter pub add dev:freezed
+flutter pub add dev:build_runner freezed_annotation dev:freezed
 # if using freezed to generate fromJson/toJson, also add:
-flutter pub add json_annotation
-flutter pub add dev:json_serializable
+flutter pub add json_annotation dev:json_serializable
 ```
 
 For a Dart project:
 
 ```console
-dart pub add freezed_annotation
-dart pub add dev:build_runner
-dart pub add dev:freezed
+dart pub add dev:build_runner freezed_annotation dev:freezed
 # if using freezed to generate fromJson/toJson, also add:
-dart pub add json_annotation
-dart pub add dev:json_serializable
+dart pub add json_annotation dev:json_serializable
 ```
 
 This installs three packages:


### PR DESCRIPTION
Allows users to copy-paste commands and run them at once instead of copying each command and running it separately. This is also a bit more readable since `build_runner` is always required when using `freezed`, and both `freezed` and `freezed_annotation` are required at the same time to use Freezed. While `json_serializable` can be slightly unrelated since serialization is not part of data classes, and it makes sense to separate them in case the user doesn't need JSON serialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified installation instructions by combining related package dependencies into single command lines for Flutter and Dart projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->