### PR TITLE
Migrate to analyzer element2 model

### DIFF
--- a/packages/freezed/CHANGELOG.md
+++ b/packages/freezed/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.2.0-dev
+## Unreleased 3.2.0-dev
 
 - Use `build` 3.0.0-dev.
 - Use `source_gen` 3.0.0-dev.

--- a/packages/freezed/CHANGELOG.md
+++ b/packages/freezed/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.0-dev
+
+- Use `build` 3.0.0-dev.
+- Use `source_gen` 3.0.0-dev.
 - Support Dart 3.8.0 and analyzer 7.5.9 as a minumum.
 
 ## 3.1.0 - 2025-07-02

--- a/packages/freezed/lib/src/ast.dart
+++ b/packages/freezed/lib/src/ast.dart
@@ -1,6 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 
 extension AstX on AstNode {
   String? get documentation {
@@ -22,16 +22,16 @@ extension AstX on AstNode {
 
 extension ClassX on ClassDeclaration {
   bool get hasCustomToString {
-    final element = declaredElement!;
+    final element = declaredFragment!.element;
 
     for (final type in [
       element,
       ...element.allSupertypes
           .where((e) => !e.isDartCoreObject)
-          .map((e) => e.element),
+          .map((e) => e.element3),
     ]) {
-      for (final method in type.methods) {
-        if (method.name == 'toString') {
+      for (final method in type.methods2) {
+        if (method.name3 == 'toString') {
           return true;
         }
       }
@@ -40,56 +40,52 @@ extension ClassX on ClassDeclaration {
     return false;
   }
 
-  bool get hasSuperEqual => declaredElement!.allSupertypes
+  bool get hasSuperEqual => declaredFragment!.element.allSupertypes
       .where((e) => !e.isDartCoreObject)
-      .map((e) => e.element)
+      .map((e) => e.element3)
       .any((e) => e.hasEqual);
 
-  bool get hasCustomEquals => declaredElement!.hasEqual;
+  bool get hasCustomEquals => declaredFragment!.element.hasEqual;
 
-  bool get hasSuperHashCode => declaredElement!.allSupertypes
+  bool get hasSuperHashCode => declaredFragment!.element.allSupertypes
       .where((e) => !e.isDartCoreObject)
-      .map((e) => e.element)
+      .map((e) => e.element3)
       .any((e) => e.hasHashCode);
 }
 
-extension on InterfaceElement {
-  bool get hasEqual => methods.any(((e) => e.isOperator && e.name == '=='));
+extension on InterfaceElement2 {
+  bool get hasEqual => methods2.any(((e) => e.isOperator && e.name3 == '=='));
 
-  bool get hasHashCode =>
-      accessors.where((e) => e.isGetter).any((e) => e.name == 'hashCode');
+  bool get hasHashCode => getters2.any((e) => e.name3 == 'hashCode');
 }
 
 extension ConstructorX on ConstructorDeclaration {
   String get fullName {
-    // ignore: deprecated_member_use, latest analyzer with enclosingElement3 not available in stable channel
-    final classElement = declaredElement!.enclosingElement3;
+    final classElement = declaredFragment!.element.enclosingElement2;
 
-    var generics = classElement.typeParameters
-        .map((e) => '\$${e.name}')
+    var generics = classElement.typeParameters2
+        .map((e) => '\$${e.name3}')
         .join(', ');
     if (generics.isNotEmpty) {
       generics = '<$generics>';
     }
 
-    // ignore: deprecated_member_use, latest analyzer with enclosingElement3 not available in stable channel
-    final className = classElement.enclosingElement3.name;
+    final className = classElement.enclosingElement2.name3;
 
     return name == null ? '$className$generics' : '$className$generics.$name';
   }
 
   String get escapedName {
-    // ignore: deprecated_member_use, latest analyzer with enclosingElement3 not available in stable channel
-    final classElement = declaredElement!.enclosingElement3;
+    final classElement = declaredFragment!.element.enclosingElement2;
 
-    var generics = classElement.typeParameters
-        .map((e) => '\$${e.name}')
+    var generics = classElement.typeParameters2
+        .map((e) => '\$${e.name3}')
         .join(', ');
     if (generics.isNotEmpty) {
       generics = '<$generics>';
     }
 
-    final escapedElementName = classElement.name.replaceAll(r'$', r'\$');
+    final escapedElementName = classElement.name3!.replaceAll(r'$', r'\$');
     final escapedConstructorName = name?.lexeme.replaceAll(r'$', r'\$');
 
     return escapedConstructorName == null

--- a/packages/freezed/lib/src/parse_generator.dart
+++ b/packages/freezed/lib/src/parse_generator.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:collection/collection.dart';
 import 'package:source_gen/source_gen.dart';
@@ -20,7 +20,7 @@ abstract class ParserGenerator<AnnotationT>
     if (oldLibrary.classes.isEmpty) return '';
 
     final units = await Stream.fromFutures(
-      oldLibrary.element.units.map(
+      oldLibrary.element.fragments.map(
         (e) => buildStep.resolver.astNodeFor(e, resolve: true),
       ),
     ).cast<CompilationUnit>().toList();
@@ -30,11 +30,11 @@ abstract class ParserGenerator<AnnotationT>
 
     for (final unit in units) {
       for (var declaration in unit.declarations) {
-        final declaredElement = declaration.declaredElement;
-        if (declaredElement == null) continue;
+        final declaredFragment = declaration.declaredFragment;
+        if (declaredFragment == null) continue;
 
         final annotation = typeChecker.firstAnnotationOf(
-          declaredElement,
+          declaredFragment.element,
           throwOnUnresolved: false,
         );
         if (annotation == null) continue;
@@ -57,7 +57,7 @@ abstract class ParserGenerator<AnnotationT>
 
   @override
   Stream<String> generateForAnnotatedElement(
-    Element element,
+    Element2 element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async* {
@@ -70,11 +70,12 @@ abstract class ParserGenerator<AnnotationT>
     if (annotation == null) return;
 
     final unit = await element.session!.getResolvedUnit(
-      element.source!.fullName,
+      element.firstFragment.libraryFragment!.source.fullName,
     );
     unit as ResolvedUnitResult;
     final Object? ast = unit.unit.declarations.firstWhereOrNull(
-      (declaration) => declaration.declaredElement?.name == element.name!,
+      (declaration) =>
+          declaration.declaredFragment?.element.name3 == element.name3!,
     );
     if (ast == null) {
       throw InvalidGenerationSourceError('Ast not found', element: element);

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:freezed/src/freezed_generator.dart';
 import 'package:freezed/src/models.dart';
 import 'package:freezed/src/templates/properties.dart';
@@ -513,20 +513,20 @@ int get hashCode => Object.hash(${hashedProperties.join(',')});
 ''';
 }
 
-extension DefaultValue on ParameterElement {
+extension DefaultValue on FormalParameterElement {
   /// Returns the sources of the default value associated with a `@Default`,
   /// or `null` if no `@Default` are specified.
   String? get defaultValue {
     const matcher = TypeChecker.fromRuntime(Default);
 
-    for (final meta in metadata) {
+    for (final meta in metadata2.annotations) {
       final obj = meta.computeConstantValue()!;
       if (matcher.isExactlyType(obj.type!)) {
         final source = meta.toSource();
         final res = source.substring('@Default('.length, source.length - 1);
 
         var needsConstModifier =
-            !declaration.type.isDartCoreString &&
+            !baseElement.type.isDartCoreString &&
             !res.trimLeft().startsWith('const') &&
             (res.contains('(') || res.contains('[') || res.contains('{'));
 
@@ -558,5 +558,5 @@ String parseTypeSource(FormalParameter p) {
       break;
   }
 
-  return p.declaredElement!.type.getDisplayString();
+  return p.declaredFragment!.element.type.getDisplayString();
 }

--- a/packages/freezed/lib/src/templates/parameter_template.dart
+++ b/packages/freezed/lib/src/templates/parameter_template.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:collection/collection.dart';
 import 'package:freezed/src/ast.dart';
@@ -11,10 +11,10 @@ class GenericsDefinitionTemplate {
   GenericsDefinitionTemplate(this.typeParameters);
 
   factory GenericsDefinitionTemplate.fromGenericElement(
-    List<TypeParameterElement> generics,
+    List<TypeParameterElement2> generics,
   ) {
     return GenericsDefinitionTemplate(
-      generics.map((e) => e.getDisplayString()).toList(),
+      generics.map((e) => e.displayString2()).toList(),
     );
   }
 
@@ -36,9 +36,9 @@ class GenericsParameterTemplate {
   GenericsParameterTemplate(this.typeParameters);
 
   factory GenericsParameterTemplate.fromGenericElement(
-    List<TypeParameterElement> generics,
+    List<TypeParameterElement2> generics,
   ) {
-    return GenericsParameterTemplate(generics.map((e) => e.name).toList());
+    return GenericsParameterTemplate(generics.map((e) => e.name3!).toList());
   }
   final List<String> typeParameters;
 
@@ -67,16 +67,16 @@ class ParametersTemplate {
     required bool addImplicitFinal,
   }) {
     Parameter asParameter(FormalParameter p) {
-      final e = p.declaredElement!;
+      final e = p.declaredFragment!.element;
 
       final value = Parameter(
-        name: e.name,
+        name: e.name3!,
         defaultValueSource: e.defaultValue,
         isRequired: e.isRequiredNamed,
         isFinal: addImplicitFinal || e.isFinal,
         type: e.type,
         typeDisplayString: parseTypeSource(p),
-        decorators: parseDecorators(e.metadata),
+        decorators: parseDecorators(e.metadata2.annotations),
         doc: p.documentation ?? '',
         showDefaultValue: true,
         parameterElement: e,
@@ -244,7 +244,7 @@ class Parameter {
   final bool showDefaultValue;
   final bool isFinal;
   final String doc;
-  final ParameterElement? parameterElement;
+  final FormalParameterElement? parameterElement;
 
   Parameter copyWith({
     DartType? type,

--- a/packages/freezed/lib/src/templates/properties.dart
+++ b/packages/freezed/lib/src/templates/properties.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:freezed/src/ast.dart';
 import 'package:freezed/src/templates/parameter_template.dart';
@@ -40,11 +40,11 @@ class Property {
     required bool addImplicitFinal,
     required bool isSynthetic,
   }) {
-    final element = parameter.declaredElement!;
+    final element = parameter.declaredFragment!.element;
 
     final defaultValue = element.defaultValue;
     if (defaultValue != null &&
-        (element.hasRequired || element.isRequiredPositional)) {
+        (element.isRequired || element.isRequiredPositional)) {
       throw InvalidGenerationSourceError(
         '@Default cannot be used on non-optional parameters',
         element: element,
@@ -52,13 +52,13 @@ class Property {
     }
 
     return Property(
-      name: element.name,
+      name: element.name3!,
       isFinal: addImplicitFinal || element.isFinal,
       isSynthetic: isSynthetic,
       doc: parameter.documentation ?? '',
       type: element.type,
       typeDisplayString: parseTypeSource(parameter),
-      decorators: parseDecorators(element.metadata),
+      decorators: parseDecorators(element.metadata2.annotations),
       defaultValueSource: defaultValue,
       hasJsonKey: element.hasJsonKey,
     );
@@ -114,7 +114,7 @@ class Property {
     bool? hasJsonKey,
     String? doc,
     bool? isPossiblyDartCollection,
-    ParameterElement? parameterElement,
+    TypeParameterElement2? parameterElement,
   }) {
     return Property(
       type: type ?? this.type,

--- a/packages/freezed/lib/src/templates/prototypes.dart
+++ b/packages/freezed/lib/src/templates/prototypes.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -38,8 +38,8 @@ extension FreezedElementAnnotation on ElementAnnotation {
   }
 }
 
-bool isDefaultConstructor(ConstructorElement constructor) {
-  return constructor.name.isEmpty;
+bool isDefaultConstructor(ConstructorElement2 constructor) {
+  return constructor.name3 == 'new';
 }
 
 String constructorNameToCallbackName(String constructorName) {

--- a/packages/freezed/lib/src/tools/imports.dart
+++ b/packages/freezed/lib/src/tools/imports.dart
@@ -1,18 +1,18 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 
-extension LibraryHasImport on LibraryElement {
-  LibraryElement? findTransitiveExportWhere(
-    bool Function(LibraryElement library) visitor,
+extension LibraryHasImport on LibraryElement2 {
+  LibraryElement2? findTransitiveExportWhere(
+    bool Function(LibraryElement2 library) visitor,
   ) {
     if (visitor(this)) return this;
 
-    final visitedLibraries = <LibraryElement>{};
-    LibraryElement? visitLibrary(LibraryElement library) {
+    final visitedLibraries = <LibraryElement2>{};
+    LibraryElement2? visitLibrary(LibraryElement2 library) {
       if (!visitedLibraries.add(library)) return null;
 
       if (visitor(library)) return library;
 
-      for (final export in library.exportedLibraries) {
+      for (final export in library.exportedLibraries2) {
         final result = visitLibrary(export);
         if (result != null) return result;
       }
@@ -20,7 +20,7 @@ extension LibraryHasImport on LibraryElement {
       return null;
     }
 
-    for (final import in exportedLibraries) {
+    for (final import in exportedLibraries2) {
       final result = visitLibrary(import);
       if (result != null) return result;
     }
@@ -28,7 +28,7 @@ extension LibraryHasImport on LibraryElement {
     return null;
   }
 
-  bool anyTransitiveExport(bool Function(LibraryElement library) visitor) {
+  bool anyTransitiveExport(bool Function(LibraryElement2 library) visitor) {
     return findTransitiveExportWhere(visitor) != null;
   }
 }

--- a/packages/freezed/lib/src/tools/recursive_import_locator.dart
+++ b/packages/freezed/lib/src/tools/recursive_import_locator.dart
@@ -1,9 +1,9 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:collection/collection.dart';
 
-extension FindAllAvailableTopLevelElements on LibraryElement {
+extension FindAllAvailableTopLevelElements on LibraryElement2 {
   bool isFromPackage(String packageName) {
-    return librarySource.fullName.startsWith('/$packageName/');
+    return firstFragment.source.fullName.startsWith('/$packageName/');
   }
 
   /// Recursively loops at the import/export directives to know what is available
@@ -11,32 +11,32 @@ extension FindAllAvailableTopLevelElements on LibraryElement {
   ///
   /// This function does not guarantees that the elements returned are unique.
   /// It is possible for the same object to be present multiple times in the list.
-  Iterable<Element> findAllAvailableTopLevelElements() {
+  Iterable<Element2> findAllAvailableTopLevelElements() {
     return _findAllAvailableTopLevelElements(
       {},
       checkExports: false,
       key: _LibraryKey(
         hideStatements: {},
         showStatements: {},
-        librarySource: librarySource.fullName,
+        librarySource: firstFragment.source.fullName,
       ),
     );
   }
 
-  Iterable<Element> _findAllAvailableTopLevelElements(
+  Iterable<Element2> _findAllAvailableTopLevelElements(
     Set<_LibraryKey> visitedLibraryPaths, {
     required bool checkExports,
     required _LibraryKey key,
   }) sync* {
-    yield* topLevelElements;
+    yield* children2;
 
     final librariesToCheck = checkExports
-        ? units
-              .expand((e) => e.libraryExports)
+        ? fragments
+              .expand((e) => e.libraryExports2)
               .map(_LibraryDirectives.fromExport)
               .nonNulls
-        : units
-              .expand((e) => e.libraryImports)
+        : fragments
+              .expand((e) => e.libraryImports2)
               .map(_LibraryDirectives.fromImport)
               .nonNulls;
 
@@ -55,8 +55,8 @@ extension FindAllAvailableTopLevelElements on LibraryElement {
             return (directive.showStatements.isEmpty &&
                     directive.hideStatements.isEmpty) ||
                 (directive.hideStatements.isNotEmpty &&
-                    !directive.hideStatements.contains(element.name)) ||
-                directive.showStatements.contains(element.name);
+                    !directive.hideStatements.contains(element.name3)) ||
+                directive.showStatements.contains(element.name3);
           });
     }
   }
@@ -69,8 +69,8 @@ class _LibraryDirectives {
     required this.library,
   });
 
-  static _LibraryDirectives? fromExport(LibraryExportElement export) {
-    final library = export.exportedLibrary;
+  static _LibraryDirectives? fromExport(LibraryExport export) {
+    final library = export.exportedLibrary2;
     if (library == null) return null;
 
     final hideStatements = export.combinators
@@ -90,8 +90,8 @@ class _LibraryDirectives {
     );
   }
 
-  static _LibraryDirectives? fromImport(LibraryImportElement export) {
-    final library = export.importedLibrary;
+  static _LibraryDirectives? fromImport(LibraryImport export) {
+    final library = export.importedLibrary2;
     if (library == null) return null;
 
     final hideStatements = export.combinators
@@ -113,13 +113,13 @@ class _LibraryDirectives {
 
   final Set<String> hideStatements;
   final Set<String> showStatements;
-  final LibraryElement library;
+  final LibraryElement2 library;
 
   _LibraryKey get key {
     return _LibraryKey(
       hideStatements: hideStatements,
       showStatements: showStatements,
-      librarySource: library.source.fullName,
+      librarySource: library.firstFragment.source.fullName,
     );
   }
 }

--- a/packages/freezed/lib/src/tools/type.dart
+++ b/packages/freezed/lib/src/tools/type.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:collection/collection.dart';
@@ -24,31 +24,29 @@ extension DartTypeX on DartType {
   }
 }
 
-/// Returns the [Element] for a given [DartType]
+/// Returns the [Element2] for a given [DartType]
 ///
 /// this is usually type.element, except if it is a typedef then it is
 /// type.alias.element
-Element? _getElementForType(DartType type) {
+Element2? _getElementForType(DartType type) {
   if (type is InterfaceType) {
-    return type.element;
+    return type.element3;
   }
   if (type is FunctionType) {
-    return type.alias?.element;
+    return type.alias?.element2;
   }
   return null;
 }
 
 /// Renders a type based on its string + potential import alias
-String resolveFullTypeStringFrom(LibraryElement originLibrary, DartType type) {
-  final owner = originLibrary.units
-      .expand((e) => e.libraryImportPrefixes)
-      .firstWhereOrNull((e) {
-        return e.imports.any((l) {
-          return l.importedLibrary!.anyTransitiveExport((library) {
-            return library.id == _getElementForType(type)?.library?.id;
-          });
-        });
+String resolveFullTypeStringFrom(LibraryElement2 originLibrary, DartType type) {
+  final owner = originLibrary.firstFragment.prefixes.firstWhereOrNull((e) {
+    return e.imports.any((l) {
+      return l.importedLibrary2!.anyTransitiveExport((library) {
+        return library.id == _getElementForType(type)?.library2?.id;
       });
+    });
+  });
 
   String? displayType = type.getDisplayString();
 
@@ -64,8 +62,8 @@ String resolveFullTypeStringFrom(LibraryElement originLibrary, DartType type) {
   // 'dynamic Function(String)'
   //
   // Instead of 'SomeTypedef'
-  if (type is FunctionType && type.alias?.element != null) {
-    displayType = type.alias!.element.name;
+  if (type is FunctionType && type.alias?.element2 != null) {
+    displayType = type.alias!.element2.name3!;
     if (type.alias!.typeArguments.isNotEmpty) {
       displayType += '<${type.alias!.typeArguments.join(', ')}>';
     }
@@ -86,14 +84,14 @@ String resolveFullTypeStringFrom(LibraryElement originLibrary, DartType type) {
   // This a regression in analyzer 5.13.0
   if (type is InterfaceType &&
       type.typeArguments.any((e) => e is InvalidType)) {
-    final dynamicType = type.element.library.typeProvider.dynamicType;
+    final dynamicType = type.element3.library2.typeProvider.dynamicType;
     var modified = type;
     modified.typeArguments..replaceWhere((t) => t is InvalidType, dynamicType);
     displayType = modified.getDisplayString();
   }
 
   if (owner != null) {
-    return '${owner.name}.$displayType';
+    return '${owner.name3}.$displayType';
   }
 
   return displayType;

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -2,7 +2,7 @@ name: freezed
 description: >
   Code generation for immutable classes that has a simple syntax/API without
   compromising on the features.
-version: 3.2.0-dev
+version: 3.1.0
 repository: https://github.com/rrousselGit/freezed
 issue_tracker: https://github.com/rrousselGit/freezed/issues
 

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -11,19 +11,19 @@ environment:
 
 dependencies:
   analyzer: ">=7.5.9 <8.0.0"
-  build: ^3.0.0-dev
+  build: ^3.0.0
   build_config: ^1.1.0
   collection: ^1.15.0
   meta: ^1.9.1
-  source_gen: ^3.0.0-dev
+  source_gen: ^3.0.0
   freezed_annotation: 3.1.0
   json_annotation: ^4.8.0
   dart_style: ^3.0.0
   pub_semver: ^2.2.0
 
 dev_dependencies:
-  json_serializable: ^6.10.0-dev
-  build_test: ^3.3.0-dev.3
+  json_serializable: ^6.10.0
+  build_test: ^3.3.0
   build_runner: ^2.3.3
   test: ^1.21.0
   matcher: ^0.12.14

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -2,7 +2,7 @@ name: freezed
 description: >
   Code generation for immutable classes that has a simple syntax/API without
   compromising on the features.
-version: 3.1.0
+version: 3.2.0-dev
 repository: https://github.com/rrousselGit/freezed
 issue_tracker: https://github.com/rrousselGit/freezed/issues
 
@@ -11,19 +11,19 @@ environment:
 
 dependencies:
   analyzer: ">=7.5.9 <8.0.0"
-  build: ^2.5.0
+  build: ^3.0.0-dev
   build_config: ^1.1.0
   collection: ^1.15.0
   meta: ^1.9.1
-  source_gen: ^2.0.0
+  source_gen: ^3.0.0-dev
   freezed_annotation: 3.1.0
   json_annotation: ^4.8.0
   dart_style: ^3.0.0
   pub_semver: ^2.2.0
 
 dev_dependencies:
-  json_serializable: ^6.3.2
-  build_test: ^3.0.0
+  json_serializable: ^6.10.0-dev
+  build_test: ^3.3.0-dev.3
   build_runner: ^2.3.3
   test: ^1.21.0
   matcher: ^0.12.14

--- a/packages/freezed/test/bidirectional_test.dart
+++ b/packages/freezed/test/bidirectional_test.dart
@@ -9,7 +9,8 @@ void main() {
     final main = await resolveSources(
       {'freezed|test/integration/bidirectional.dart': useAssetReader},
       (r) => r.libraries.firstWhere(
-        (element) => element.source.toString().contains('bidirectional'),
+        (element) =>
+            element.firstFragment.source.toString().contains('bidirectional'),
       ),
     );
 

--- a/packages/freezed/test/common_types_test.dart
+++ b/packages/freezed/test/common_types_test.dart
@@ -14,7 +14,8 @@ Future<void> main() async {
     final main = await resolveSources(
       {'freezed|test/integration/common_types.dart': useAssetReader},
       (r) => r.libraries.firstWhere(
-        (element) => element.source.toString().contains('common_types'),
+        (element) =>
+            element.firstFragment.source.toString().contains('common_types'),
       ),
     );
 

--- a/packages/freezed/test/decorator_test.dart
+++ b/packages/freezed/test/decorator_test.dart
@@ -1,5 +1,4 @@
 import 'package:analyzer/dart/analysis/results.dart';
-import 'package:analyzer/dart/element/element.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
@@ -8,7 +7,8 @@ void main() {
     final main = await resolveSources(
       {'freezed|test/integration/decorator.dart': useAssetReader},
       (r) => r.libraries.firstWhere(
-        (element) => element.source.toString().contains('decorator'),
+        (element) =>
+            element.firstFragment.source.toString().contains('decorator'),
       ),
     );
 
@@ -33,26 +33,32 @@ import 'decorator.dart';
 ''',
         },
         (r) => r.libraries.firstWhere(
-          (element) => element.library.name == 'decorator',
+          (element) => element.library2.name3 == 'decorator',
         ),
         readAllSourcesFromFilesystem: true,
       );
 
-      final concrete = main.topLevelElements
-          .whereType<ClassElement>()
-          .firstWhere((e) => e.name == r'ListDecorator0');
+      final concrete = main.classes.firstWhere(
+        (e) => e.name3 == r'ListDecorator0',
+      );
 
       expect(
-        concrete.fields.firstWhere((element) => element.name == '_a').metadata,
+        concrete.fields2
+            .firstWhere((element) => element.name3 == '_a')
+            .metadata2
+            .annotations,
         isEmpty,
       );
 
-      final unmodifiableGetter = concrete.fields
-          .firstWhere((element) => element.name == 'a')
-          .getter!;
+      final unmodifiableGetter = concrete.fields2
+          .firstWhere((element) => element.name3 == 'a')
+          .getter2!;
 
-      expect(unmodifiableGetter.metadata.length, 2);
-      expect(unmodifiableGetter.metadata.last.toSource(), '@Foo()');
+      expect(unmodifiableGetter.metadata2.annotations.length, 2);
+      expect(
+        unmodifiableGetter.metadata2.annotations.last.toSource(),
+        '@Foo()',
+      );
     },
   );
 
@@ -81,7 +87,7 @@ void main() {
 ''',
       },
       (r) => r.libraries.firstWhere(
-        (element) => element.source.toString().contains('decorator'),
+        (element) => element.firstFragment.toString().contains('decorator'),
       ),
       readAllSourcesFromFilesystem: true,
     );

--- a/packages/freezed/test/deep_copy_test.dart
+++ b/packages/freezed/test/deep_copy_test.dart
@@ -20,7 +20,8 @@ void main() {
     final main = await resolveSources(
       {'freezed|test/integration/deep_copy.dart': useAssetReader},
       (r) => r.libraries.firstWhere(
-        (element) => element.source.toString().contains('deep_copy'),
+        (element) =>
+            element.firstFragment.source.toString().contains('deep_copy'),
       ),
     );
 
@@ -37,7 +38,8 @@ void main() {
     final main = await resolveSources(
       {'freezed|test/integration/deep_copy2.dart': useAssetReader},
       (r) => r.libraries.firstWhere(
-        (element) => element.source.toString().contains('deep_copy2'),
+        (element) =>
+            element.firstFragment.source.toString().contains('deep_copy2'),
       ),
     );
 
@@ -722,7 +724,8 @@ void main() {
 ''',
       },
       (r) => r.libraries.firstWhere(
-        (element) => element.source.toString().contains('deep_copy'),
+        (element) =>
+            element.firstFragment.source.toString().contains('deep_copy'),
       ),
       readAllSourcesFromFilesystem: true,
     );

--- a/packages/freezed/test/generic_test.dart
+++ b/packages/freezed/test/generic_test.dart
@@ -41,7 +41,8 @@ void main() {
     final main = await resolveSources(
       {'freezed|test/integration/generic.dart': useAssetReader},
       (r) => r.libraries.firstWhere(
-        (element) => element.source.toString().contains('generic'),
+        (element) =>
+            element.firstFragment.source.toString().contains('generic'),
       ),
     );
 

--- a/packages/freezed/test/generics_refs_test.dart
+++ b/packages/freezed/test/generics_refs_test.dart
@@ -10,7 +10,8 @@ void main() {
     final main = await resolveSources(
       {'freezed|test/integration/generics_refs.dart': useAssetReader},
       (r) => r.libraries.firstWhere(
-        (element) => element.source.toString().contains('generics_refs'),
+        (element) =>
+            element.firstFragment.source.toString().contains('generics_refs'),
       ),
     );
 

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -11,7 +11,7 @@ Future<void> main() async {
   final jsonFile = await resolveSources(
     {'freezed|test/integration/json.dart': useAssetReader},
     (r) => r.libraries.firstWhere(
-      (element) => element.source.toString().contains('json'),
+      (element) => element.firstFragment.source.toString().contains('json'),
     ),
   );
 
@@ -23,7 +23,7 @@ Future<void> main() async {
     expect(Regression280n2.fromJson('hello'), Regression280n2('hello'));
 
     expect(
-      jsonFile.topLevelElements.map((e) => e.name),
+      jsonFile.publicNamespace.definedNames2.keys.toSet(),
       allOf(
         isNot(contains(r'_$Regression280FromJson')),
         isNot(contains(r'_$Regression280ToJson')),

--- a/packages/freezed/test/multiple_constructors_test.dart
+++ b/packages/freezed/test/multiple_constructors_test.dart
@@ -2,7 +2,7 @@
 import 'dart:async';
 
 import 'package:analyzer/dart/analysis/results.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
@@ -17,16 +17,14 @@ Future<void> main() async {
     (r) {
       return r.libraries.firstWhere(
         (element) =>
-            element.source.toString().contains('multiple_constructors'),
+            element.firstFragment.toString().contains('multiple_constructors'),
       );
     },
     readAllSourcesFromFilesystem: true,
   );
 
-  ClassElement _getClassElement(String elementName) {
-    return sources.topLevelElements.whereType<ClassElement>().firstWhere(
-      (element) => element.name == elementName,
-    );
+  ClassElement2 _getClassElement(String elementName) {
+    return sources.classes.singleWhere((e) => e.name3 == elementName);
   }
 
   test('Response', () {
@@ -39,14 +37,14 @@ Future<void> main() async {
   test('recursive class does not generate dynamic', () async {
     final recursiveClass = _getClassElement('_RecursiveNext');
 
-    expect(recursiveClass.getField('value')!.type, isA<InterfaceType>());
+    expect(recursiveClass.getField2('value')!.type, isA<InterfaceType>());
   });
 
   test('recursive class with dollar generates correctly', () async {
     final recursiveClass = _getClassElement('_RecursiveWith\$DollarNext');
 
     expect(
-      recursiveClass.getField('value')!.type.getDisplayString(),
+      recursiveClass.getField2('value')!.type.getDisplayString(),
       'RecursiveWith\$DollarImpl',
     );
   });
@@ -66,54 +64,54 @@ Future<void> main() async {
     final complex2 = _getClassElement('Complex2');
 
     expect(
-      complex.mixins.first.accessors.first,
-      isA<PropertyAccessorElement>()
-          .having((e) => e.name, 'name', 'a')
+      complex.mixins.first.getters.first,
+      isA<PropertyAccessorElement2>()
+          .having((e) => e.name3, 'name', 'a')
           .having((e) => e.documentationComment, 'doc', '/// Hello'),
     );
 
     expect(
-      complex0.fields.where(
-        (e) => e.name != 'copyWith' && e.name != 'hashCode',
+      complex0.fields2.where(
+        (e) => e.name3 != 'copyWith' && e.name3 != 'hashCode',
       ),
       [
-        isA<FieldElement>()
-            .having((e) => e.name, 'name', 'a')
+        isA<FieldElement2>()
+            .having((e) => e.name3, 'name', 'a')
             .having((e) => e.documentationComment, 'doc', '/// Hello'),
       ],
     );
 
     expect(
-      complex1.fields.where(
-        (e) => e.name != 'copyWith' && e.name != 'hashCode',
+      complex1.fields2.where(
+        (e) => e.name3 != 'copyWith' && e.name3 != 'hashCode',
       ),
       [
-        isA<FieldElement>()
-            .having((e) => e.name, 'name', 'a')
+        isA<FieldElement2>()
+            .having((e) => e.name3, 'name', 'a')
             .having((e) => e.documentationComment, 'doc', '/// World'),
-        isA<FieldElement>()
-            .having((e) => e.name, 'name', 'b')
+        isA<FieldElement2>()
+            .having((e) => e.name3, 'name', 'b')
             .having((e) => e.documentationComment, 'doc', '/// B'),
-        isA<FieldElement>()
-            .having((e) => e.name, 'name', 'd')
+        isA<FieldElement2>()
+            .having((e) => e.name3, 'name', 'd')
             .having((e) => e.documentationComment, 'doc', null),
       ],
     );
 
     expect(
-      complex2.fields.where(
-        (e) => e.name != 'copyWith' && e.name != 'hashCode',
+      complex2.fields2.where(
+        (e) => e.name3 != 'copyWith' && e.name3 != 'hashCode',
       ),
       [
-        isA<FieldElement>()
-            .having((e) => e.name, 'name', 'a')
+        isA<FieldElement2>()
+            .having((e) => e.name3, 'name', 'a')
             // The doc is inherited from `Complex`
             .having((e) => e.documentationComment, 'doc', null),
-        isA<FieldElement>()
-            .having((e) => e.name, 'name', 'c')
+        isA<FieldElement2>()
+            .having((e) => e.name3, 'name', 'c')
             .having((e) => e.documentationComment, 'doc', '/// C'),
-        isA<FieldElement>()
-            .having((e) => e.name, 'name', 'd')
+        isA<FieldElement2>()
+            .having((e) => e.name3, 'name', 'd')
             .having((e) => e.documentationComment, 'doc', null),
       ],
     );
@@ -171,8 +169,9 @@ void main() {
       final main = await resolveSources(
         {'freezed|test/integration/multiple_constructors.dart': useAssetReader},
         (r) => r.libraries.firstWhere(
-          (element) =>
-              element.source.toString().contains('multiple_constructors'),
+          (element) => element.firstFragment.source.toString().contains(
+            'multiple_constructors',
+          ),
         ),
       );
 
@@ -575,7 +574,7 @@ void main() {
       final nestedListClass = _getClassElement('ShallowNestedList');
 
       expect(
-        nestedListClass.getField('children')!.type.getDisplayString(),
+        nestedListClass.getField2('children')!.type.getDisplayString(),
         'List<LeafNestedListItem>',
       );
     });
@@ -584,14 +583,14 @@ void main() {
       final nestedListClass = _getClassElement('DeepNestedList');
 
       expect(
-        nestedListClass.getField('children')!.type.getDisplayString(),
+        nestedListClass.getField2('children')!.type.getDisplayString(),
         'List<InnerNestedListItem>',
       );
 
       final nestedListItemClass = _getClassElement('InnerNestedListItem');
 
       expect(
-        nestedListItemClass.getField('children')!.type.getDisplayString(),
+        nestedListItemClass.getField2('children')!.type.getDisplayString(),
         'List<LeafNestedListItem>',
       );
     });
@@ -601,7 +600,7 @@ void main() {
       final nestedMapClass = _getClassElement('ShallowNestedMap');
 
       expect(
-        nestedMapClass.getField('children')!.type.getDisplayString(),
+        nestedMapClass.getField2('children')!.type.getDisplayString(),
         'Map<String, LeafNestedMapItem>',
       );
     });
@@ -610,14 +609,14 @@ void main() {
       final nestedMapClass = _getClassElement('DeepNestedMap');
 
       expect(
-        nestedMapClass.getField('children')!.type.getDisplayString(),
+        nestedMapClass.getField2('children')!.type.getDisplayString(),
         'Map<String, InnerNestedMapItem>',
       );
 
       final nestedMapItemClass = _getClassElement('InnerNestedMapItem');
 
       expect(
-        nestedMapItemClass.getField('children')!.type.getDisplayString(),
+        nestedMapItemClass.getField2('children')!.type.getDisplayString(),
         'Map<String, LeafNestedMapItem>',
       );
     });
@@ -628,19 +627,19 @@ void main() {
       final nestedMapClass = _getClassElement('_UsesGenerated');
 
       expect(
-        nestedMapClass.getField('value')!.type.getDisplayString(),
+        nestedMapClass.getField2('value')!.type.getDisplayString(),
         'CodeGenerated',
       );
       expect(
-        nestedMapClass.getField('list')!.type.getDisplayString(),
+        nestedMapClass.getField2('list')!.type.getDisplayString(),
         'List<CodeGenerated>',
       );
       expect(
-        nestedMapClass.getField('nestedList')!.type.getDisplayString(),
+        nestedMapClass.getField2('nestedList')!.type.getDisplayString(),
         'List<List<CodeGenerated>>',
       );
       expect(
-        nestedMapClass.getField('map')!.type.getDisplayString(),
+        nestedMapClass.getField2('map')!.type.getDisplayString(),
         'Map<int, CodeGenerated>',
       );
     });

--- a/packages/freezed/test/optional_maybe_test.dart
+++ b/packages/freezed/test/optional_maybe_test.dart
@@ -10,7 +10,8 @@ void main() {
     final main = await resolveSources(
       {'freezed|test/integration/optional_maybe.dart': useAssetReader},
       (r) => r.libraries.firstWhere(
-        (element) => element.source.toString().contains('optional_maybe'),
+        (element) =>
+            element.firstFragment.source.toString().contains('optional_maybe'),
       ),
     );
 

--- a/packages/freezed/test/single_class_constructor_test.dart
+++ b/packages/freezed/test/single_class_constructor_test.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: prefer_const_constructors, omit_local_variable_types, deprecated_member_use_from_same_package
 import 'package:analyzer/dart/analysis/results.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
@@ -25,14 +25,14 @@ class MyObject {
 }
 
 Future<void> main() async {
-  Future<LibraryElement> analyze() {
+  Future<LibraryElement2> analyze() {
     return resolveSources(
       {
         'freezed|test/integration/single_class_constructor.dart':
             useAssetReader,
       },
       (r) => r.libraries.firstWhere((e) {
-        return e.source.fullName ==
+        return e.firstFragment.source.fullName ==
             '/freezed/test/integration/single_class_constructor.dart';
       }),
       readAllSourcesFromFilesystem: true,
@@ -211,30 +211,28 @@ Future<void> main() async {
   test('documentation', () async {
     final singleClassLibrary = await analyze();
 
-    final doc =
-        singleClassLibrary.topLevelElements.firstWhere((e) => e.name == 'Doc')
-            as ClassElement;
+    final doc = singleClassLibrary.classes.firstWhere((e) => e.name3 == 'Doc');
 
     expect(
-      doc.mixins.first.accessors.where(
-        (e) => e.name != 'copyWith' && e.name != 'hashCode',
+      doc.mixins.first.getters.where(
+        (e) => e.name3 != 'copyWith' && e.name3 != 'hashCode',
       ),
       [
-        isA<PropertyAccessorElement>()
-            .having((e) => e.name, 'name', 'positional')
+        isA<PropertyAccessorElement2>()
+            .having((e) => e.name3, 'name', 'positional')
             .having((e) => e.documentationComment, 'doc', '''
 /// Multi
 /// line
 /// positional'''),
-        isA<PropertyAccessorElement>() //
-            .having((e) => e.name, 'name', 'named')
+        isA<PropertyAccessorElement2>() //
+            .having((e) => e.name3, 'name', 'named')
             .having(
               (e) => e.documentationComment,
               'doc',
               '/// Single line named',
             ),
-        isA<PropertyAccessorElement>() //
-            .having((e) => e.name, 'name', 'simple')
+        isA<PropertyAccessorElement2>() //
+            .having((e) => e.name3, 'name', 'simple')
             .having((e) => e.documentationComment, 'doc', null),
       ],
     );

--- a/packages/freezed/test/typedef_parameter_test.dart
+++ b/packages/freezed/test/typedef_parameter_test.dart
@@ -1,5 +1,4 @@
 import 'package:analyzer/dart/analysis/results.dart';
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build_test/build_test.dart';
@@ -10,7 +9,9 @@ void main() {
     final main = await resolveSources(
       {'freezed|test/integration/typedef_parameter.dart': useAssetReader},
       (r) => r.libraries.firstWhere(
-        (element) => element.source.toString().contains('typedef_parameter'),
+        (element) => element.firstFragment.source.toString().contains(
+          'typedef_parameter',
+        ),
       ),
     );
 
@@ -27,39 +28,41 @@ void main() {
     final main = await resolveSources(
       {'freezed|test/integration/typedef_parameter.dart': useAssetReader},
       (r) => r.libraries.firstWhere(
-        (element) => element.source.toString().contains('typedef_parameter'),
+        (element) => element.firstFragment.source.toString().contains(
+          'typedef_parameter',
+        ),
       ),
       readAllSourcesFromFilesystem: true,
     );
 
-    var freezedClass = main.topLevelElements
-        .whereType<ClassElement>()
-        .firstWhere((element) => element.name == '_ClassWithTypedef');
-
-    var constructor = freezedClass.constructors.firstWhere(
-      (element) => element.name == '',
+    var freezedClass = main.classes.firstWhere(
+      (element) => element.name3 == '_ClassWithTypedef',
     );
 
-    var a = constructor.parameters.first.type;
-    expect(a, isA<FunctionType>());
-    expect(a.alias!.element.name, equals('MyTypedef'));
+    var constructor = freezedClass.constructors2.firstWhere(
+      (element) => element.name3 == 'new',
+    );
 
-    var b = constructor.parameters[1].type;
+    var a = constructor.formalParameters.first.type;
+    expect(a, isA<FunctionType>());
+    expect(a.alias!.element2.name3, equals('MyTypedef'));
+
+    var b = constructor.formalParameters[1].type;
     expect(b, isA<FunctionType>());
-    expect(b.alias!.element.name, equals('MyTypedef'));
+    expect(b.alias!.element2.name3, equals('MyTypedef'));
     expect(b.nullabilitySuffix, equals(NullabilitySuffix.question));
 
-    var c = constructor.parameters[2].type;
+    var c = constructor.formalParameters[2].type;
     expect(c, isA<FunctionType>());
-    expect(c.alias!.element.name, equals('ExternalTypedef'));
+    expect(c.alias!.element2.name3, equals('ExternalTypedef'));
 
-    var d = constructor.parameters[3].type;
+    var d = constructor.formalParameters[3].type;
     expect(d, isA<FunctionType>());
-    expect(d.alias!.element.name, equals('ExternalTypedefTwo'));
+    expect(d.alias!.element2.name3, equals('ExternalTypedefTwo'));
 
-    var e = constructor.parameters[4].type;
+    var e = constructor.formalParameters[4].type;
     expect(e, isA<FunctionType>());
-    expect(e.alias!.element.name, equals('GenericTypedef'));
+    expect(e.alias!.element2.name3, equals('GenericTypedef'));
     expect(e.alias!.typeArguments.toString(), equals('[int, bool]'));
   });
 }


### PR DESCRIPTION
For #1265.

This edits pubspec+CHANGELOG as if there will be a `dev` release, but I don't think we actually need to release it, I think the actual `build 3.0.0` release will be this week or early next week.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated compatibility to support the latest Dart analyzer element2 API, ensuring continued functionality with future Dart SDKs.

* **Bug Fixes**
  * Improved internal handling of code generation and type resolution by migrating to the new analyzer APIs, reducing potential for incompatibility issues.

* **Chores**
  * Upgraded dependencies to development versions, including `build`, `source_gen`, and `json_serializable`.
  * Updated test suite to align with the new analyzer element2 API and maintain test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->