### PR TITLE
Use Dart 3.8.0, analyzer 7.5.9, reformat.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,12 @@ jobs:
           - packages/freezed_annotation
           - packages/freezed_lint
         channel:
-          - master
+          - stable
         dependencies:
           - get
           - downgrade
         exclude:
-          - channel: master
+          - channel: stable
             dependencies: downgrade
           - package: packages/freezed_lint
             channel: stable
@@ -37,7 +37,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.channel }}
-          cache: ${{ matrix.channel == 'master' }}
+          cache: ${{ matrix.channel == 'stable' }}
 
       # It is executed separately
       - name: Removing example folder
@@ -52,8 +52,8 @@ jobs:
         working-directory: ${{ matrix.package }}
 
       - name: Check format
-        # Check dart format only on master
-        if: matrix.channel == 'master'
+        # Check dart format only on stable
+        if: matrix.channel == 'stable'
         run: dart format --set-exit-if-changed .
         working-directory: ${{ matrix.package }}
 

--- a/packages/freezed/CHANGELOG.md
+++ b/packages/freezed/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Support Dart 3.8.0 and analyzer 7.5.9 as a minumum.
+
 ## 3.1.0 - 2025-07-02
 
 - Added `when`/`map` back

--- a/packages/freezed/example/lib/main.dart
+++ b/packages/freezed/example/lib/main.dart
@@ -21,15 +21,10 @@ sealed class Union with _$Union {
 
 @freezed
 abstract class SharedProperty with _$SharedProperty {
-  factory SharedProperty.person({
-    String? name,
-    int? age,
-  }) = SharedProperty0;
+  factory SharedProperty.person({String? name, int? age}) = SharedProperty0;
 
-  factory SharedProperty.city({
-    String? name,
-    int? population,
-  }) = SharedProperty1;
+  factory SharedProperty.city({String? name, int? population}) =
+      SharedProperty1;
 }
 
 void main() {
@@ -56,42 +51,37 @@ void main() {
     Complex(:final a, :final b) => 'complex $a $b',
   }); // 42
 
-  print(
-    switch (unionExample) {
-      Loading _ => 'loading',
-      // voluntarily didn't handle error/complex cases
-      _ => 42,
-    },
-  ); // 42
+  print(switch (unionExample) {
+    Loading _ => 'loading',
+    // voluntarily didn't handle error/complex cases
+    _ => 42,
+  }); // 42
 
   // ------------------
 
   // non-destructuring pattern-matching
   // works the same as `when`, but the callback is slightly different
-  print(
-    switch (unionExample) {
-      Data value => '$value',
-      Loading _ => 'loading',
-      ErrorDetails(:final message) => 'Error: $message',
-      Complex(:final a, :final b) => 'complex $a $b',
-    },
-  ); // 42
+  print(switch (unionExample) {
+    Data value => '$value',
+    Loading _ => 'loading',
+    ErrorDetails(:final message) => 'Error: $message',
+    Complex(:final a, :final b) => 'complex $a $b',
+  }); // 42
 
-  print(
-    switch (unionExample) {
-      ErrorDetails(:final message) => message,
-      // voluntarily didn't handle error/complex cases
-      _ => 'fallthrough',
-    },
-  ); // fallthrough
+  print(switch (unionExample) {
+    ErrorDetails(:final message) => message,
+    // voluntarily didn't handle error/complex cases
+    _ => 'fallthrough',
+  }); // fallthrough
 
   // ------------------
 
   // nice toString
   print(const Union(42)); // Union(value: 42)
   print(const Union.loading()); // Union.loading()
-  print(const Union.error(
-      'Failed to fetch')); // Union.error(message: Failed to fetch)
+  print(
+    const Union.error('Failed to fetch'),
+  ); // Union.error(message: Failed to fetch)
 
   // ------------------
 

--- a/packages/freezed/example/lib/time_slot.dart
+++ b/packages/freezed/example/lib/time_slot.dart
@@ -7,8 +7,5 @@ part 'time_slot.freezed.dart';
 /// https://github.com/rrousselGit/freezed/issues/220
 @freezed
 abstract class TimeSlot with _$TimeSlot {
-  factory TimeSlot({
-    TimeOfDay? start,
-    TimeOfDay? end,
-  }) = _TimeSlot;
+  factory TimeSlot({TimeOfDay? start, TimeOfDay? end}) = _TimeSlot;
 }

--- a/packages/freezed/example/test/diagnosticable_test.dart
+++ b/packages/freezed/example/test/diagnosticable_test.dart
@@ -9,10 +9,7 @@ void main() {
   test('overriding toString works', () {
     // regression test for https://github.com/rrousselGit/freezed/issues/221
 
-    expect(
-      diagnosticable.ToString().toString(),
-      'MyToString()',
-    );
+    expect(diagnosticable.ToString().toString(), 'MyToString()');
   });
 
   test('use Diagnosticable instead of toString if possible', () {

--- a/packages/freezed/example/test/json_test.dart
+++ b/packages/freezed/example/test/json_test.dart
@@ -3,26 +3,19 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('Union toJson', () {
-    expect(
-      const Union(42).toJson(),
-      <String, dynamic>{
-        'custom-key': 'Default',
-        'value': 42,
-      },
-    );
+    expect(const Union(42).toJson(), <String, dynamic>{
+      'custom-key': 'Default',
+      'value': 42,
+    });
 
-    expect(
-      const Union.loading().toJson(),
-      <String, dynamic>{'custom-key': 'Loading'},
-    );
+    expect(const Union.loading().toJson(), <String, dynamic>{
+      'custom-key': 'Loading',
+    });
   });
 
   test('Union fromJson', () {
     expect(
-      Union.fromJson(<String, dynamic>{
-        'custom-key': 'Default',
-        'value': 42,
-      }),
+      Union.fromJson(<String, dynamic>{'custom-key': 'Default', 'value': 42}),
       const Union(42),
     );
 

--- a/packages/freezed/lib/src/ast.dart
+++ b/packages/freezed/lib/src/ast.dart
@@ -6,9 +6,11 @@ extension AstX on AstNode {
   String? get documentation {
     final builder = StringBuffer();
 
-    for (Token? token = beginToken.precedingComments;
-        token != null;
-        token = token.next) {
+    for (
+      Token? token = beginToken.precedingComments;
+      token != null;
+      token = token.next
+    ) {
       builder.writeln(token);
     }
 
@@ -63,8 +65,9 @@ extension ConstructorX on ConstructorDeclaration {
     // ignore: deprecated_member_use, latest analyzer with enclosingElement3 not available in stable channel
     final classElement = declaredElement!.enclosingElement3;
 
-    var generics =
-        classElement.typeParameters.map((e) => '\$${e.name}').join(', ');
+    var generics = classElement.typeParameters
+        .map((e) => '\$${e.name}')
+        .join(', ');
     if (generics.isNotEmpty) {
       generics = '<$generics>';
     }
@@ -79,8 +82,9 @@ extension ConstructorX on ConstructorDeclaration {
     // ignore: deprecated_member_use, latest analyzer with enclosingElement3 not available in stable channel
     final classElement = declaredElement!.enclosingElement3;
 
-    var generics =
-        classElement.typeParameters.map((e) => '\$${e.name}').join(', ');
+    var generics = classElement.typeParameters
+        .map((e) => '\$${e.name}')
+        .join(', ');
     if (generics.isNotEmpty) {
       generics = '<$generics>';
     }

--- a/packages/freezed/lib/src/freezed_generator.dart
+++ b/packages/freezed/lib/src/freezed_generator.dart
@@ -40,7 +40,8 @@ class FreezedGenerator extends ParserGenerator<Freezed> {
       if (deepCopyProperty == null || commonGetter == null) continue;
 
       yield deepCopyProperty.copyWith(
-        nullable: deepCopyProperty.nullable ||
+        nullable:
+            deepCopyProperty.nullable ||
             commonProperty.type.isNullable ||
             commonGetter.type.isNullable,
       );
@@ -115,14 +116,16 @@ class FreezedGenerator extends ParserGenerator<Freezed> {
         constructor: constructor,
         commonProperties: data.properties.readableProperties,
         globalData: globalData,
-        copyWith: data.options.annotation.copyWith ??
+        copyWith:
+            data.options.annotation.copyWith ??
                 constructor.parameters.allParameters.isNotEmpty
             ? CopyWith(
                 parents: {},
                 clonedClassName: constructor.redirectedName,
                 cloneableProperties: constructor.properties.toList(),
-                readableProperties:
-                    constructor.properties.where((e) => e.isSynthetic).toList(),
+                readableProperties: constructor.properties
+                    .where((e) => e.isSynthetic)
+                    .toList(),
                 deepCloneableProperties: constructor.deepCloneableProperties,
                 genericsDefinition: data.genericsDefinitionTemplate,
                 genericsParameter: data.genericsParameterTemplate,

--- a/packages/freezed/lib/src/models.dart
+++ b/packages/freezed/lib/src/models.dart
@@ -116,8 +116,7 @@ class DeepCloneableProperty {
         nullable: parameter.type.isNullable,
         typeName: typeElement.name,
         genericParameters: GenericsParameterTemplate(
-          (parameter.type as InterfaceType)
-              .typeArguments
+          (parameter.type as InterfaceType).typeArguments
               .map((e) => e.getDisplayString())
               .toList(),
         ),
@@ -151,8 +150,8 @@ extension on FormalParameter {
       DefaultFormalParameter() => that.parameter.typeAnnotation(),
       FieldFormalParameter() => that.type,
       FunctionTypedFormalParameter() => throw UnsupportedError(
-          'Parameters of format `T name()` are not supported. Use `T Function()` name.',
-        ),
+        'Parameters of format `T name()` are not supported. Use `T Function()` name.',
+      ),
       SimpleFormalParameter() => that.type,
       SuperFormalParameter() => that.type,
     };
@@ -277,7 +276,8 @@ When specifying fields in non-factory constructor then specifying factory constr
         className: declaration.name.lexeme,
       );
 
-      final excludedProperties = manualConstructor?.parameters.parameters
+      final excludedProperties =
+          manualConstructor?.parameters.parameters
               .map((e) => e.declaredElement!.name)
               .toSet() ??
           <String>{};
@@ -315,7 +315,8 @@ When specifying fields in non-factory constructor then specifying factory constr
                 final elementSourceUri =
                     element.element?.declaration?.librarySource?.uri;
 
-                final isFreezedAnnotation = elementSourceUri != null &&
+                final isFreezedAnnotation =
+                    elementSourceUri != null &&
                     elementSourceUri.scheme == 'package' &&
                     elementSourceUri.pathSegments.isNotEmpty &&
                     elementSourceUri.pathSegments.first == 'freezed_annotation';
@@ -526,8 +527,8 @@ class Class {
     required this.properties,
     required this.copyWithTarget,
     required ClassDeclaration node,
-  })  : _node = node,
-        assert(constructors.isNotEmpty);
+  }) : _node = node,
+       assert(constructors.isNotEmpty);
 
   final String name;
   final ClassConfig options;
@@ -564,7 +565,8 @@ class Class {
       }
     }
 
-    final has$ClassMixin = declaration.withClause?.mixinTypes.any(
+    final has$ClassMixin =
+        declaration.withClause?.mixinTypes.any(
           (e) => e.isSuperMixin(declaration),
         ) ??
         false;
@@ -593,12 +595,14 @@ class Class {
       );
     properties.cloneableProperties.addAll(
       _computeCloneableProperties(declaration, constructors, configs).where(
-          (cloneable) => properties.readableProperties
-              .any((e) => e.name == cloneable.name)),
+        (cloneable) =>
+            properties.readableProperties.any((e) => e.name == cloneable.name),
+      ),
     );
 
-    final copyWithTarget =
-        constructors.isNotEmpty ? null : declaration.copyWithTarget;
+    final copyWithTarget = constructors.isNotEmpty
+        ? null
+        : declaration.copyWithTarget;
 
     if (copyWithTarget != null) {
       // Check for missing required parameters on the copyWith target
@@ -773,15 +777,19 @@ To fix, either:
     ClassDeclaration declaration,
     List<ConstructorDetails> constructorsNeedsGeneration,
   ) sync* {
-    final typesMap = <String,
-        List<
+    final typesMap =
+        <
+          String,
+          List<
             ({
               TypeAnnotation? type,
               String? doc,
               bool isFinal,
               bool isSynthetic,
               List<String> decorators,
-            })?>>{};
+            })?
+          >
+        >{};
     void setForName({
       required String name,
       required TypeAnnotation? type,
@@ -956,11 +964,11 @@ To fix, either:
         // be present in the abstract class.
         if (matchingParameter == null) continue parameterLoop;
 
-        commonTypeBetweenAllUnionConstructors =
-            library.typeSystem.leastUpperBound(
-          commonTypeBetweenAllUnionConstructors,
-          matchingParameter.parameterElement!.type,
-        );
+        commonTypeBetweenAllUnionConstructors = library.typeSystem
+            .leastUpperBound(
+              commonTypeBetweenAllUnionConstructors,
+              matchingParameter.parameterElement!.type,
+            );
       }
 
       final matchingParameters = constructorsNeedsGeneration
@@ -1078,8 +1086,9 @@ To fix, either:
   bool get isSealed => _node.sealedKeyword != null;
 
   String get escapedName {
-    var generics =
-        genericsParameterTemplate.typeParameters.map((e) => '\$$e').join(', ');
+    var generics = genericsParameterTemplate.typeParameters
+        .map((e) => '\$$e')
+        .join(', ');
     if (generics.isNotEmpty) {
       generics = '<$generics>';
     }

--- a/packages/freezed/lib/src/string.dart
+++ b/packages/freezed/lib/src/string.dart
@@ -14,12 +14,12 @@ extension StringX on String {
   }
 
   String _fixCase(String separator) => replaceAllMapped(_upperCase, (match) {
-        var lower = match.group(0)!.toLowerCase();
+    var lower = match.group(0)!.toLowerCase();
 
-        if (match.start > 0) {
-          lower = '$separator$lower';
-        }
+    if (match.start > 0) {
+      lower = '$separator$lower';
+    }
 
-        return lower;
-      });
+    return lower;
+  });
 }

--- a/packages/freezed/lib/src/templates/abstract_template.dart
+++ b/packages/freezed/lib/src/templates/abstract_template.dart
@@ -20,7 +20,8 @@ class Abstract {
 
   @override
   String toString() {
-    final needsAbstractGetters = data.options.toJson ||
+    final needsAbstractGetters =
+        data.options.toJson ||
         copyWith != null ||
         data.options.asString ||
         data.options.equal;
@@ -35,7 +36,7 @@ class Abstract {
 
     var interfaces = [
       if (globalData.hasDiagnostics && data.options.asString)
-        'DiagnosticableTreeMixin'
+        'DiagnosticableTreeMixin',
     ].join();
     if (interfaces.isNotEmpty) interfaces = ' implements $interfaces';
 

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -28,10 +28,10 @@ class Concrete {
 
   late final bool _hasUnionKeyProperty =
       (data.options.toJson || data.options.fromJson) &&
-          data.constructors.length > 1 &&
-          constructor.properties.every(
-            (e) => e.name != data.options.annotation.unionKey,
-          );
+      data.constructors.length > 1 &&
+      constructor.properties.every(
+        (e) => e.name != data.options.annotation.unionKey,
+      );
 
   @override
   String toString() {
@@ -138,10 +138,12 @@ ${copyWith?.concreteImpl(constructor.parameters) ?? ''}
       if (data.options.asUnmodifiableCollections)
         ...constructor.properties
             .where((e) => e.isSynthetic)
-            .where((e) =>
-                e.type.isDartCoreList ||
-                e.type.isDartCoreMap ||
-                e.type.isDartCoreSet)
+            .where(
+              (e) =>
+                  e.type.isDartCoreList ||
+                  e.type.isDartCoreMap ||
+                  e.type.isDartCoreSet,
+            )
             .map((e) => '_${e.name} = ${e.name}'),
       if (_hasUnionKeyProperty)
         "\$type = \$type ?? '${constructor.unionValue}'",
@@ -227,55 +229,59 @@ ${copyWith?.concreteImpl(constructor.parameters) ?? ''}
   }
 
   String get _properties {
-    final classProperties =
-        constructor.properties.where((e) => e.isSynthetic).expand((p) {
-      final annotatedProperty = p.copyWith(
-        decorators: [
-          if (commonProperties.any((element) => element.name == p.name))
-            '@override',
-          if (p.defaultValueSource != null && !p.hasJsonKey) '@JsonKey()',
-          ...p.decorators,
-        ],
-      );
+    final classProperties = constructor.properties
+        .where((e) => e.isSynthetic)
+        .expand((p) {
+          final annotatedProperty = p.copyWith(
+            decorators: [
+              if (commonProperties.any((element) => element.name == p.name))
+                '@override',
+              if (p.defaultValueSource != null && !p.hasJsonKey) '@JsonKey()',
+              ...p.decorators,
+            ],
+          );
 
-      if (data.options.asUnmodifiableCollections) {
-        String? viewType;
+          if (data.options.asUnmodifiableCollections) {
+            String? viewType;
 
-        if (p.type.isDartCoreList) {
-          viewType = 'EqualUnmodifiableListView';
-        } else if (p.type.isDartCoreMap) {
-          viewType = 'EqualUnmodifiableMapView';
-        } else if (p.type.isDartCoreSet) {
-          viewType = 'EqualUnmodifiableSetView';
-        }
+            if (p.type.isDartCoreList) {
+              viewType = 'EqualUnmodifiableListView';
+            } else if (p.type.isDartCoreMap) {
+              viewType = 'EqualUnmodifiableMapView';
+            } else if (p.type.isDartCoreSet) {
+              viewType = 'EqualUnmodifiableSetView';
+            }
 
-        if (viewType != null) {
-          // If the collection is already unmodifiable, we don't want to wrap
-          // it in an unmodifiable view again.
-          final isAlreadyUnmodifiableCheck =
-              'if (_${p.name} is $viewType) return _${p.name};';
+            if (viewType != null) {
+              // If the collection is already unmodifiable, we don't want to wrap
+              // it in an unmodifiable view again.
+              final isAlreadyUnmodifiableCheck =
+                  'if (_${p.name} is $viewType) return _${p.name};';
 
-          return [
-            p.copyWith(name: '_${p.name}', decorators: const []),
-            if (p.type.isNullable) annotatedProperty.asGetter(''' {
+              return [
+                p.copyWith(name: '_${p.name}', decorators: const []),
+                if (p.type.isNullable)
+                  annotatedProperty.asGetter(''' {
   final value = _${p.name};
   if (value == null) return null;
   $isAlreadyUnmodifiableCheck
   // ignore: implicit_dynamic_type
   return $viewType(value);
 }
-''') else annotatedProperty.asGetter(''' {
+''')
+                else
+                  annotatedProperty.asGetter(''' {
   $isAlreadyUnmodifiableCheck
   // ignore: implicit_dynamic_type
   return $viewType(_${p.name});
 }
 '''),
-          ];
-        }
-      }
+              ];
+            }
+          }
 
-      return [annotatedProperty];
-    });
+          return [annotatedProperty];
+        });
 
     if (_hasUnionKeyProperty) {
       return '''
@@ -294,14 +300,14 @@ final String \$type;
   }
 
   String get _fromJsonArgs => fromJsonArguments(
-        data.genericsParameterTemplate,
-        data.options.genericArgumentFactories,
-      );
+    data.genericsParameterTemplate,
+    data.options.genericArgumentFactories,
+  );
 
   String get _fromJsonParams => fromJsonParameters(
-        data.genericsParameterTemplate,
-        data.options.genericArgumentFactories,
-      );
+    data.genericsParameterTemplate,
+    data.options.genericArgumentFactories,
+  );
 
   String get _concreteFromJsonConstructor {
     if (!data.options.fromJson) return '';
@@ -519,7 +525,8 @@ extension DefaultValue on ParameterElement {
         final source = meta.toSource();
         final res = source.substring('@Default('.length, source.length - 1);
 
-        var needsConstModifier = !declaration.type.isDartCoreString &&
+        var needsConstModifier =
+            !declaration.type.isDartCoreString &&
             !res.trimLeft().startsWith('const') &&
             (res.contains('(') || res.contains('[') || res.contains('{'));
 

--- a/packages/freezed/lib/src/templates/copy_with.dart
+++ b/packages/freezed/lib/src/templates/copy_with.dart
@@ -62,7 +62,8 @@ class CopyWith {
     var leading = '';
     if (cloneableProperties.isNotEmpty) {
       leading = 'abstract mixin ';
-      body = '''
+      body =
+          '''
   factory $_abstractClassName($clonedClassName$genericsParameter value, \$Res Function($clonedClassName$genericsParameter) _then) = $_implClassName;
 ${_copyWithPrototype('call')}
 
@@ -86,7 +87,8 @@ $body
 
     final cast = needsCast ? ' as $clonedClassName$genericsParameter' : '';
     return _maybeOverride(
-      doc: '''
+      doc:
+          '''
 ${_copyWithDocs(data.name)}
 ''',
       '''
@@ -216,9 +218,11 @@ ${_deepCopyMethods(isConcrete: true).join()}
     required String methodName,
     required List<Property> properties,
   }) {
-    final parameters = properties.map((p) {
-      return '${p.decorators.join()} ${p.typeDisplayString} ${p.name}';
-    }).join(',');
+    final parameters = properties
+        .map((p) {
+          return '${p.decorators.join()} ${p.typeDisplayString} ${p.name}';
+        })
+        .join(',');
 
     return _maybeOverride('''
 @useResult
@@ -242,7 +246,8 @@ $parameters
     );
 
     return _maybeOverride(
-      doc: '''
+      doc:
+          '''
 ${_copyWithDocs(data.name)}
 ''',
       '@pragma(\'vm:prefer-inline\') $prototype $body',

--- a/packages/freezed/lib/src/templates/from_json_template.dart
+++ b/packages/freezed/lib/src/templates/from_json_template.dart
@@ -32,28 +32,30 @@ Rename one or the other, such that they don't conflict.
     String content;
 
     if (clazz.constructors.length == 1) {
-      content = '''
+      content =
+          '''
     return ${clazz.constructors.first.redirectedName}${clazz.genericsParameterTemplate}.fromJson(
       json${fromJsonArguments(clazz.genericsParameterTemplate, clazz.options.genericArgumentFactories)}
     );''';
     } else {
-      final cases =
-          clazz.constructors.where((element) => !element.isFallback).map((
-        constructor,
-      ) {
-        final caseName = constructor.unionValue;
-        final concreteName = constructor.redirectedName;
+      final cases = clazz.constructors
+          .where((element) => !element.isFallback)
+          .map((constructor) {
+            final caseName = constructor.unionValue;
+            final concreteName = constructor.redirectedName;
 
-        return '''
+            return '''
         case '$caseName':
           return $concreteName${clazz.genericsParameterTemplate}.fromJson(
             json${fromJsonArguments(clazz.genericsParameterTemplate, clazz.options.genericArgumentFactories)}
           );
         ''';
-      }).join();
+          })
+          .join();
 
       // TODO(rrousselGit): update logic once https://github.com/rrousselGit/freezed/pull/370 lands
-      var defaultCase = '''
+      var defaultCase =
+          '''
 throw CheckedFromJsonException(
   json,
   \'${clazz.options.annotation.unionKey}\',
@@ -64,13 +66,15 @@ throw CheckedFromJsonException(
         (element) => element.isFallback,
       );
       if (fallbackConstructor != null) {
-        defaultCase = '''
+        defaultCase =
+            '''
 return ${fallbackConstructor.redirectedName}${clazz.genericsParameterTemplate}.fromJson(
   json${fromJsonArguments(clazz.genericsParameterTemplate, clazz.options.genericArgumentFactories)}
 );''';
       }
 
-      content = '''
+      content =
+          '''
         switch (json['${clazz.options.annotation.unionKey}']) {
           $cases
           default:

--- a/packages/freezed/lib/src/templates/parameter_template.dart
+++ b/packages/freezed/lib/src/templates/parameter_template.dart
@@ -92,8 +92,10 @@ class ParametersTemplate {
           .where((p) => p.isOptionalPositional)
           .map(asParameter)
           .toList(),
-      namedParameters:
-          parameters.where((p) => p.isNamed).map(asParameter).toList(),
+      namedParameters: parameters
+          .where((p) => p.isNamed)
+          .map(asParameter)
+          .toList(),
     );
   }
 
@@ -127,8 +129,9 @@ class ParametersTemplate {
   ParametersTemplate mapParameters(Parameter Function(Parameter parameter) cb) {
     return ParametersTemplate(
       requiredPositionalParameters.map(cb).toList(),
-      optionalPositionalParameters:
-          optionalPositionalParameters.map(cb).toList(),
+      optionalPositionalParameters: optionalPositionalParameters
+          .map(cb)
+          .toList(),
       namedParameters: namedParameters.map(cb).toList(),
     );
   }
@@ -139,7 +142,8 @@ class ParametersTemplate {
       required bool isNamed,
       required bool isRequired,
       required int? index,
-    }) cb,
+    })
+    cb,
   ) {
     final parameters = [
       ...requiredPositionalParameters.mapIndexed(
@@ -162,8 +166,10 @@ class ParametersTemplate {
           .where((e) => e.isNamed == false && e.isRequired == false)
           .map((e) => e.$1)
           .toList(),
-      namedParameters:
-          parameters.where((e) => e.isNamed == true).map((e) => e.$1).toList(),
+      namedParameters: parameters
+          .where((e) => e.isNamed == true)
+          .map((e) => e.$1)
+          .toList(),
     );
   }
 
@@ -249,19 +255,18 @@ class Parameter {
     bool? showDefaultValue,
     String? doc,
     bool? isFinal,
-  }) =>
-      Parameter(
-        type: type ?? this.type,
-        typeDisplayString: typeDisplayString,
-        name: name ?? this.name,
-        defaultValueSource: defaultValueSource ?? this.defaultValueSource,
-        isRequired: isRequired ?? this.isRequired,
-        decorators: decorators ?? this.decorators,
-        showDefaultValue: showDefaultValue ?? this.showDefaultValue,
-        doc: doc ?? this.doc,
-        isFinal: isFinal ?? this.isFinal,
-        parameterElement: parameterElement,
-      );
+  }) => Parameter(
+    type: type ?? this.type,
+    typeDisplayString: typeDisplayString,
+    name: name ?? this.name,
+    defaultValueSource: defaultValueSource ?? this.defaultValueSource,
+    isRequired: isRequired ?? this.isRequired,
+    decorators: decorators ?? this.decorators,
+    showDefaultValue: showDefaultValue ?? this.showDefaultValue,
+    doc: doc ?? this.doc,
+    isFinal: isFinal ?? this.isFinal,
+    parameterElement: parameterElement,
+  );
 
   @override
   String toString() {
@@ -296,17 +301,17 @@ class SuperParameter extends Parameter {
   }) : super(showDefaultValue: true);
 
   SuperParameter.fromParameter(Parameter p)
-      : this(
-          name: p.name,
-          type: p.type,
-          typeDisplayString: p.typeDisplayString,
-          defaultValueSource: p.defaultValueSource,
-          isFinal: p.isFinal,
-          isRequired: p.isRequired,
-          decorators: p.decorators,
-          doc: p.doc,
-          parameterElement: p.parameterElement,
-        );
+    : this(
+        name: p.name,
+        type: p.type,
+        typeDisplayString: p.typeDisplayString,
+        defaultValueSource: p.defaultValueSource,
+        isFinal: p.isFinal,
+        isRequired: p.isRequired,
+        decorators: p.decorators,
+        doc: p.doc,
+        parameterElement: p.parameterElement,
+      );
 
   @override
   String toString() {
@@ -338,17 +343,17 @@ class LocalParameter extends Parameter {
   }) : super(showDefaultValue: true);
 
   LocalParameter.fromParameter(Parameter p)
-      : this(
-          name: p.name,
-          type: p.type,
-          typeDisplayString: p.typeDisplayString,
-          defaultValueSource: p.defaultValueSource,
-          isFinal: p.isFinal,
-          isRequired: p.isRequired,
-          decorators: p.decorators,
-          doc: p.doc,
-          parameterElement: p.parameterElement,
-        );
+    : this(
+        name: p.name,
+        type: p.type,
+        typeDisplayString: p.typeDisplayString,
+        defaultValueSource: p.defaultValueSource,
+        isFinal: p.isFinal,
+        isRequired: p.isRequired,
+        decorators: p.decorators,
+        doc: p.doc,
+        parameterElement: p.parameterElement,
+      );
 
   @override
   String toString() {

--- a/packages/freezed/lib/src/templates/pattern_template.dart
+++ b/packages/freezed/lib/src/templates/pattern_template.dart
@@ -25,10 +25,7 @@ $buffer
   return '';
 }
 
-String _maybeMap(
-  Class data, {
-  required TypeProvider typeProvider,
-}) {
+String _maybeMap(Class data, {required TypeProvider typeProvider}) {
   if (!data.options.map.maybeMap) return '';
 
   return _mapImpl(
@@ -53,10 +50,7 @@ String _maybeMap(
   );
 }
 
-String _map(
-  Class data, {
-  required TypeProvider typeProvider,
-}) {
+String _map(Class data, {required TypeProvider typeProvider}) {
   if (!data.options.map.map) return '';
 
   return _mapImpl(
@@ -82,10 +76,7 @@ String _map(
   );
 }
 
-String _mapOrNull(
-  Class data, {
-  required TypeProvider typeProvider,
-}) {
+String _mapOrNull(Class data, {required TypeProvider typeProvider}) {
   if (!data.options.map.mapOrNull) return '';
 
   return _mapImpl(
@@ -110,10 +101,7 @@ String _mapOrNull(
   );
 }
 
-String _maybeWhen(
-  Class data, {
-  required TypeProvider typeProvider,
-}) {
+String _maybeWhen(Class data, {required TypeProvider typeProvider}) {
   if (!data.options.when.maybeWhen) return '';
 
   return _whenImpl(
@@ -138,10 +126,7 @@ String _maybeWhen(
   );
 }
 
-String _when(
-  Class data, {
-  required TypeProvider typeProvider,
-}) {
+String _when(Class data, {required TypeProvider typeProvider}) {
   if (!data.options.when.when) return '';
 
   return _whenImpl(
@@ -167,10 +152,7 @@ String _when(
   );
 }
 
-String _whenOrNull(
-  Class data, {
-  required TypeProvider typeProvider,
-}) {
+String _whenOrNull(Class data, {required TypeProvider typeProvider}) {
   if (!data.options.when.whenOrNull) return '';
 
   return _whenImpl(
@@ -284,18 +266,19 @@ String _whenImpl(
     typeProvider: typeProvider,
     ctor2parameters: (constructor) {
       return ParametersTemplate([
-        ...constructor.parameters.requiredPositionalParameters
-            .map((e) => e.copyWith(isFinal: false)),
-        ...constructor.parameters.optionalPositionalParameters
-            .map((e) => e.copyWith(
-                  isFinal: false,
-                  showDefaultValue: false,
-                )),
-        ...constructor.parameters.namedParameters.map((e) => e.copyWith(
-              isRequired: false,
-              isFinal: false,
-              showDefaultValue: false,
-            )),
+        ...constructor.parameters.requiredPositionalParameters.map(
+          (e) => e.copyWith(isFinal: false),
+        ),
+        ...constructor.parameters.optionalPositionalParameters.map(
+          (e) => e.copyWith(isFinal: false, showDefaultValue: false),
+        ),
+        ...constructor.parameters.namedParameters.map(
+          (e) => e.copyWith(
+            isRequired: false,
+            isFinal: false,
+            showDefaultValue: false,
+          ),
+        ),
       ]);
     },
   );
@@ -310,8 +293,9 @@ String _whenImpl(
       buffer.write(' when ${constructor.callbackName} != null');
     }
 
-    final callbackParameters =
-        constructor.properties.map((e) => '_that.${e.name}').join(',');
+    final callbackParameters = constructor.properties
+        .map((e) => '_that.${e.name}')
+        .join(',');
 
     buffer
       ..writeln(':')

--- a/packages/freezed/lib/src/templates/properties.dart
+++ b/packages/freezed/lib/src/templates/properties.dart
@@ -23,17 +23,17 @@ class Property {
   });
 
   Property.fromParameter(Parameter p, {required bool isSynthetic})
-      : this(
-          decorators: p.decorators,
-          name: p.name,
-          isFinal: p.isFinal,
-          doc: p.doc,
-          type: p.type,
-          typeDisplayString: p.typeDisplayString,
-          defaultValueSource: p.defaultValueSource,
-          isSynthetic: isSynthetic,
-          hasJsonKey: false,
-        );
+    : this(
+        decorators: p.decorators,
+        name: p.name,
+        isFinal: p.isFinal,
+        doc: p.doc,
+        type: p.type,
+        typeDisplayString: p.typeDisplayString,
+        defaultValueSource: p.defaultValueSource,
+        isSynthetic: isSynthetic,
+        hasJsonKey: false,
+      );
 
   static Property fromFormalParameter(
     FormalParameter parameter, {
@@ -81,28 +81,28 @@ class Property {
   }
 
   Getter get abstractGetter => Getter(
-        name: name,
-        type: typeDisplayString,
-        decorators: decorators,
-        doc: doc,
-        body: ';',
-      );
+    name: name,
+    type: typeDisplayString,
+    decorators: decorators,
+    doc: doc,
+    body: ';',
+  );
 
   Getter asGetter(String body) => Getter(
-        name: name,
-        type: typeDisplayString,
-        decorators: decorators,
-        doc: doc,
-        body: body,
-      );
+    name: name,
+    type: typeDisplayString,
+    decorators: decorators,
+    doc: doc,
+    body: body,
+  );
 
   Setter get abstractSetter => Setter(
-        name: name,
-        type: typeDisplayString,
-        decorators: decorators,
-        doc: doc,
-        body: ';',
-      );
+    name: name,
+    type: typeDisplayString,
+    decorators: decorators,
+    doc: doc,
+    body: ';',
+  );
 
   Property copyWith({
     DartType? type,

--- a/packages/freezed/lib/src/tools/recursive_import_locator.dart
+++ b/packages/freezed/lib/src/tools/recursive_import_locator.dart
@@ -32,13 +32,13 @@ extension FindAllAvailableTopLevelElements on LibraryElement {
 
     final librariesToCheck = checkExports
         ? units
-            .expand((e) => e.libraryExports)
-            .map(_LibraryDirectives.fromExport)
-            .nonNulls
+              .expand((e) => e.libraryExports)
+              .map(_LibraryDirectives.fromExport)
+              .nonNulls
         : units
-            .expand((e) => e.libraryImports)
-            .map(_LibraryDirectives.fromImport)
-            .nonNulls;
+              .expand((e) => e.libraryImports)
+              .map(_LibraryDirectives.fromImport)
+              .nonNulls;
 
     for (final directive in librariesToCheck) {
       if (!visitedLibraryPaths.add(directive.key)) {
@@ -47,17 +47,17 @@ extension FindAllAvailableTopLevelElements on LibraryElement {
 
       yield* directive.library
           ._findAllAvailableTopLevelElements(
-        visitedLibraryPaths,
-        checkExports: true,
-        key: directive.key,
-      )
+            visitedLibraryPaths,
+            checkExports: true,
+            key: directive.key,
+          )
           .where((element) {
-        return (directive.showStatements.isEmpty &&
-                directive.hideStatements.isEmpty) ||
-            (directive.hideStatements.isNotEmpty &&
-                !directive.hideStatements.contains(element.name)) ||
-            directive.showStatements.contains(element.name);
-      });
+            return (directive.showStatements.isEmpty &&
+                    directive.hideStatements.isEmpty) ||
+                (directive.hideStatements.isNotEmpty &&
+                    !directive.hideStatements.contains(element.name)) ||
+                directive.showStatements.contains(element.name);
+          });
     }
   }
 }
@@ -161,10 +161,10 @@ class _LibraryKey {
 
   @override
   int get hashCode => Object.hash(
-        librarySource,
-        const SetEquality<String>().hash(hideStatements),
-        const SetEquality<String>().hash(showStatements),
-      );
+    librarySource,
+    const SetEquality<String>().hash(hideStatements),
+    const SetEquality<String>().hash(showStatements),
+  );
 
   @override
   String toString() {

--- a/packages/freezed/lib/src/tools/type.dart
+++ b/packages/freezed/lib/src/tools/type.dart
@@ -43,12 +43,12 @@ String resolveFullTypeStringFrom(LibraryElement originLibrary, DartType type) {
   final owner = originLibrary.units
       .expand((e) => e.libraryImportPrefixes)
       .firstWhereOrNull((e) {
-    return e.imports.any((l) {
-      return l.importedLibrary!.anyTransitiveExport((library) {
-        return library.id == _getElementForType(type)?.library?.id;
+        return e.imports.any((l) {
+          return l.importedLibrary!.anyTransitiveExport((library) {
+            return library.id == _getElementForType(type)?.library?.id;
+          });
+        });
       });
-    });
-  });
 
   String? displayType = type.getDisplayString();
 

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -7,10 +7,10 @@ repository: https://github.com/rrousselGit/freezed
 issue_tracker: https://github.com/rrousselGit/freezed/issues
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=6.9.0 <8.0.0"
+  analyzer: ">=7.5.9 <8.0.0"
   build: ^2.5.0
   build_config: ^1.1.0
   collection: ^1.15.0

--- a/packages/freezed/test/bidirectional_test.dart
+++ b/packages/freezed/test/bidirectional_test.dart
@@ -13,9 +13,11 @@ void main() {
       ),
     );
 
-    final errorResult = await main.session.getErrors(
-      '/freezed/test/integration/bidirectional.freezed.dart',
-    ) as ErrorsResult;
+    final errorResult =
+        await main.session.getErrors(
+              '/freezed/test/integration/bidirectional.freezed.dart',
+            )
+            as ErrorsResult;
 
     expect(errorResult.errors, isEmpty);
   });

--- a/packages/freezed/test/common.dart
+++ b/packages/freezed/test/common.dart
@@ -7,16 +7,22 @@ import 'package:test/test.dart';
 final throwsCompileError = throwsA(isA<CompileError>());
 
 Future<void> compile(String src) async {
-  final main = await resolveSources({
-    'freezed|test/integration/main.dart': '''
+  final main = await resolveSources(
+    {
+      'freezed|test/integration/main.dart':
+          '''
 library main;
 
 $src
     ''',
-  }, (r) => r.findLibraryByName('main'), readAllSourcesFromFilesystem: true);
+    },
+    (r) => r.findLibraryByName('main'),
+    readAllSourcesFromFilesystem: true,
+  );
 
-  final errorResult = await main!.session
-      .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
+  final errorResult =
+      await main!.session.getErrors('/freezed/test/integration/main.dart')
+          as ErrorsResult;
   final criticalErrors = errorResult.errors
       .where((element) => element.severity == Severity.error)
       .toList();

--- a/packages/freezed/test/common_types_test.dart
+++ b/packages/freezed/test/common_types_test.dart
@@ -18,9 +18,11 @@ Future<void> main() async {
       ),
     );
 
-    final errorResult = await main.session.getErrors(
-      '/freezed/test/integration/common_types.freezed.dart',
-    ) as ErrorsResult;
+    final errorResult =
+        await main.session.getErrors(
+              '/freezed/test/integration/common_types.freezed.dart',
+            )
+            as ErrorsResult;
 
     expect(errorResult.errors, isEmpty);
   });

--- a/packages/freezed/test/decorator_test.dart
+++ b/packages/freezed/test/decorator_test.dart
@@ -12,27 +12,31 @@ void main() {
       ),
     );
 
-    var errorResult = await main.session.getErrors(
-      '/freezed/test/integration/decorator.freezed.dart',
-    ) as ErrorsResult;
+    var errorResult =
+        await main.session.getErrors(
+              '/freezed/test/integration/decorator.freezed.dart',
+            )
+            as ErrorsResult;
     expect(errorResult.errors, isEmpty);
-    errorResult = await main.session
-        .getErrors('/freezed/test/integration/decorator.dart') as ErrorsResult;
+    errorResult =
+        await main.session.getErrors('/freezed/test/integration/decorator.dart')
+            as ErrorsResult;
   });
 
   test(
     'internal raw collection is not decorated when using immutable collections',
     () async {
       final main = await resolveSources(
-          {
-            'freezed|test/integration/main.dart': r'''
+        {
+          'freezed|test/integration/main.dart': r'''
 import 'decorator.dart';
 ''',
-          },
-          (r) => r.libraries.firstWhere(
-                (element) => element.library.name == 'decorator',
-              ),
-          readAllSourcesFromFilesystem: true);
+        },
+        (r) => r.libraries.firstWhere(
+          (element) => element.library.name == 'decorator',
+        ),
+        readAllSourcesFromFilesystem: true,
+      );
 
       final concrete = main.topLevelElements
           .whereType<ClassElement>()
@@ -43,8 +47,9 @@ import 'decorator.dart';
         isEmpty,
       );
 
-      final unmodifiableGetter =
-          concrete.fields.firstWhere((element) => element.name == 'a').getter!;
+      final unmodifiableGetter = concrete.fields
+          .firstWhere((element) => element.name == 'a')
+          .getter!;
 
       expect(unmodifiableGetter.metadata.length, 2);
       expect(unmodifiableGetter.metadata.last.toSource(), '@Foo()');
@@ -53,8 +58,8 @@ import 'decorator.dart';
 
   test('warns if try to use deprecated property', () async {
     final main = await resolveSources(
-        {
-          'freezed|test/integration/main.dart': r'''
+      {
+        'freezed|test/integration/main.dart': r'''
 import 'decorator.dart';
 
 void main() {
@@ -74,14 +79,16 @@ void main() {
   );
 }
 ''',
-        },
-        (r) => r.libraries.firstWhere(
-              (element) => element.source.toString().contains('decorator'),
-            ),
-        readAllSourcesFromFilesystem: true);
+      },
+      (r) => r.libraries.firstWhere(
+        (element) => element.source.toString().contains('decorator'),
+      ),
+      readAllSourcesFromFilesystem: true,
+    );
 
-    var errorResult = await main.session
-        .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
+    var errorResult =
+        await main.session.getErrors('/freezed/test/integration/main.dart')
+            as ErrorsResult;
     expect(
       errorResult.errors.map((e) => e.errorCode.name),
       anyOf([

--- a/packages/freezed/test/deep_copy_test.dart
+++ b/packages/freezed/test/deep_copy_test.dart
@@ -24,9 +24,11 @@ void main() {
       ),
     );
 
-    final errorResult = await main.session.getErrors(
-      '/freezed/test/integration/deep_copy.freezed.dart',
-    ) as ErrorsResult;
+    final errorResult =
+        await main.session.getErrors(
+              '/freezed/test/integration/deep_copy.freezed.dart',
+            )
+            as ErrorsResult;
 
     expect(errorResult.errors, isEmpty);
   });
@@ -39,9 +41,11 @@ void main() {
       ),
     );
 
-    final errorResult = await main.session.getErrors(
-      '/freezed/test/integration/deep_copy2.freezed.dart',
-    ) as ErrorsResult;
+    final errorResult =
+        await main.session.getErrors(
+              '/freezed/test/integration/deep_copy2.freezed.dart',
+            )
+            as ErrorsResult;
 
     expect(errorResult.errors, isEmpty);
   });
@@ -705,8 +709,8 @@ void main() {
 
   test('warns about unused copyWith result', () async {
     final main = await resolveSources(
-        {
-          'freezed|test/integration/main.dart': r'''
+      {
+        'freezed|test/integration/main.dart': r'''
 library main;
 import 'deep_copy.dart';
 
@@ -716,14 +720,16 @@ void main() {
   company.copyWith(name: 'MyCompany');
 }
 ''',
-        },
-        (r) => r.libraries.firstWhere(
-              (element) => element.source.toString().contains('deep_copy'),
-            ),
-        readAllSourcesFromFilesystem: true);
+      },
+      (r) => r.libraries.firstWhere(
+        (element) => element.source.toString().contains('deep_copy'),
+      ),
+      readAllSourcesFromFilesystem: true,
+    );
 
-    final errorResult = await main.session
-        .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
+    final errorResult =
+        await main.session.getErrors('/freezed/test/integration/main.dart')
+            as ErrorsResult;
 
     expect(errorResult.errors.map((e) => e.errorCode.name), [
       'UNUSED_RESULT',

--- a/packages/freezed/test/generic_test.dart
+++ b/packages/freezed/test/generic_test.dart
@@ -45,9 +45,11 @@ void main() {
       ),
     );
 
-    final errorResult = await main.session.getErrors(
-      '/freezed/test/integration/generic.freezed.dart',
-    ) as ErrorsResult;
+    final errorResult =
+        await main.session.getErrors(
+              '/freezed/test/integration/generic.freezed.dart',
+            )
+            as ErrorsResult;
 
     expect(errorResult.errors, isEmpty);
   });
@@ -62,15 +64,16 @@ void main() {
   test('map is generic too', () {
     var result = MultipleConstructors<int, double>(false)
         .map<MultipleConstructors<int, double>>(
-      (Default<int, double> value) => value,
-      first: (First<int, double> value) => value,
-      second: (Second<int, double> value) => value,
-    );
+          (Default<int, double> value) => value,
+          first: (First<int, double> value) => value,
+          second: (Second<int, double> value) => value,
+        );
 
     expect(result, MultipleConstructors<int, double>(false));
 
-    MultipleConstructors<int, double>(false)
-        .maybeMap<MultipleConstructors<int, double>>(
+    MultipleConstructors<int, double>(
+      false,
+    ).maybeMap<MultipleConstructors<int, double>>(
       (Default<int, double> value) => value,
       first: (First<int, double> value) => value,
       second: (Second<int, double> value) => value,

--- a/packages/freezed/test/generics_refs_test.dart
+++ b/packages/freezed/test/generics_refs_test.dart
@@ -14,9 +14,11 @@ void main() {
       ),
     );
 
-    final errorResult = await main.session.getErrors(
-      '/freezed/test/integration/generics_refs.freezed.dart',
-    ) as ErrorsResult;
+    final errorResult =
+        await main.session.getErrors(
+              '/freezed/test/integration/generics_refs.freezed.dart',
+            )
+            as ErrorsResult;
 
     expect(errorResult.errors, isEmpty);
   });

--- a/packages/freezed/test/integration/json.dart
+++ b/packages/freezed/test/integration/json.dart
@@ -344,8 +344,7 @@ abstract class UnrecognizedKeysCustomUnionValue
 
   factory UnrecognizedKeysCustomUnionValue.fromJson(
     Map<String, dynamic> json,
-  ) =>
-      _$UnrecognizedKeysCustomUnionValueFromJson(json);
+  ) => _$UnrecognizedKeysCustomUnionValueFromJson(json);
 }
 
 @Freezed(fallbackUnion: 'fallback')
@@ -380,8 +379,7 @@ abstract class UnrecognizedKeysUnionFallbackWithDefault
 
   factory UnrecognizedKeysUnionFallbackWithDefault.fromJson(
     Map<String, dynamic> json,
-  ) =>
-      _$UnrecognizedKeysUnionFallbackWithDefaultFromJson(json);
+  ) => _$UnrecognizedKeysUnionFallbackWithDefaultFromJson(json);
 }
 
 @Freezed(unionValueCase: FreezedUnionCase.pascal)
@@ -396,8 +394,7 @@ abstract class UnrecognizedKeysUnionValueCasePascal
 
   factory UnrecognizedKeysUnionValueCasePascal.fromJson(
     Map<String, dynamic> json,
-  ) =>
-      _$UnrecognizedKeysUnionValueCasePascalFromJson(json);
+  ) => _$UnrecognizedKeysUnionValueCasePascalFromJson(json);
 }
 
 @Freezed(unionValueCase: FreezedUnionCase.kebab)
@@ -412,8 +409,7 @@ abstract class UnrecognizedKeysUnionValueCaseKebab
 
   factory UnrecognizedKeysUnionValueCaseKebab.fromJson(
     Map<String, dynamic> json,
-  ) =>
-      _$UnrecognizedKeysUnionValueCaseKebabFromJson(json);
+  ) => _$UnrecognizedKeysUnionValueCaseKebabFromJson(json);
 }
 
 @Freezed(unionValueCase: FreezedUnionCase.snake)
@@ -428,8 +424,7 @@ abstract class UnrecognizedKeysUnionValueCaseSnake
 
   factory UnrecognizedKeysUnionValueCaseSnake.fromJson(
     Map<String, dynamic> json,
-  ) =>
-      _$UnrecognizedKeysUnionValueCaseSnakeFromJson(json);
+  ) => _$UnrecognizedKeysUnionValueCaseSnakeFromJson(json);
 }
 
 @Freezed(unionValueCase: FreezedUnionCase.screamingSnake)
@@ -445,8 +440,7 @@ abstract class UnrecognizedKeysUnionValueCaseScreamingSnake
 
   factory UnrecognizedKeysUnionValueCaseScreamingSnake.fromJson(
     Map<String, dynamic> json,
-  ) =>
-      _$UnrecognizedKeysUnionValueCaseScreamingSnakeFromJson(json);
+  ) => _$UnrecognizedKeysUnionValueCaseScreamingSnakeFromJson(json);
 }
 
 @freezed
@@ -574,8 +568,7 @@ abstract class GenericWithArgumentFactories<T>
   factory GenericWithArgumentFactories.fromJson(
     Map<String, dynamic> json,
     T Function(Object? json) fromJsonT,
-  ) =>
-      _$GenericWithArgumentFactoriesFromJson<T>(json, fromJsonT);
+  ) => _$GenericWithArgumentFactoriesFromJson<T>(json, fromJsonT);
 }
 
 @Freezed(genericArgumentFactories: true)
@@ -588,8 +581,7 @@ abstract class GenericTupleWithArgumentFactories<T, S>
     Map<String, dynamic> json,
     T Function(Object? json) fromJsonT,
     S Function(Object? json) fromJsonS,
-  ) =>
-      _$GenericTupleWithArgumentFactoriesFromJson(json, fromJsonT, fromJsonS);
+  ) => _$GenericTupleWithArgumentFactoriesFromJson(json, fromJsonT, fromJsonS);
 }
 
 @Freezed(genericArgumentFactories: true)
@@ -622,10 +614,9 @@ abstract class GenericMultiCtorWithArgumentFactories<T, S>
     Map<String, dynamic> json,
     T Function(Object? json) fromJsonT,
     S Function(Object? json) fromJsonS,
-  ) =>
-      _$GenericMultiCtorWithArgumentFactoriesFromJson<T, S>(
-        json,
-        fromJsonT,
-        fromJsonS,
-      );
+  ) => _$GenericMultiCtorWithArgumentFactoriesFromJson<T, S>(
+    json,
+    fromJsonT,
+    fromJsonS,
+  );
 }

--- a/packages/freezed/test/integration/multiple_constructors.dart
+++ b/packages/freezed/test/integration/multiple_constructors.dart
@@ -140,6 +140,7 @@ abstract class Complex with _$Complex {
   const factory Complex.first(
     /// World
     String a, {
+
     /// B
     bool? b,
     double? d,
@@ -147,6 +148,7 @@ abstract class Complex with _$Complex {
 
   const factory Complex.second(
     String a, [
+
     /// C
     int? c,
     double? d,

--- a/packages/freezed/test/integration/single_class_constructor.dart
+++ b/packages/freezed/test/integration/single_class_constructor.dart
@@ -12,9 +12,7 @@ typedef StringAlias = String;
 // https://github.com/rrousselGit/freezed/issues/1204
 @freezed
 sealed class Regression1204 with _$Regression1204 {
-  const factory Regression1204({
-    required StringAlias id,
-  }) = _Regression1204;
+  const factory Regression1204({required StringAlias id}) = _Regression1204;
 }
 
 @optionalTypeArgs
@@ -305,6 +303,7 @@ abstract class Doc with _$Doc {
     /// line
     /// positional
     int positional, {
+
     /// Single line named
     int? named,
 
@@ -533,8 +532,8 @@ abstract class NullDefault with _$NullDefault {
 @freezed
 abstract class ExplicitConstDefault with _$ExplicitConstDefault {
   factory ExplicitConstDefault(
-      //ignore: unnecessary_const
-      [@Default(const <Object>[]) List<Object> value]) = _ExplicitConstDefault;
+  //ignore: unnecessary_const
+  [@Default(const <Object>[]) List<Object> value]) = _ExplicitConstDefault;
 }
 
 @freezed

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -747,9 +747,11 @@ Future<void> main() async {
   });
 
   test('has no issue', () async {
-    var errorResult = await jsonFile.session.getErrors(
-      '/freezed/test/integration/json.freezed.dart',
-    ) as ErrorsResult;
+    var errorResult =
+        await jsonFile.session.getErrors(
+              '/freezed/test/integration/json.freezed.dart',
+            )
+            as ErrorsResult;
     expect(errorResult.errors, isEmpty);
   }, skip: true);
 

--- a/packages/freezed/test/manual_test.dart
+++ b/packages/freezed/test/manual_test.dart
@@ -21,7 +21,7 @@ class CartLine with _$CartLine {
   final int amount;
 
   CartLine({required this.product, int? defaultAmount})
-      : amount = defaultAmount ?? product.price;
+    : amount = defaultAmount ?? product.price;
 }
 
 // Regression for https://github.com/rrousselGit/freezed/issues/1168
@@ -109,8 +109,9 @@ void main() {
   group('CartLine', () {
     test('has copyWith use default', () {
       expect(
-        CartLine(product: const Product(42))
-            .copyWith(product: const Product(21)),
+        CartLine(
+          product: const Product(42),
+        ).copyWith(product: const Product(21)),
         CartLine(product: const Product(21)),
       );
     });

--- a/packages/freezed/test/map_test.dart
+++ b/packages/freezed/test/map_test.dart
@@ -33,7 +33,8 @@ void main() {
 
     group('default ctor', () {
       test("assert callbacks can't be null", () async {
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -45,9 +46,12 @@ void main() {
     second: (SwitchTest2 c) {},
   );
 }
-'''), completes);
+'''),
+          completes,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -59,9 +63,12 @@ void main() {
     second: (SwitchTest2 value) {},
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -73,9 +80,12 @@ void main() {
     second: (SwitchTest2 value) {},
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -87,7 +97,9 @@ void main() {
     second: null,
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
       });
       test('calls default callback', () {
         final value = SwitchTest('a');
@@ -105,7 +117,8 @@ void main() {
 
     group('first ctor', () {
       test("assert callbacks can't be null", () async {
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -117,9 +130,12 @@ void main() {
     second: (SwitchTest2 c) {},
   );
 }
-'''), completes);
+'''),
+          completes,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -131,9 +147,12 @@ void main() {
     second: (SwitchTest2 value) {},
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -145,9 +164,12 @@ void main() {
     second: (SwitchTest2 value) {},
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -159,7 +181,9 @@ void main() {
     second: null,
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
       });
 
       test('calls first callback', () {
@@ -177,7 +201,8 @@ void main() {
     });
     group('second ctor', () {
       test("assert callbacks can't be null", () async {
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -189,9 +214,12 @@ void main() {
     second: (SwitchTest2 c) {},
   );
 }
-'''), completes);
+'''),
+          completes,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -203,9 +231,12 @@ void main() {
     second: (SwitchTest2 value) {},
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -217,9 +248,12 @@ void main() {
     second: (SwitchTest2 value) {},
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -231,7 +265,9 @@ void main() {
     second: null,
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
       });
       test('calls second callback', () {
         final value = SwitchTest.second('a', 21, .42);
@@ -248,9 +284,8 @@ void main() {
     });
 
     test('named parameters are marked as required', () async {
-      final main = await resolveSources(
-        {
-          'freezed|test/integration/main.dart': r'''
+      final main = await resolveSources({
+        'freezed|test/integration/main.dart': r'''
 library main;
 import 'multiple_constructors.dart';
 
@@ -262,12 +297,11 @@ void main() {
   );
 }
 ''',
-        },
-        (r) => r.findLibraryByName('main'),
-      );
+      }, (r) => r.findLibraryByName('main'));
 
-      final errorResult = await main!.session
-          .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
+      final errorResult =
+          await main!.session.getErrors('/freezed/test/integration/main.dart')
+              as ErrorsResult;
 
       expect(errorResult.errors, isNotEmpty);
     });
@@ -309,7 +343,8 @@ void main() {
     });
 
     test('assert orElse is passed', () async {
-      await expectLater(compile(r'''
+      await expectLater(
+        compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -320,9 +355,12 @@ void main() {
     orElse: () {},
   );
 }
-'''), completes);
+'''),
+        completes,
+      );
 
-      await expectLater(compile(r'''
+      await expectLater(
+        compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -333,9 +371,12 @@ void main() {
     orElse: null,
   );
 }
-'''), throwsCompileError);
+'''),
+        throwsCompileError,
+      );
 
-      await expectLater(compile(r'''
+      await expectLater(
+        compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -346,7 +387,9 @@ void main() {
     orElse: null,
   );
 }
-'''), throwsCompileError);
+'''),
+        throwsCompileError,
+      );
     });
 
     test('orElse is called', () {
@@ -364,9 +407,8 @@ void main() {
     });
 
     test('orElse is required', () async {
-      final main = await resolveSources(
-        {
-          'freezed|test/integration/main.dart': r'''
+      final main = await resolveSources({
+        'freezed|test/integration/main.dart': r'''
 library main;
 import 'multiple_constructors.dart';
 
@@ -376,12 +418,11 @@ void main() {
   value.maybeMap(null);
 }
 ''',
-        },
-        (r) => r.findLibraryByName('main'),
-      );
+      }, (r) => r.findLibraryByName('main'));
 
-      final errorResult = await main!.session
-          .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
+      final errorResult =
+          await main!.session.getErrors('/freezed/test/integration/main.dart')
+              as ErrorsResult;
 
       expect(errorResult.errors, isNotEmpty);
     });
@@ -394,9 +435,9 @@ void main() {
     });
 
     test('can map to nullable return type without type cast', () {
-      String? res = NoDefault.first('a').mapOrNull(
-        first: (value) => value.a.isEmpty ? null : value.a,
-      );
+      String? res = NoDefault.first(
+        'a',
+      ).mapOrNull(first: (value) => value.a.isEmpty ? null : value.a);
       expect(res, 'a');
     });
 

--- a/packages/freezed/test/multiple_constructors_test.dart
+++ b/packages/freezed/test/multiple_constructors_test.dart
@@ -25,8 +25,8 @@ Future<void> main() async {
 
   ClassElement _getClassElement(String elementName) {
     return sources.topLevelElements.whereType<ClassElement>().firstWhere(
-          (element) => element.name == elementName,
-        );
+      (element) => element.name == elementName,
+    );
   }
 
   test('Response', () {
@@ -176,9 +176,11 @@ void main() {
         ),
       );
 
-      final errorResult = await main.session.getErrors(
-        '/freezed/test/integration/multiple_constructors.freezed.dart',
-      ) as ErrorsResult;
+      final errorResult =
+          await main.session.getErrors(
+                '/freezed/test/integration/multiple_constructors.freezed.dart',
+              )
+              as ErrorsResult;
 
       expect(errorResult.errors, isEmpty);
     });
@@ -245,21 +247,12 @@ void main() {
         21,
       );
       expect(
-        RequiredParams.second(a: 'a').whenOrNull(
-          (a) => 21,
-          second: (_) => 42,
-        ),
+        RequiredParams.second(a: 'a').whenOrNull((a) => 21, second: (_) => 42),
         42,
       );
 
-      expect(
-        RequiredParams(a: 'a').whenOrNull(null, second: (_) => 42),
-        null,
-      );
-      expect(
-        RequiredParams.second(a: 'a').whenOrNull((a) => 21),
-        null,
-      );
+      expect(RequiredParams(a: 'a').whenOrNull(null, second: (_) => 42), null);
+      expect(RequiredParams.second(a: 'a').whenOrNull((a) => 21), null);
     });
 
     test('map works on unnamed constructors', () {
@@ -278,10 +271,7 @@ void main() {
       );
 
       expect(RequiredParams(a: 'a').mapOrNull(null), null);
-      expect(
-        RequiredParams.second(a: 'a').mapOrNull(null),
-        null,
-      );
+      expect(RequiredParams.second(a: 'a').mapOrNull(null), null);
     });
 
     test('maybeMap works on unnamed constructors', () {
@@ -327,31 +317,27 @@ void main() {
     });
 
     test('mapOrNull can use FutureOr', () async {
-      var res = NoDefault.first('a').mapOrNull<FutureOr<int>>(
-        first: (a) => 21,
-      );
+      var res = NoDefault.first('a').mapOrNull<FutureOr<int>>(first: (a) => 21);
 
       expect(res, 21);
 
-      res = NoDefault.second('a').mapOrNull<FutureOr<int>>(
-        second: (b) => Future.value(42),
-      );
+      res = NoDefault.second(
+        'a',
+      ).mapOrNull<FutureOr<int>>(second: (b) => Future.value(42));
 
       await expectLater(res, completion(42));
     });
 
     test('map can use FutureOr', () async {
-      var res = NoDefault.first('a').map<FutureOr<int>>(
-        first: (a) => 21,
-        second: (b) => Future.value(42),
-      );
+      var res = NoDefault.first(
+        'a',
+      ).map<FutureOr<int>>(first: (a) => 21, second: (b) => Future.value(42));
 
       expect(res, 21);
 
-      res = NoDefault.second('a').map<FutureOr<int>>(
-        first: (a) => 21,
-        second: (b) => Future.value(42),
-      );
+      res = NoDefault.second(
+        'a',
+      ).map<FutureOr<int>>(first: (a) => 21, second: (b) => Future.value(42));
 
       await expectLater(res, completion(42));
     });
@@ -373,31 +359,29 @@ void main() {
     });
 
     test('whenOrNull can use FutureOr', () async {
-      var res = NoDefault.first('a').whenOrNull<FutureOr<int>>(
-        first: (a) => 21,
-      );
+      var res = NoDefault.first(
+        'a',
+      ).whenOrNull<FutureOr<int>>(first: (a) => 21);
 
       expect(res, 21);
 
-      res = NoDefault.second('a').whenOrNull<FutureOr<int>>(
-        second: (b) => Future.value(42),
-      );
+      res = NoDefault.second(
+        'a',
+      ).whenOrNull<FutureOr<int>>(second: (b) => Future.value(42));
 
       await expectLater(res, completion(42));
     });
 
     test('when can use FutureOr', () async {
-      var res = NoDefault.first('a').when<FutureOr<int>>(
-        first: (a) => 21,
-        second: (b) => Future.value(42),
-      );
+      var res = NoDefault.first(
+        'a',
+      ).when<FutureOr<int>>(first: (a) => 21, second: (b) => Future.value(42));
 
       expect(res, 21);
 
-      res = NoDefault.second('a').when<FutureOr<int>>(
-        first: (a) => 21,
-        second: (b) => Future.value(42),
-      );
+      res = NoDefault.second(
+        'a',
+      ).when<FutureOr<int>>(first: (a) => 21, second: (b) => Future.value(42));
 
       await expectLater(res, completion(42));
     });
