### PR TITLE
Handle analyzer 8

### DIFF
--- a/packages/freezed/lib/src/ast.dart
+++ b/packages/freezed/lib/src/ast.dart
@@ -1,6 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 
 extension AstX on AstNode {
   String? get documentation {
@@ -28,10 +28,10 @@ extension ClassX on ClassDeclaration {
       element,
       ...element.allSupertypes
           .where((e) => !e.isDartCoreObject)
-          .map((e) => e.element3),
+          .map((e) => e.element),
     ]) {
-      for (final method in type.methods2) {
-        if (method.name3 == 'toString') {
+      for (final method in type.methods) {
+        if (method.name == 'toString') {
           return true;
         }
       }
@@ -42,50 +42,50 @@ extension ClassX on ClassDeclaration {
 
   bool get hasSuperEqual => declaredFragment!.element.allSupertypes
       .where((e) => !e.isDartCoreObject)
-      .map((e) => e.element3)
+      .map((e) => e.element)
       .any((e) => e.hasEqual);
 
   bool get hasCustomEquals => declaredFragment!.element.hasEqual;
 
   bool get hasSuperHashCode => declaredFragment!.element.allSupertypes
       .where((e) => !e.isDartCoreObject)
-      .map((e) => e.element3)
+      .map((e) => e.element)
       .any((e) => e.hasHashCode);
 }
 
-extension on InterfaceElement2 {
-  bool get hasEqual => methods2.any(((e) => e.isOperator && e.name3 == '=='));
+extension on InterfaceElement {
+  bool get hasEqual => methods.any(((e) => e.isOperator && e.name == '=='));
 
-  bool get hasHashCode => getters2.any((e) => e.name3 == 'hashCode');
+  bool get hasHashCode => getters.any((e) => e.name == 'hashCode');
 }
 
 extension ConstructorX on ConstructorDeclaration {
   String get fullName {
-    final classElement = declaredFragment!.element.enclosingElement2;
+    final classElement = declaredFragment!.element.enclosingElement;
 
-    var generics = classElement.typeParameters2
-        .map((e) => '\$${e.name3}')
+    var generics = classElement.typeParameters
+        .map((e) => '\$${e.name}')
         .join(', ');
     if (generics.isNotEmpty) {
       generics = '<$generics>';
     }
 
-    final className = classElement.enclosingElement2.name3;
+    final className = classElement.enclosingElement.name;
 
     return name == null ? '$className$generics' : '$className$generics.$name';
   }
 
   String get escapedName {
-    final classElement = declaredFragment!.element.enclosingElement2;
+    final classElement = declaredFragment!.element.enclosingElement;
 
-    var generics = classElement.typeParameters2
-        .map((e) => '\$${e.name3}')
+    var generics = classElement.typeParameters
+        .map((e) => '\$${e.name}')
         .join(', ');
     if (generics.isNotEmpty) {
       generics = '<$generics>';
     }
 
-    final escapedElementName = classElement.name3!.replaceAll(r'$', r'\$');
+    final escapedElementName = classElement.name!.replaceAll(r'$', r'\$');
     final escapedConstructorName = name?.lexeme.replaceAll(r'$', r'\$');
 
     return escapedConstructorName == null

--- a/packages/freezed/lib/src/parse_generator.dart
+++ b/packages/freezed/lib/src/parse_generator.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:collection/collection.dart';
 import 'package:source_gen/source_gen.dart';
@@ -57,7 +57,7 @@ abstract class ParserGenerator<AnnotationT>
 
   @override
   Stream<String> generateForAnnotatedElement(
-    Element2 element,
+    Element element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async* {
@@ -75,7 +75,7 @@ abstract class ParserGenerator<AnnotationT>
     unit as ResolvedUnitResult;
     final Object? ast = unit.unit.declarations.firstWhereOrNull(
       (declaration) =>
-          declaration.declaredFragment?.element.name3 == element.name3!,
+          declaration.declaredFragment?.element.name == element.name!,
     );
     if (ast == null) {
       throw InvalidGenerationSourceError('Ast not found', element: element);

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:freezed/src/freezed_generator.dart';
 import 'package:freezed/src/models.dart';
 import 'package:freezed/src/templates/properties.dart';
@@ -522,7 +522,7 @@ extension DefaultValue on FormalParameterElement {
       inPackage: 'freezed_annotation',
     );
 
-    for (final meta in metadata2.annotations) {
+    for (final meta in metadata.annotations) {
       final obj = meta.computeConstantValue()!;
       if (matcher.isExactlyType(obj.type!)) {
         final source = meta.toSource();

--- a/packages/freezed/lib/src/templates/parameter_template.dart
+++ b/packages/freezed/lib/src/templates/parameter_template.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:collection/collection.dart';
 import 'package:freezed/src/ast.dart';
@@ -11,10 +11,10 @@ class GenericsDefinitionTemplate {
   GenericsDefinitionTemplate(this.typeParameters);
 
   factory GenericsDefinitionTemplate.fromGenericElement(
-    List<TypeParameterElement2> generics,
+    List<TypeParameterElement> generics,
   ) {
     return GenericsDefinitionTemplate(
-      generics.map((e) => e.displayString2()).toList(),
+      generics.map((e) => e.displayString()).toList(),
     );
   }
 
@@ -36,9 +36,9 @@ class GenericsParameterTemplate {
   GenericsParameterTemplate(this.typeParameters);
 
   factory GenericsParameterTemplate.fromGenericElement(
-    List<TypeParameterElement2> generics,
+    List<TypeParameterElement> generics,
   ) {
-    return GenericsParameterTemplate(generics.map((e) => e.name3!).toList());
+    return GenericsParameterTemplate(generics.map((e) => e.name!).toList());
   }
   final List<String> typeParameters;
 
@@ -70,13 +70,13 @@ class ParametersTemplate {
       final e = p.declaredFragment!.element;
 
       final value = Parameter(
-        name: e.name3!,
+        name: e.name!,
         defaultValueSource: e.defaultValue,
         isRequired: e.isRequiredNamed,
         isFinal: addImplicitFinal || e.isFinal,
         type: e.type,
         typeDisplayString: parseTypeSource(p),
-        decorators: parseDecorators(e.metadata2.annotations),
+        decorators: parseDecorators(e.metadata.annotations),
         doc: p.documentation ?? '',
         showDefaultValue: true,
         parameterElement: e,

--- a/packages/freezed/lib/src/templates/properties.dart
+++ b/packages/freezed/lib/src/templates/properties.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:freezed/src/ast.dart';
 import 'package:freezed/src/templates/parameter_template.dart';
@@ -52,13 +52,13 @@ class Property {
     }
 
     return Property(
-      name: element.name3!,
+      name: element.name!,
       isFinal: addImplicitFinal || element.isFinal,
       isSynthetic: isSynthetic,
       doc: parameter.documentation ?? '',
       type: element.type,
       typeDisplayString: parseTypeSource(parameter),
-      decorators: parseDecorators(element.metadata2.annotations),
+      decorators: parseDecorators(element.metadata.annotations),
       defaultValueSource: defaultValue,
       hasJsonKey: element.hasJsonKey,
     );
@@ -114,7 +114,7 @@ class Property {
     bool? hasJsonKey,
     String? doc,
     bool? isPossiblyDartCollection,
-    TypeParameterElement2? parameterElement,
+    TypeParameterElement? parameterElement,
   }) {
     return Property(
       type: type ?? this.type,

--- a/packages/freezed/lib/src/templates/prototypes.dart
+++ b/packages/freezed/lib/src/templates/prototypes.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -41,8 +41,8 @@ extension FreezedElementAnnotation on ElementAnnotation {
   }
 }
 
-bool isDefaultConstructor(ConstructorElement2 constructor) {
-  return constructor.name3 == 'new';
+bool isDefaultConstructor(ConstructorElement constructor) {
+  return constructor.name == 'new';
 }
 
 String constructorNameToCallbackName(String constructorName) {

--- a/packages/freezed/lib/src/tools/imports.dart
+++ b/packages/freezed/lib/src/tools/imports.dart
@@ -1,18 +1,18 @@
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 
-extension LibraryHasImport on LibraryElement2 {
-  LibraryElement2? findTransitiveExportWhere(
-    bool Function(LibraryElement2 library) visitor,
+extension LibraryHasImport on LibraryElement {
+  LibraryElement? findTransitiveExportWhere(
+    bool Function(LibraryElement library) visitor,
   ) {
     if (visitor(this)) return this;
 
-    final visitedLibraries = <LibraryElement2>{};
-    LibraryElement2? visitLibrary(LibraryElement2 library) {
+    final visitedLibraries = <LibraryElement>{};
+    LibraryElement? visitLibrary(LibraryElement library) {
       if (!visitedLibraries.add(library)) return null;
 
       if (visitor(library)) return library;
 
-      for (final export in library.exportedLibraries2) {
+      for (final export in library.exportedLibraries) {
         final result = visitLibrary(export);
         if (result != null) return result;
       }
@@ -20,7 +20,7 @@ extension LibraryHasImport on LibraryElement2 {
       return null;
     }
 
-    for (final import in exportedLibraries2) {
+    for (final import in exportedLibraries) {
       final result = visitLibrary(import);
       if (result != null) return result;
     }
@@ -28,7 +28,7 @@ extension LibraryHasImport on LibraryElement2 {
     return null;
   }
 
-  bool anyTransitiveExport(bool Function(LibraryElement2 library) visitor) {
+  bool anyTransitiveExport(bool Function(LibraryElement library) visitor) {
     return findTransitiveExportWhere(visitor) != null;
   }
 }

--- a/packages/freezed/lib/src/tools/recursive_import_locator.dart
+++ b/packages/freezed/lib/src/tools/recursive_import_locator.dart
@@ -1,7 +1,7 @@
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:collection/collection.dart';
 
-extension FindAllAvailableTopLevelElements on LibraryElement2 {
+extension FindAllAvailableTopLevelElements on LibraryElement {
   bool isFromPackage(String packageName) {
     return firstFragment.source.fullName.startsWith('/$packageName/');
   }
@@ -11,7 +11,7 @@ extension FindAllAvailableTopLevelElements on LibraryElement2 {
   ///
   /// This function does not guarantees that the elements returned are unique.
   /// It is possible for the same object to be present multiple times in the list.
-  Iterable<Element2> findAllAvailableTopLevelElements() {
+  Iterable<Element> findAllAvailableTopLevelElements() {
     return _findAllAvailableTopLevelElements(
       {},
       checkExports: false,
@@ -23,20 +23,20 @@ extension FindAllAvailableTopLevelElements on LibraryElement2 {
     );
   }
 
-  Iterable<Element2> _findAllAvailableTopLevelElements(
+  Iterable<Element> _findAllAvailableTopLevelElements(
     Set<_LibraryKey> visitedLibraryPaths, {
     required bool checkExports,
     required _LibraryKey key,
   }) sync* {
-    yield* children2;
+    yield* children;
 
     final librariesToCheck = checkExports
         ? fragments
-              .expand((e) => e.libraryExports2)
+              .expand((e) => e.libraryExports)
               .map(_LibraryDirectives.fromExport)
               .nonNulls
         : fragments
-              .expand((e) => e.libraryImports2)
+              .expand((e) => e.libraryImports)
               .map(_LibraryDirectives.fromImport)
               .nonNulls;
 
@@ -55,8 +55,8 @@ extension FindAllAvailableTopLevelElements on LibraryElement2 {
             return (directive.showStatements.isEmpty &&
                     directive.hideStatements.isEmpty) ||
                 (directive.hideStatements.isNotEmpty &&
-                    !directive.hideStatements.contains(element.name3)) ||
-                directive.showStatements.contains(element.name3);
+                    !directive.hideStatements.contains(element.name)) ||
+                directive.showStatements.contains(element.name);
           });
     }
   }
@@ -70,7 +70,7 @@ class _LibraryDirectives {
   });
 
   static _LibraryDirectives? fromExport(LibraryExport export) {
-    final library = export.exportedLibrary2;
+    final library = export.exportedLibrary;
     if (library == null) return null;
 
     final hideStatements = export.combinators
@@ -91,7 +91,7 @@ class _LibraryDirectives {
   }
 
   static _LibraryDirectives? fromImport(LibraryImport export) {
-    final library = export.importedLibrary2;
+    final library = export.importedLibrary;
     if (library == null) return null;
 
     final hideStatements = export.combinators
@@ -113,7 +113,7 @@ class _LibraryDirectives {
 
   final Set<String> hideStatements;
   final Set<String> showStatements;
-  final LibraryElement2 library;
+  final LibraryElement library;
 
   _LibraryKey get key {
     return _LibraryKey(

--- a/packages/freezed/lib/src/tools/type.dart
+++ b/packages/freezed/lib/src/tools/type.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:collection/collection.dart';
@@ -24,26 +24,26 @@ extension DartTypeX on DartType {
   }
 }
 
-/// Returns the [Element2] for a given [DartType]
+/// Returns the [Element] for a given [DartType]
 ///
 /// this is usually type.element, except if it is a typedef then it is
 /// type.alias.element
-Element2? _getElementForType(DartType type) {
+Element? _getElementForType(DartType type) {
   if (type is InterfaceType) {
-    return type.element3;
+    return type.element;
   }
   if (type is FunctionType) {
-    return type.alias?.element2;
+    return type.alias?.element;
   }
   return null;
 }
 
 /// Renders a type based on its string + potential import alias
-String resolveFullTypeStringFrom(LibraryElement2 originLibrary, DartType type) {
+String resolveFullTypeStringFrom(LibraryElement originLibrary, DartType type) {
   final owner = originLibrary.firstFragment.prefixes.firstWhereOrNull((e) {
     return e.imports.any((l) {
-      return l.importedLibrary2!.anyTransitiveExport((library) {
-        return library.id == _getElementForType(type)?.library2?.id;
+      return l.importedLibrary!.anyTransitiveExport((library) {
+        return library.id == _getElementForType(type)?.library?.id;
       });
     });
   });
@@ -62,8 +62,8 @@ String resolveFullTypeStringFrom(LibraryElement2 originLibrary, DartType type) {
   // 'dynamic Function(String)'
   //
   // Instead of 'SomeTypedef'
-  if (type is FunctionType && type.alias?.element2 != null) {
-    displayType = type.alias!.element2.name3!;
+  if (type is FunctionType && type.alias?.element != null) {
+    displayType = type.alias!.element.name!;
     if (type.alias!.typeArguments.isNotEmpty) {
       displayType += '<${type.alias!.typeArguments.join(', ')}>';
     }
@@ -84,14 +84,14 @@ String resolveFullTypeStringFrom(LibraryElement2 originLibrary, DartType type) {
   // This a regression in analyzer 5.13.0
   if (type is InterfaceType &&
       type.typeArguments.any((e) => e is InvalidType)) {
-    final dynamicType = type.element3.library2.typeProvider.dynamicType;
+    final dynamicType = type.element.library.typeProvider.dynamicType;
     var modified = type;
     modified.typeArguments..replaceWhere((t) => t is InvalidType, dynamicType);
     displayType = modified.getDisplayString();
   }
 
   if (owner != null) {
-    return '${owner.name3}.$displayType';
+    return '${owner.name}.$displayType';
   }
 
   return displayType;

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=7.5.9 <8.0.0"
+  analyzer: ^8.0.0
   build: ^3.0.0
   build_config: ^1.1.0
   collection: ^1.15.0
   meta: ^1.9.1
-  source_gen: ^3.0.0
+  source_gen: ^4.0.0
   freezed_annotation: 3.1.0
   json_annotation: ^4.8.0
   dart_style: ^3.0.0

--- a/packages/freezed/test/bidirectional_test.dart
+++ b/packages/freezed/test/bidirectional_test.dart
@@ -20,7 +20,7 @@ void main() {
             )
             as ErrorsResult;
 
-    expect(errorResult.errors, isEmpty);
+    expect(errorResult.diagnostics, isEmpty);
   });
 
   test('bidirectional deep_copy', () {

--- a/packages/freezed/test/common.dart
+++ b/packages/freezed/test/common.dart
@@ -1,6 +1,5 @@
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/diagnostic/diagnostic.dart';
-import 'package:analyzer/error/error.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
@@ -23,7 +22,7 @@ $src
   final errorResult =
       await main!.session.getErrors('/freezed/test/integration/main.dart')
           as ErrorsResult;
-  final criticalErrors = errorResult.errors
+  final criticalErrors = errorResult.diagnostics
       .where((element) => element.severity == Severity.error)
       .toList();
 
@@ -34,7 +33,7 @@ $src
 
 class CompileError extends Error {
   CompileError(this.errors);
-  final List<AnalysisError> errors;
+  final List<Diagnostic> errors;
 
   @override
   String toString() {

--- a/packages/freezed/test/common_types_test.dart
+++ b/packages/freezed/test/common_types_test.dart
@@ -25,7 +25,7 @@ Future<void> main() async {
             )
             as ErrorsResult;
 
-    expect(errorResult.errors, isEmpty);
+    expect(errorResult.diagnostics, isEmpty);
   });
 
   group('CommonSuperSubtype', () {

--- a/packages/freezed/test/decorator_test.dart
+++ b/packages/freezed/test/decorator_test.dart
@@ -17,7 +17,7 @@ void main() {
               '/freezed/test/integration/decorator.freezed.dart',
             )
             as ErrorsResult;
-    expect(errorResult.errors, isEmpty);
+    expect(errorResult.diagnostics, isEmpty);
     errorResult =
         await main.session.getErrors('/freezed/test/integration/decorator.dart')
             as ErrorsResult;
@@ -33,32 +33,29 @@ import 'decorator.dart';
 ''',
         },
         (r) => r.libraries.firstWhere(
-          (element) => element.library2.name3 == 'decorator',
+          (element) => element.library.name == 'decorator',
         ),
         readAllSourcesFromFilesystem: true,
       );
 
       final concrete = main.classes.firstWhere(
-        (e) => e.name3 == r'ListDecorator0',
+        (e) => e.name == r'ListDecorator0',
       );
 
       expect(
-        concrete.fields2
-            .firstWhere((element) => element.name3 == '_a')
-            .metadata2
+        concrete.fields
+            .firstWhere((element) => element.name == '_a')
+            .metadata
             .annotations,
         isEmpty,
       );
 
-      final unmodifiableGetter = concrete.fields2
-          .firstWhere((element) => element.name3 == 'a')
-          .getter2!;
+      final unmodifiableGetter = concrete.fields
+          .firstWhere((element) => element.name == 'a')
+          .getter!;
 
-      expect(unmodifiableGetter.metadata2.annotations.length, 2);
-      expect(
-        unmodifiableGetter.metadata2.annotations.last.toSource(),
-        '@Foo()',
-      );
+      expect(unmodifiableGetter.metadata.annotations.length, 2);
+      expect(unmodifiableGetter.metadata.annotations.last.toSource(), '@Foo()');
     },
   );
 
@@ -96,7 +93,7 @@ void main() {
         await main.session.getErrors('/freezed/test/integration/main.dart')
             as ErrorsResult;
     expect(
-      errorResult.errors.map((e) => e.errorCode.name),
+      errorResult.diagnostics.map((e) => e.diagnosticCode.name),
       anyOf([
         [
           'UNUSED_RESULT',

--- a/packages/freezed/test/deep_copy_test.dart
+++ b/packages/freezed/test/deep_copy_test.dart
@@ -31,7 +31,7 @@ void main() {
             )
             as ErrorsResult;
 
-    expect(errorResult.errors, isEmpty);
+    expect(errorResult.diagnostics, isEmpty);
   });
 
   test('has no issue #2', () async {
@@ -49,7 +49,7 @@ void main() {
             )
             as ErrorsResult;
 
-    expect(errorResult.errors, isEmpty);
+    expect(errorResult.diagnostics, isEmpty);
   });
 
   test('handles null', () {
@@ -734,7 +734,7 @@ void main() {
         await main.session.getErrors('/freezed/test/integration/main.dart')
             as ErrorsResult;
 
-    expect(errorResult.errors.map((e) => e.errorCode.name), [
+    expect(errorResult.diagnostics.map((e) => e.diagnosticCode.name), [
       'UNUSED_RESULT',
       'UNUSED_RESULT',
     ]);

--- a/packages/freezed/test/generic_test.dart
+++ b/packages/freezed/test/generic_test.dart
@@ -52,7 +52,7 @@ void main() {
             )
             as ErrorsResult;
 
-    expect(errorResult.errors, isEmpty);
+    expect(errorResult.diagnostics, isEmpty);
   });
 
   test('is generic', () {

--- a/packages/freezed/test/generics_refs_test.dart
+++ b/packages/freezed/test/generics_refs_test.dart
@@ -21,7 +21,7 @@ void main() {
             )
             as ErrorsResult;
 
-    expect(errorResult.errors, isEmpty);
+    expect(errorResult.diagnostics, isEmpty);
   });
 
   test('handles lists', () async {

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -752,7 +752,7 @@ Future<void> main() async {
               '/freezed/test/integration/json.freezed.dart',
             )
             as ErrorsResult;
-    expect(errorResult.errors, isEmpty);
+    expect(errorResult.diagnostics, isEmpty);
   }, skip: true);
 
   test("single constructor fromJson doesn't require type", () {

--- a/packages/freezed/test/map_test.dart
+++ b/packages/freezed/test/map_test.dart
@@ -303,7 +303,7 @@ void main() {
           await main!.session.getErrors('/freezed/test/integration/main.dart')
               as ErrorsResult;
 
-      expect(errorResult.errors, isNotEmpty);
+      expect(errorResult.diagnostics, isNotEmpty);
     });
   });
 
@@ -424,7 +424,7 @@ void main() {
           await main!.session.getErrors('/freezed/test/integration/main.dart')
               as ErrorsResult;
 
-      expect(errorResult.errors, isNotEmpty);
+      expect(errorResult.diagnostics, isNotEmpty);
     });
   });
 

--- a/packages/freezed/test/multiple_constructors_test.dart
+++ b/packages/freezed/test/multiple_constructors_test.dart
@@ -2,7 +2,7 @@
 import 'dart:async';
 
 import 'package:analyzer/dart/analysis/results.dart';
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
@@ -23,8 +23,8 @@ Future<void> main() async {
     readAllSourcesFromFilesystem: true,
   );
 
-  ClassElement2 _getClassElement(String elementName) {
-    return sources.classes.singleWhere((e) => e.name3 == elementName);
+  ClassElement _getClassElement(String elementName) {
+    return sources.classes.singleWhere((e) => e.name == elementName);
   }
 
   test('Response', () {
@@ -37,14 +37,14 @@ Future<void> main() async {
   test('recursive class does not generate dynamic', () async {
     final recursiveClass = _getClassElement('_RecursiveNext');
 
-    expect(recursiveClass.getField2('value')!.type, isA<InterfaceType>());
+    expect(recursiveClass.getField('value')!.type, isA<InterfaceType>());
   });
 
   test('recursive class with dollar generates correctly', () async {
     final recursiveClass = _getClassElement('_RecursiveWith\$DollarNext');
 
     expect(
-      recursiveClass.getField2('value')!.type.getDisplayString(),
+      recursiveClass.getField('value')!.type.getDisplayString(),
       'RecursiveWith\$DollarImpl',
     );
   });
@@ -65,53 +65,53 @@ Future<void> main() async {
 
     expect(
       complex.mixins.first.getters.first,
-      isA<PropertyAccessorElement2>()
-          .having((e) => e.name3, 'name', 'a')
+      isA<PropertyAccessorElement>()
+          .having((e) => e.name, 'name', 'a')
           .having((e) => e.documentationComment, 'doc', '/// Hello'),
     );
 
     expect(
-      complex0.fields2.where(
-        (e) => e.name3 != 'copyWith' && e.name3 != 'hashCode',
+      complex0.fields.where(
+        (e) => e.name != 'copyWith' && e.name != 'hashCode',
       ),
       [
-        isA<FieldElement2>()
-            .having((e) => e.name3, 'name', 'a')
+        isA<FieldElement>()
+            .having((e) => e.name, 'name', 'a')
             .having((e) => e.documentationComment, 'doc', '/// Hello'),
       ],
     );
 
     expect(
-      complex1.fields2.where(
-        (e) => e.name3 != 'copyWith' && e.name3 != 'hashCode',
+      complex1.fields.where(
+        (e) => e.name != 'copyWith' && e.name != 'hashCode',
       ),
       [
-        isA<FieldElement2>()
-            .having((e) => e.name3, 'name', 'a')
+        isA<FieldElement>()
+            .having((e) => e.name, 'name', 'a')
             .having((e) => e.documentationComment, 'doc', '/// World'),
-        isA<FieldElement2>()
-            .having((e) => e.name3, 'name', 'b')
+        isA<FieldElement>()
+            .having((e) => e.name, 'name', 'b')
             .having((e) => e.documentationComment, 'doc', '/// B'),
-        isA<FieldElement2>()
-            .having((e) => e.name3, 'name', 'd')
+        isA<FieldElement>()
+            .having((e) => e.name, 'name', 'd')
             .having((e) => e.documentationComment, 'doc', null),
       ],
     );
 
     expect(
-      complex2.fields2.where(
-        (e) => e.name3 != 'copyWith' && e.name3 != 'hashCode',
+      complex2.fields.where(
+        (e) => e.name != 'copyWith' && e.name != 'hashCode',
       ),
       [
-        isA<FieldElement2>()
-            .having((e) => e.name3, 'name', 'a')
+        isA<FieldElement>()
+            .having((e) => e.name, 'name', 'a')
             // The doc is inherited from `Complex`
             .having((e) => e.documentationComment, 'doc', null),
-        isA<FieldElement2>()
-            .having((e) => e.name3, 'name', 'c')
+        isA<FieldElement>()
+            .having((e) => e.name, 'name', 'c')
             .having((e) => e.documentationComment, 'doc', '/// C'),
-        isA<FieldElement2>()
-            .having((e) => e.name3, 'name', 'd')
+        isA<FieldElement>()
+            .having((e) => e.name, 'name', 'd')
             .having((e) => e.documentationComment, 'doc', null),
       ],
     );
@@ -181,7 +181,7 @@ void main() {
               )
               as ErrorsResult;
 
-      expect(errorResult.errors, isEmpty);
+      expect(errorResult.diagnostics, isEmpty);
     });
 
     test('can mutate unfreezed unions', () {
@@ -574,7 +574,7 @@ void main() {
       final nestedListClass = _getClassElement('ShallowNestedList');
 
       expect(
-        nestedListClass.getField2('children')!.type.getDisplayString(),
+        nestedListClass.getField('children')!.type.getDisplayString(),
         'List<LeafNestedListItem>',
       );
     });
@@ -583,14 +583,14 @@ void main() {
       final nestedListClass = _getClassElement('DeepNestedList');
 
       expect(
-        nestedListClass.getField2('children')!.type.getDisplayString(),
+        nestedListClass.getField('children')!.type.getDisplayString(),
         'List<InnerNestedListItem>',
       );
 
       final nestedListItemClass = _getClassElement('InnerNestedListItem');
 
       expect(
-        nestedListItemClass.getField2('children')!.type.getDisplayString(),
+        nestedListItemClass.getField('children')!.type.getDisplayString(),
         'List<LeafNestedListItem>',
       );
     });
@@ -600,7 +600,7 @@ void main() {
       final nestedMapClass = _getClassElement('ShallowNestedMap');
 
       expect(
-        nestedMapClass.getField2('children')!.type.getDisplayString(),
+        nestedMapClass.getField('children')!.type.getDisplayString(),
         'Map<String, LeafNestedMapItem>',
       );
     });
@@ -609,14 +609,14 @@ void main() {
       final nestedMapClass = _getClassElement('DeepNestedMap');
 
       expect(
-        nestedMapClass.getField2('children')!.type.getDisplayString(),
+        nestedMapClass.getField('children')!.type.getDisplayString(),
         'Map<String, InnerNestedMapItem>',
       );
 
       final nestedMapItemClass = _getClassElement('InnerNestedMapItem');
 
       expect(
-        nestedMapItemClass.getField2('children')!.type.getDisplayString(),
+        nestedMapItemClass.getField('children')!.type.getDisplayString(),
         'Map<String, LeafNestedMapItem>',
       );
     });
@@ -627,19 +627,19 @@ void main() {
       final nestedMapClass = _getClassElement('_UsesGenerated');
 
       expect(
-        nestedMapClass.getField2('value')!.type.getDisplayString(),
+        nestedMapClass.getField('value')!.type.getDisplayString(),
         'CodeGenerated',
       );
       expect(
-        nestedMapClass.getField2('list')!.type.getDisplayString(),
+        nestedMapClass.getField('list')!.type.getDisplayString(),
         'List<CodeGenerated>',
       );
       expect(
-        nestedMapClass.getField2('nestedList')!.type.getDisplayString(),
+        nestedMapClass.getField('nestedList')!.type.getDisplayString(),
         'List<List<CodeGenerated>>',
       );
       expect(
-        nestedMapClass.getField2('map')!.type.getDisplayString(),
+        nestedMapClass.getField('map')!.type.getDisplayString(),
         'Map<int, CodeGenerated>',
       );
     });

--- a/packages/freezed/test/optional_maybe_test.dart
+++ b/packages/freezed/test/optional_maybe_test.dart
@@ -21,7 +21,7 @@ void main() {
             )
             as ErrorsResult;
 
-    expect(errorResult.errors, isEmpty);
+    expect(errorResult.diagnostics, isEmpty);
   });
 
   test('does not generates maybeMap', () async {

--- a/packages/freezed/test/single_class_constructor_test.dart
+++ b/packages/freezed/test/single_class_constructor_test.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: prefer_const_constructors, omit_local_variable_types, deprecated_member_use_from_same_package
 import 'package:analyzer/dart/analysis/results.dart';
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
@@ -25,7 +25,7 @@ class MyObject {
 }
 
 Future<void> main() async {
-  Future<LibraryElement2> analyze() {
+  Future<LibraryElement> analyze() {
     return resolveSources(
       {
         'freezed|test/integration/single_class_constructor.dart':
@@ -211,28 +211,28 @@ Future<void> main() async {
   test('documentation', () async {
     final singleClassLibrary = await analyze();
 
-    final doc = singleClassLibrary.classes.firstWhere((e) => e.name3 == 'Doc');
+    final doc = singleClassLibrary.classes.firstWhere((e) => e.name == 'Doc');
 
     expect(
       doc.mixins.first.getters.where(
-        (e) => e.name3 != 'copyWith' && e.name3 != 'hashCode',
+        (e) => e.name != 'copyWith' && e.name != 'hashCode',
       ),
       [
-        isA<PropertyAccessorElement2>()
-            .having((e) => e.name3, 'name', 'positional')
+        isA<PropertyAccessorElement>()
+            .having((e) => e.name, 'name', 'positional')
             .having((e) => e.documentationComment, 'doc', '''
 /// Multi
 /// line
 /// positional'''),
-        isA<PropertyAccessorElement2>() //
-            .having((e) => e.name3, 'name', 'named')
+        isA<PropertyAccessorElement>() //
+            .having((e) => e.name, 'name', 'named')
             .having(
               (e) => e.documentationComment,
               'doc',
               '/// Single line named',
             ),
-        isA<PropertyAccessorElement2>() //
-            .having((e) => e.name3, 'name', 'simple')
+        isA<PropertyAccessorElement>() //
+            .having((e) => e.name, 'name', 'simple')
             .having((e) => e.documentationComment, 'doc', null),
       ],
     );
@@ -379,7 +379,7 @@ void main() {
             )
             as ErrorsResult;
 
-    expect(errorResult.errors, isEmpty);
+    expect(errorResult.diagnostics, isEmpty);
   });
 
   test('toString includes the constructor name', () {
@@ -651,7 +651,7 @@ void main() {
               as ErrorsResult;
 
       expect(
-        errorResult.errors.map((e) => e.toString()),
+        errorResult.diagnostics.map((e) => e.toString()),
         anyElement(contains("The named parameter 'a' is required")),
       );
     },

--- a/packages/freezed/test/typedef_parameter_test.dart
+++ b/packages/freezed/test/typedef_parameter_test.dart
@@ -21,7 +21,7 @@ void main() {
             )
             as ErrorsResult;
 
-    expect(errorResult.errors, isEmpty);
+    expect(errorResult.diagnostics, isEmpty);
   });
 
   test('generates correct typedefs', () async {
@@ -36,33 +36,33 @@ void main() {
     );
 
     var freezedClass = main.classes.firstWhere(
-      (element) => element.name3 == '_ClassWithTypedef',
+      (element) => element.name == '_ClassWithTypedef',
     );
 
-    var constructor = freezedClass.constructors2.firstWhere(
-      (element) => element.name3 == 'new',
+    var constructor = freezedClass.constructors.firstWhere(
+      (element) => element.name == 'new',
     );
 
     var a = constructor.formalParameters.first.type;
     expect(a, isA<FunctionType>());
-    expect(a.alias!.element2.name3, equals('MyTypedef'));
+    expect(a.alias!.element.name, equals('MyTypedef'));
 
     var b = constructor.formalParameters[1].type;
     expect(b, isA<FunctionType>());
-    expect(b.alias!.element2.name3, equals('MyTypedef'));
+    expect(b.alias!.element.name, equals('MyTypedef'));
     expect(b.nullabilitySuffix, equals(NullabilitySuffix.question));
 
     var c = constructor.formalParameters[2].type;
     expect(c, isA<FunctionType>());
-    expect(c.alias!.element2.name3, equals('ExternalTypedef'));
+    expect(c.alias!.element.name, equals('ExternalTypedef'));
 
     var d = constructor.formalParameters[3].type;
     expect(d, isA<FunctionType>());
-    expect(d.alias!.element2.name3, equals('ExternalTypedefTwo'));
+    expect(d.alias!.element.name, equals('ExternalTypedefTwo'));
 
     var e = constructor.formalParameters[4].type;
     expect(e, isA<FunctionType>());
-    expect(e.alias!.element2.name3, equals('GenericTypedef'));
+    expect(e.alias!.element.name, equals('GenericTypedef'));
     expect(e.alias!.typeArguments.toString(), equals('[int, bool]'));
   });
 }

--- a/packages/freezed/test/when_test.dart
+++ b/packages/freezed/test/when_test.dart
@@ -302,7 +302,7 @@ void main() {
           await main!.session.getErrors('/freezed/test/integration/main.dart')
               as ErrorsResult;
 
-      expect(errorResult.errors, isNotEmpty);
+      expect(errorResult.diagnostics, isNotEmpty);
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Breaking Changes
  - Requires analyzer ^8.0.0 and source_gen ^4.0.0; older versions are no longer supported.
  - Minor public API adjustments in analyzer-facing utilities (e.g., element/library types and error “diagnostics” naming).

- Refactor
  - Migrated internals to the latest analyzer Element API for improved compatibility and future-proofing.

- Chores
  - Updated dependencies; added pub_semver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->