@@ -581,12 +565,10 @@ void main() {
     var error = Error();
     final value = NameConflict.error(error);
 
-    expect(
-        switch (value) {
-          Something() => 42,
-          SomeError(:final error) => error,
-        },
-        error);
+    expect(switch (value) {
+      Something() => 42,
+      SomeError(:final error) => error,
+    }, error);
   });
   group('NestedList', () {
     test('generates List of correct type', () async {

--- a/packages/freezed/test/optional_maybe_test.dart
+++ b/packages/freezed/test/optional_maybe_test.dart
@@ -8,22 +8,24 @@ import 'integration/optional_maybe.dart';
 void main() {
   test('has no issue', () async {
     final main = await resolveSources(
-      {
-        'freezed|test/integration/optional_maybe.dart': useAssetReader,
-      },
+      {'freezed|test/integration/optional_maybe.dart': useAssetReader},
       (r) => r.libraries.firstWhere(
-          (element) => element.source.toString().contains('optional_maybe')),
+        (element) => element.source.toString().contains('optional_maybe'),
+      ),
     );
 
-    final errorResult = await main.session
-            .getErrors('/freezed/test/integration/optional_maybe.freezed.dart')
-        as ErrorsResult;
+    final errorResult =
+        await main.session.getErrors(
+              '/freezed/test/integration/optional_maybe.freezed.dart',
+            )
+            as ErrorsResult;
 
     expect(errorResult.errors, isEmpty);
   });
 
   test('does not generates maybeMap', () async {
-    await expectLater(compile(r'''
+    await expectLater(
+      compile(r'''
       import 'optional_maybe.dart';
 
       void main() {
@@ -36,19 +38,19 @@ void main() {
         );
         value.mapOrNull();
       }
-      '''), throwsCompileError);
+      '''),
+      throwsCompileError,
+    );
 
     const OptionalMaybeMap.first()
       ..whenOrNull()
       ..maybeWhen(orElse: () {})
-      ..when(
-        first: () {},
-        second: () {},
-      );
+      ..when(first: () {}, second: () {});
   });
 
   test('does not generates maybeWhen', () async {
-    await expectLater(compile(r'''
+    await expectLater(
+      compile(r'''
       import 'optional_maybe.dart';
 
       void main() {
@@ -61,25 +63,27 @@ void main() {
         );
         value.whenOrNull();
       }
-      '''), throwsCompileError);
+      '''),
+      throwsCompileError,
+    );
 
     const OptionalMaybeWhen.first()
       ..mapOrNull()
       ..maybeMap(orElse: () {})
-      ..map(
-        first: (_) {},
-        second: (_) {},
-      );
+      ..map(first: (_) {}, second: (_) {});
   });
 
   test('can disable copyWith', () async {
-    await expectLater(compile(r'''
+    await expectLater(
+      compile(r'''
 import 'optional_maybe.dart';
 
 void main() {
   OptionalCopyWith().copyWith;
 }
-'''), throwsCompileError);
+'''),
+      throwsCompileError,
+    );
   });
 
   test('can disable toString', () {
@@ -90,14 +94,8 @@ void main() {
   });
 
   test('can disable ==/hash', () {
-    expect(
-      OptionalEqual(),
-      isNot(OptionalEqual()),
-    );
-    expect(
-      OptionalEqual().hashCode,
-      isNot(OptionalEqual().hashCode),
-    );
+    expect(OptionalEqual(), isNot(OptionalEqual()));
+    expect(OptionalEqual().hashCode, isNot(OptionalEqual().hashCode));
   });
 
   test('can force the generation of when/map', () {
@@ -122,13 +120,16 @@ void main() {
     OptionalToJson();
     OptionalToJson.fromJson({});
 
-    await expectLater(compile(r'''
+    await expectLater(
+      compile(r'''
 import 'optional_maybe.dart';
 
 void main() {
   OptionalToJson().toJson;
 }
-'''), throwsCompileError);
+'''),
+      throwsCompileError,
+    );
   });
 
   test('can force toJson', () async {

--- a/packages/freezed/test/single_class_constructor_test.dart
+++ b/packages/freezed/test/single_class_constructor_test.dart
@@ -27,15 +27,16 @@ class MyObject {
 Future<void> main() async {
   Future<LibraryElement> analyze() {
     return resolveSources(
-        {
-          'freezed|test/integration/single_class_constructor.dart':
-              useAssetReader,
-        },
-        (r) => r.libraries.firstWhere((e) {
-              return e.source.fullName ==
-                  '/freezed/test/integration/single_class_constructor.dart';
-            }),
-        readAllSourcesFromFilesystem: true);
+      {
+        'freezed|test/integration/single_class_constructor.dart':
+            useAssetReader,
+      },
+      (r) => r.libraries.firstWhere((e) {
+        return e.source.fullName ==
+            '/freezed/test/integration/single_class_constructor.dart';
+      }),
+      readAllSourcesFromFilesystem: true,
+    );
   }
 
   test('Regression1204', () {
@@ -210,8 +211,9 @@ Future<void> main() async {
   test('documentation', () async {
     final singleClassLibrary = await analyze();
 
-    final doc = singleClassLibrary.topLevelElements
-        .firstWhere((e) => e.name == 'Doc') as ClassElement;
+    final doc =
+        singleClassLibrary.topLevelElements.firstWhere((e) => e.name == 'Doc')
+            as ClassElement;
 
     expect(
       doc.mixins.first.accessors.where(
@@ -246,23 +248,35 @@ Future<void> main() async {
   });
 
   test('deep copy of recursive classes', () {
-    final value = Product(name: 'foo', parent: Product(name: 'bar'));
+    final value = Product(
+      name: 'foo',
+      parent: Product(name: 'bar'),
+    );
 
     expect(
       value.copyWith.parent!(name: 'baz'),
-      Product(name: 'foo', parent: Product(name: 'baz')),
+      Product(
+        name: 'foo',
+        parent: Product(name: 'baz'),
+      ),
     );
 
     final value2 = Product(
       name: 'foo',
-      parent: Product(name: 'bar', parent: Product(name: 'baz')),
+      parent: Product(
+        name: 'bar',
+        parent: Product(name: 'baz'),
+      ),
     );
 
     expect(
       value2.copyWith.parent!.parent!(name: 'quaz'),
       Product(
         name: 'foo',
-        parent: Product(name: 'bar', parent: Product(name: 'quaz')),
+        parent: Product(
+          name: 'bar',
+          parent: Product(name: 'quaz'),
+        ),
       ),
     );
   });
@@ -361,9 +375,11 @@ void main() {
   test('has no issue', () async {
     final singleClassLibrary = await analyze();
 
-    final errorResult = await singleClassLibrary.session.getErrors(
-      '/freezed/test/integration/single_class_constructor.freezed.dart',
-    ) as ErrorsResult;
+    final errorResult =
+        await singleClassLibrary.session.getErrors(
+              '/freezed/test/integration/single_class_constructor.freezed.dart',
+            )
+            as ErrorsResult;
 
     expect(errorResult.errors, isEmpty);
   });
@@ -374,9 +390,9 @@ void main() {
 
   test('single-case union does have map', () async {
     expect(
-      SingleNamedCtor.named(42).map(
-        named: (WhateverSingleNamedCtor value) => '${value.a}',
-      ),
+      SingleNamedCtor.named(
+        42,
+      ).map(named: (WhateverSingleNamedCtor value) => '${value.a}'),
       '42',
     );
   });
@@ -616,8 +632,9 @@ void main() {
   test(
     'required parameters are transmitted to redirected constructor',
     () async {
-      final main = await resolveSources({
-        'freezed|test/integration/main.dart': '''
+      final main = await resolveSources(
+        {
+          'freezed|test/integration/main.dart': '''
 library main;
 
 import 'single_class_constructor.dart';
@@ -626,11 +643,14 @@ void main() {
   WhateverRequired();
 }
     ''',
-      }, (r) => r.findLibraryByName('main'),
-          readAllSourcesFromFilesystem: true);
+        },
+        (r) => r.findLibraryByName('main'),
+        readAllSourcesFromFilesystem: true,
+      );
 
-      final errorResult = await main!.session
-          .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
+      final errorResult =
+          await main!.session.getErrors('/freezed/test/integration/main.dart')
+              as ErrorsResult;
 
       expect(
         errorResult.errors.map((e) => e.toString()),

--- a/packages/freezed/test/source_gen_src.dart
+++ b/packages/freezed/test/source_gen_src.dart
@@ -13,9 +13,7 @@ To fix, either:
 ''')
 @freezed
 class RequiredCloneable with _$RequiredCloneable {
-  RequiredCloneable({
-    required int notCloneable,
-  });
+  RequiredCloneable({required int notCloneable});
 }
 
 mixin _$RequiredCloneable {}

--- a/packages/freezed/test/source_gen_test.dart
+++ b/packages/freezed/test/source_gen_test.dart
@@ -40,12 +40,13 @@ Future<void> main() async {
       // Verify the custom header is present
       expect(content, contains('// coverage:ignore-file'));
       expect(
-          content.substring(
-            0,
-            '// GENERATED CODE - DO NOT MODIFY BY HAND'.length + 1,
-          ),
-          startsWith('// GENERATED CODE - DO NOT MODIFY BY HAND'),
-          reason: 'Start with GENERATED for Github Linguist');
+        content.substring(
+          0,
+          '// GENERATED CODE - DO NOT MODIFY BY HAND'.length + 1,
+        ),
+        startsWith('// GENERATED CODE - DO NOT MODIFY BY HAND'),
+        reason: 'Start with GENERATED for Github Linguist',
+      );
       expect(content, contains('// ignore_for_file: type=lint'));
 
       // Verify the default source_gen header is NOT present

--- a/packages/freezed/test/typedef_parameter_test.dart
+++ b/packages/freezed/test/typedef_parameter_test.dart
@@ -14,9 +14,11 @@ void main() {
       ),
     );
 
-    final errorResult = await main.session.getErrors(
-      '/freezed/test/integration/typedef_parameter_test.freezed.dart',
-    ) as ErrorsResult;
+    final errorResult =
+        await main.session.getErrors(
+              '/freezed/test/integration/typedef_parameter_test.freezed.dart',
+            )
+            as ErrorsResult;
 
     expect(errorResult.errors, isEmpty);
   });

--- a/packages/freezed/test/when_test.dart
+++ b/packages/freezed/test/when_test.dart
@@ -31,7 +31,8 @@ void main() {
     });
     group('default ctor', () {
       test("assert callbacks can't be null", () async {
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -43,9 +44,12 @@ void main() {
     second: (String a, int? c, double? d) {},
   );
 }
-'''), completes);
+'''),
+          completes,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -57,9 +61,12 @@ void main() {
     second: (String value) {},
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -71,9 +78,12 @@ void main() {
     second: (String value) {},
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -85,7 +95,9 @@ void main() {
     second: null,
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
       });
 
       test('calls default callback', () {
@@ -104,7 +116,8 @@ void main() {
 
     group('first ctor', () {
       test("assert callbacks can't be null", () async {
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -115,9 +128,12 @@ void main() {
     second: (String a, int? c, double? d) {},
   );
 }
-'''), completes);
+'''),
+          completes,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -129,9 +145,12 @@ void main() {
     second: (String value) {},
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -143,9 +162,12 @@ void main() {
     second: (String value) {},
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -157,7 +179,9 @@ void main() {
     second: null,
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
       });
 
       test('calls first callback', () {
@@ -176,7 +200,8 @@ void main() {
 
     group('second ctor', () {
       test("assert callbacks can't be null", () async {
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -187,9 +212,12 @@ void main() {
     second: (String a, int? c, double? d) {},
   );
 }
-'''), completes);
+'''),
+          completes,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -201,9 +229,12 @@ void main() {
     second: (String value) {},
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -215,9 +246,12 @@ void main() {
     second: (String value) {},
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
 
-        await expectLater(compile(r'''
+        await expectLater(
+          compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -229,7 +263,9 @@ void main() {
     second: null,
   );
 }
-'''), throwsCompileError);
+'''),
+          throwsCompileError,
+        );
       });
 
       test('calls second callback', () {
@@ -247,9 +283,8 @@ void main() {
     });
 
     test('named parameters are marked as required', () async {
-      final main = await resolveSources(
-        {
-          'freezed|test/integration/main.dart': r'''
+      final main = await resolveSources({
+        'freezed|test/integration/main.dart': r'''
 library main;
 import 'multiple_constructors.dart';
 
@@ -261,12 +296,11 @@ void main() {
   );
 }
 ''',
-        },
-        (r) => r.findLibraryByName('main'),
-      );
+      }, (r) => r.findLibraryByName('main'));
 
-      final errorResult = await main!.session
-          .getErrors('/freezed/test/integration/main.dart') as ErrorsResult;
+      final errorResult =
+          await main!.session.getErrors('/freezed/test/integration/main.dart')
+              as ErrorsResult;
 
       expect(errorResult.errors, isNotEmpty);
     });
@@ -308,7 +342,8 @@ void main() {
     });
 
     test('assert orElse is passed', () async {
-      await expectLater(compile(r'''
+      await expectLater(
+        compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -319,9 +354,12 @@ void main() {
     orElse: () {},
   );
 }
-'''), completes);
+'''),
+        completes,
+      );
 
-      await expectLater(compile(r'''
+      await expectLater(
+        compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -332,9 +370,12 @@ void main() {
     orElse: null,
   );
 }
-'''), throwsCompileError);
+'''),
+        throwsCompileError,
+      );
 
-      await expectLater(compile(r'''
+      await expectLater(
+        compile(r'''
 import 'multiple_constructors.dart';
 
 void main() {
@@ -345,7 +386,9 @@ void main() {
     orElse: null,
   );
 }
-'''), throwsCompileError);
+'''),
+        throwsCompileError,
+      );
     });
 
     test('orElse is called', () {
@@ -365,9 +408,9 @@ void main() {
 
   group('whenOrNull', () {
     test('can map to nullable return type without type cast', () {
-      String? res = NoDefault.first('a').whenOrNull(
-        first: (a) => a.isEmpty ? null : a,
-      );
+      String? res = NoDefault.first(
+        'a',
+      ).whenOrNull(first: (a) => a.isEmpty ? null : a);
       expect(res, 'a');
     });
 
@@ -377,15 +420,9 @@ void main() {
     });
 
     test('calls callback on matching constructor', () {
-      expect(
-        NoDefault.first('a').whenOrNull(first: (v) => v),
-        'a',
-      );
+      expect(NoDefault.first('a').whenOrNull(first: (v) => v), 'a');
 
-      expect(
-        NoDefault.second('a').whenOrNull(second: (v) => v),
-        'a',
-      );
+      expect(NoDefault.second('a').whenOrNull(second: (v) => v), 'a');
     });
   });
 }


### PR DESCRIPTION
Flutter channel name has changed from `master` to `main`, change it to `main` to get the latest Flutter which has 3.8.0.

But, this hits an [issue in custom_lint](https://github.com/invertase/dart_custom_lint/issues/337), so use `stable` for now.

Using Dart 3.8.0 triggers a formatting change: reformat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to use the Flutter stable channel instead of master.
  * Raised minimum supported Dart SDK to 3.8.0 and analyzer version to 7.5.9.

* **Style**
  * Applied consistent formatting and indentation improvements across source files and test cases for better readability and code style.

* **Documentation**
  * Updated changelog to reflect new minimum version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->