### PR TITLE
Use range for analyzer version

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,6 +7,8 @@ analyzer:
     strict-raw-types: true
   errors:
     invalid_annotation_target: ignore
+    # Remove when we require analyzer >=8
+    deprecated_member_use: ignore
 
 linter:
   rules:

--- a/packages/freezed/lib/src/ast.dart
+++ b/packages/freezed/lib/src/ast.dart
@@ -1,6 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 
 extension AstX on AstNode {
   String? get documentation {
@@ -28,10 +28,10 @@ extension ClassX on ClassDeclaration {
       element,
       ...element.allSupertypes
           .where((e) => !e.isDartCoreObject)
-          .map((e) => e.element),
+          .map((e) => e.element3),
     ]) {
-      for (final method in type.methods) {
-        if (method.name == 'toString') {
+      for (final method in type.methods2) {
+        if (method.name3 == 'toString') {
           return true;
         }
       }
@@ -42,50 +42,50 @@ extension ClassX on ClassDeclaration {
 
   bool get hasSuperEqual => declaredFragment!.element.allSupertypes
       .where((e) => !e.isDartCoreObject)
-      .map((e) => e.element)
+      .map((e) => e.element3)
       .any((e) => e.hasEqual);
 
   bool get hasCustomEquals => declaredFragment!.element.hasEqual;
 
   bool get hasSuperHashCode => declaredFragment!.element.allSupertypes
       .where((e) => !e.isDartCoreObject)
-      .map((e) => e.element)
+      .map((e) => e.element3)
       .any((e) => e.hasHashCode);
 }
 
-extension on InterfaceElement {
-  bool get hasEqual => methods.any(((e) => e.isOperator && e.name == '=='));
+extension on InterfaceElement2 {
+  bool get hasEqual => methods2.any(((e) => e.isOperator && e.name3 == '=='));
 
-  bool get hasHashCode => getters.any((e) => e.name == 'hashCode');
+  bool get hasHashCode => getters2.any((e) => e.name3 == 'hashCode');
 }
 
 extension ConstructorX on ConstructorDeclaration {
   String get fullName {
-    final classElement = declaredFragment!.element.enclosingElement;
+    final classElement = declaredFragment!.element.enclosingElement2;
 
-    var generics = classElement.typeParameters
-        .map((e) => '\$${e.name}')
+    var generics = classElement.typeParameters2
+        .map((e) => '\$${e.name3}')
         .join(', ');
     if (generics.isNotEmpty) {
       generics = '<$generics>';
     }
 
-    final className = classElement.enclosingElement.name;
+    final className = classElement.enclosingElement2.name3;
 
     return name == null ? '$className$generics' : '$className$generics.$name';
   }
 
   String get escapedName {
-    final classElement = declaredFragment!.element.enclosingElement;
+    final classElement = declaredFragment!.element.enclosingElement2;
 
-    var generics = classElement.typeParameters
-        .map((e) => '\$${e.name}')
+    var generics = classElement.typeParameters2
+        .map((e) => '\$${e.name3}')
         .join(', ');
     if (generics.isNotEmpty) {
       generics = '<$generics>';
     }
 
-    final escapedElementName = classElement.name!.replaceAll(r'$', r'\$');
+    final escapedElementName = classElement.name3!.replaceAll(r'$', r'\$');
     final escapedConstructorName = name?.lexeme.replaceAll(r'$', r'\$');
 
     return escapedConstructorName == null

--- a/packages/freezed/lib/src/models.dart
+++ b/packages/freezed/lib/src/models.dart
@@ -4,7 +4,7 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:collection/collection.dart';
@@ -27,7 +27,7 @@ class _Sentinel {
   const _Sentinel();
 }
 
-extension on Element {
+extension on Element2 {
   bool get hasJsonSerializable {
     return const TypeChecker.typeNamed(
       JsonSerializable,
@@ -36,9 +36,9 @@ extension on Element {
   }
 }
 
-extension on ConstructorElement {
+extension on ConstructorElement2 {
   bool isFallbackUnion(String? fallbackConstructorName) {
-    final constructorName = isDefaultConstructor(this) ? 'default' : name;
+    final constructorName = isDefaultConstructor(this) ? 'default' : name3;
     return constructorName == fallbackConstructorName;
   }
 
@@ -51,7 +51,7 @@ extension on ConstructorElement {
       return annotation.getField('value')!.toStringValue()!;
     }
 
-    final constructorName = isDefaultConstructor(this) ? 'default' : name!;
+    final constructorName = isDefaultConstructor(this) ? 'default' : name3!;
     switch (unionCase) {
       case null:
       case FreezedUnionCase.none:
@@ -97,8 +97,8 @@ class DeepCloneableProperty {
 
       final parameterType = parameter.type;
       if (parameterType is! InterfaceType) continue;
-      final typeElement = parameterType.element;
-      if (typeElement is! ClassElement) continue;
+      final typeElement = parameterType.element3;
+      if (typeElement is! ClassElement2) continue;
 
       final freezedAnnotation = freezedType.firstAnnotationOf(
         typeElement,
@@ -116,10 +116,10 @@ class DeepCloneableProperty {
       if (configs.copyWith == false) continue;
 
       yield DeepCloneableProperty(
-        name: parameter.name!,
+        name: parameter.name3!,
         type: type,
         nullable: parameter.type.isNullable,
-        typeName: typeElement.name!,
+        typeName: typeElement.name3!,
         genericParameters: GenericsParameterTemplate(
           (parameter.type as InterfaceType).typeArguments
               .map((e) => e.getDisplayString())
@@ -269,7 +269,7 @@ When specifying fields in non-factory constructor then specifying factory constr
       }
 
       final redirectedName =
-          constructor.redirectedConstructor?.type.name.lexeme;
+          constructor.redirectedConstructor?.type.name2.lexeme;
 
       if (redirectedName == null) {
         _assertValidNormalConstructorUsage(declaration, constructor);
@@ -283,7 +283,7 @@ When specifying fields in non-factory constructor then specifying factory constr
 
       final excludedProperties =
           manualConstructor?.parameters.parameters
-              .map((e) => e.declaredFragment!.element.name!)
+              .map((e) => e.declaredFragment!.element.name3!)
               .toSet() ??
           <String>{};
 
@@ -318,7 +318,7 @@ When specifying fields in non-factory constructor then specifying factory constr
           decorators: constructor.metadata
               .where((element) {
                 final elementSourceUri =
-                    element.element?.baseElement.library?.uri;
+                    element.element2?.baseElement.library2?.uri;
 
                 final isFreezedAnnotation =
                     elementSourceUri != null &&
@@ -424,7 +424,7 @@ class ImplementsAnnotation {
   ImplementsAnnotation({required this.type});
 
   static Iterable<ImplementsAnnotation> parseAll(
-    ConstructorElement constructor,
+    ConstructorElement2 constructor,
   ) sync* {
     for (final meta in const TypeChecker.typeNamed(
       Implements,
@@ -436,7 +436,7 @@ class ImplementsAnnotation {
       } else {
         yield ImplementsAnnotation(
           type: resolveFullTypeStringFrom(
-            constructor.library,
+            constructor.library2,
             (meta.type! as InterfaceType).typeArguments.single,
           ),
         );
@@ -451,9 +451,9 @@ class WithAnnotation {
   WithAnnotation({required this.type});
 
   static Iterable<WithAnnotation> parseAll(
-    ConstructorElement constructor,
+    ConstructorElement2 constructor,
   ) sync* {
-    for (final metadata in constructor.metadata.annotations) {
+    for (final metadata in constructor.metadata2.annotations) {
       if (!metadata.isWith) continue;
       final object = metadata.computeConstantValue()!;
 
@@ -463,7 +463,7 @@ class WithAnnotation {
       } else {
         yield WithAnnotation(
           type: resolveFullTypeStringFrom(
-            constructor.library,
+            constructor.library2,
             (object.type! as InterfaceType).typeArguments.single,
           ),
         );
@@ -522,7 +522,7 @@ class CopyWithTarget {
 
 extension on NamedType {
   bool isSuperMixin(ClassDeclaration declaration) =>
-      name.lexeme == '_\$${declaration.name.lexeme.public}';
+      name2.lexeme == '_\$${declaration.name.lexeme.public}';
 }
 
 class Class {
@@ -552,7 +552,7 @@ class Class {
   final ClassDeclaration _node;
   final Set<Class> parents = {};
 
-  LibraryElement get library => _node.declaredFragment!.element.library;
+  LibraryElement2 get library => _node.declaredFragment!.element.library2;
 
   static Class _from(
     ClassDeclaration declaration,
@@ -570,7 +570,7 @@ class Class {
     );
 
     if (constructors.isNotEmpty) {
-      for (final field in declaration.declaredFragment!.element.fields) {
+      for (final field in declaration.declaredFragment!.element.fields2) {
         _assertValidFieldUsage(field, shouldUseExtends: privateCtor != null);
       }
     }
@@ -676,14 +676,14 @@ To fix, either:
       options: configs,
       constructors: constructors,
       concretePropertiesName: [
-        for (final p in declaration.declaredFragment!.element.fields)
-          if (!p.isStatic) p.name!,
+        for (final p in declaration.declaredFragment!.element.fields2)
+          if (!p.isStatic) p.name3!,
       ],
       genericsDefinitionTemplate: GenericsDefinitionTemplate.fromGenericElement(
-        declaration.declaredFragment!.element.typeParameters,
+        declaration.declaredFragment!.element.typeParameters2,
       ),
       genericsParameterTemplate: GenericsParameterTemplate.fromGenericElement(
-        declaration.declaredFragment!.element.typeParameters,
+        declaration.declaredFragment!.element.typeParameters2,
       ),
     );
   }
@@ -745,7 +745,7 @@ To fix, either:
         if (clazz._node.extendsClause case final extend?) extend.superclass,
         ...?clazz._node.implementsClause?.interfaces,
         ...?clazz._node.withClause?.mixinTypes,
-      ].map((e) => e.name.lexeme);
+      ].map((e) => e.name2.lexeme);
 
       for (final superType in superTypes) {
         final superTypeClass = classMap[superType];
@@ -833,10 +833,7 @@ To fix, either:
         isFinal: property.$1.fields.isFinal,
         isSynthetic: false,
         decorators: switch (property.$1.declaredFragment?.element) {
-          Fragment(metadata: final metadata) ||
-          Element(
-            metadata: final metadata,
-          ) => parseDecorators(metadata.annotations),
+          final Annotatable e => parseDecorators(e.metadata2.annotations),
           _ => [],
         },
       );
@@ -865,9 +862,9 @@ To fix, either:
     }
 
     late final typeSystem =
-        declaration.declaredFragment!.element.library.typeSystem;
+        declaration.declaredFragment!.element.library2.typeSystem;
     late final typeProvider =
-        declaration.declaredFragment!.element.library.typeProvider;
+        declaration.declaredFragment!.element.library2.typeProvider;
 
     fieldLoop:
     for (final entry in typesMap.entries) {
@@ -921,7 +918,7 @@ To fix, either:
           isFinal = true;
 
           typeString = resolveFullTypeStringFrom(
-            declaration.declaredFragment!.element.library,
+            declaration.declaredFragment!.element.library2,
             type,
           );
       }
@@ -967,7 +964,7 @@ To fix, either:
         param: parameter.name,
       );
 
-      final library = parameter.parameterElement!.library!;
+      final library = parameter.parameterElement!.library2!;
 
       var commonTypeBetweenAllUnionConstructors =
           parameter.parameterElement!.type;
@@ -1064,12 +1061,12 @@ To fix, either:
   }
 
   static void _assertValidFieldUsage(
-    FieldElement field, {
+    FieldElement2 field, {
     required bool shouldUseExtends,
   }) {
     if (field.isStatic) return;
 
-    if (field.setter != null) {
+    if (field.setter2 != null) {
       throw InvalidGenerationSourceError(
         'Classes decorated with @freezed cannot have mutable properties',
         element: field,
@@ -1078,9 +1075,9 @@ To fix, either:
 
     // The field is a "Type get name => "
     if (!shouldUseExtends &&
-        field.getter != null &&
-        !field.getter!.isAbstract &&
-        !field.getter!.isSynthetic) {
+        field.getter2 != null &&
+        !field.getter2!.isAbstract &&
+        !field.getter2!.isSynthetic) {
       throw InvalidGenerationSourceError(
         'Getters require a MyClass._() constructor',
         element: field,
@@ -1132,10 +1129,10 @@ class Library {
     return Library(
       hasJson: units.any(
         (unit) =>
-            unit.declaredFragment!.element.library.importsJsonSerializable,
+            unit.declaredFragment!.element.library2.importsJsonSerializable,
       ),
       hasDiagnostics: units.any(
-        (unit) => unit.declaredFragment!.element.library.importsDiagnosticable,
+        (unit) => unit.declaredFragment!.element.library2.importsDiagnosticable,
       ),
     );
   }
@@ -1360,18 +1357,18 @@ extension ClassDeclarationX on ClassDeclaration {
   }
 }
 
-extension on LibraryElement {
+extension on LibraryElement2 {
   bool get importsJsonSerializable {
     return findAllAvailableTopLevelElements().any((element) {
-      return element.name == 'JsonSerializable' &&
-          (element.library?.isFromPackage('json_annotation') ?? false);
+      return element.name3 == 'JsonSerializable' &&
+          (element.library2?.isFromPackage('json_annotation') ?? false);
     });
   }
 
   bool get importsDiagnosticable {
     return findAllAvailableTopLevelElements().any((element) {
-      return element.name == 'DiagnosticableTreeMixin' &&
-          (element.library?.isFromPackage('flutter') ?? false);
+      return element.name3 == 'DiagnosticableTreeMixin' &&
+          (element.library2?.isFromPackage('flutter') ?? false);
     });
   }
 }

--- a/packages/freezed/lib/src/parse_generator.dart
+++ b/packages/freezed/lib/src/parse_generator.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:collection/collection.dart';
 import 'package:source_gen/source_gen.dart';
@@ -57,7 +57,7 @@ abstract class ParserGenerator<AnnotationT>
 
   @override
   Stream<String> generateForAnnotatedElement(
-    Element element,
+    Element2 element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async* {
@@ -75,7 +75,7 @@ abstract class ParserGenerator<AnnotationT>
     unit as ResolvedUnitResult;
     final Object? ast = unit.unit.declarations.firstWhereOrNull(
       (declaration) =>
-          declaration.declaredFragment?.element.name == element.name!,
+          declaration.declaredFragment?.element.name3 == element.name3!,
     );
     if (ast == null) {
       throw InvalidGenerationSourceError('Ast not found', element: element);

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:freezed/src/freezed_generator.dart';
 import 'package:freezed/src/models.dart';
 import 'package:freezed/src/templates/properties.dart';
@@ -522,7 +522,7 @@ extension DefaultValue on FormalParameterElement {
       inPackage: 'freezed_annotation',
     );
 
-    for (final meta in metadata.annotations) {
+    for (final meta in metadata2.annotations) {
       final obj = meta.computeConstantValue()!;
       if (matcher.isExactlyType(obj.type!)) {
         final source = meta.toSource();

--- a/packages/freezed/lib/src/templates/parameter_template.dart
+++ b/packages/freezed/lib/src/templates/parameter_template.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:collection/collection.dart';
 import 'package:freezed/src/ast.dart';
@@ -11,10 +11,10 @@ class GenericsDefinitionTemplate {
   GenericsDefinitionTemplate(this.typeParameters);
 
   factory GenericsDefinitionTemplate.fromGenericElement(
-    List<TypeParameterElement> generics,
+    List<TypeParameterElement2> generics,
   ) {
     return GenericsDefinitionTemplate(
-      generics.map((e) => e.displayString()).toList(),
+      generics.map((e) => e.displayString2()).toList(),
     );
   }
 
@@ -36,9 +36,9 @@ class GenericsParameterTemplate {
   GenericsParameterTemplate(this.typeParameters);
 
   factory GenericsParameterTemplate.fromGenericElement(
-    List<TypeParameterElement> generics,
+    List<TypeParameterElement2> generics,
   ) {
-    return GenericsParameterTemplate(generics.map((e) => e.name!).toList());
+    return GenericsParameterTemplate(generics.map((e) => e.name3!).toList());
   }
   final List<String> typeParameters;
 
@@ -70,13 +70,13 @@ class ParametersTemplate {
       final e = p.declaredFragment!.element;
 
       final value = Parameter(
-        name: e.name!,
+        name: e.name3!,
         defaultValueSource: e.defaultValue,
         isRequired: e.isRequiredNamed,
         isFinal: addImplicitFinal || e.isFinal,
         type: e.type,
         typeDisplayString: parseTypeSource(p),
-        decorators: parseDecorators(e.metadata.annotations),
+        decorators: parseDecorators(e.metadata2.annotations),
         doc: p.documentation ?? '',
         showDefaultValue: true,
         parameterElement: e,

--- a/packages/freezed/lib/src/templates/properties.dart
+++ b/packages/freezed/lib/src/templates/properties.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:freezed/src/ast.dart';
 import 'package:freezed/src/templates/parameter_template.dart';
@@ -52,13 +52,13 @@ class Property {
     }
 
     return Property(
-      name: element.name!,
+      name: element.name3!,
       isFinal: addImplicitFinal || element.isFinal,
       isSynthetic: isSynthetic,
       doc: parameter.documentation ?? '',
       type: element.type,
       typeDisplayString: parseTypeSource(parameter),
-      decorators: parseDecorators(element.metadata.annotations),
+      decorators: parseDecorators(element.metadata2.annotations),
       defaultValueSource: defaultValue,
       hasJsonKey: element.hasJsonKey,
     );
@@ -114,7 +114,7 @@ class Property {
     bool? hasJsonKey,
     String? doc,
     bool? isPossiblyDartCollection,
-    TypeParameterElement? parameterElement,
+    TypeParameterElement2? parameterElement,
   }) {
     return Property(
       type: type ?? this.type,

--- a/packages/freezed/lib/src/templates/prototypes.dart
+++ b/packages/freezed/lib/src/templates/prototypes.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -41,8 +41,8 @@ extension FreezedElementAnnotation on ElementAnnotation {
   }
 }
 
-bool isDefaultConstructor(ConstructorElement constructor) {
-  return constructor.name == 'new';
+bool isDefaultConstructor(ConstructorElement2 constructor) {
+  return constructor.name3 == 'new';
 }
 
 String constructorNameToCallbackName(String constructorName) {

--- a/packages/freezed/lib/src/tools/imports.dart
+++ b/packages/freezed/lib/src/tools/imports.dart
@@ -1,18 +1,18 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 
-extension LibraryHasImport on LibraryElement {
-  LibraryElement? findTransitiveExportWhere(
-    bool Function(LibraryElement library) visitor,
+extension LibraryHasImport on LibraryElement2 {
+  LibraryElement2? findTransitiveExportWhere(
+    bool Function(LibraryElement2 library) visitor,
   ) {
     if (visitor(this)) return this;
 
-    final visitedLibraries = <LibraryElement>{};
-    LibraryElement? visitLibrary(LibraryElement library) {
+    final visitedLibraries = <LibraryElement2>{};
+    LibraryElement2? visitLibrary(LibraryElement2 library) {
       if (!visitedLibraries.add(library)) return null;
 
       if (visitor(library)) return library;
 
-      for (final export in library.exportedLibraries) {
+      for (final export in library.exportedLibraries2) {
         final result = visitLibrary(export);
         if (result != null) return result;
       }
@@ -20,7 +20,7 @@ extension LibraryHasImport on LibraryElement {
       return null;
     }
 
-    for (final import in exportedLibraries) {
+    for (final import in exportedLibraries2) {
       final result = visitLibrary(import);
       if (result != null) return result;
     }
@@ -28,7 +28,7 @@ extension LibraryHasImport on LibraryElement {
     return null;
   }
 
-  bool anyTransitiveExport(bool Function(LibraryElement library) visitor) {
+  bool anyTransitiveExport(bool Function(LibraryElement2 library) visitor) {
     return findTransitiveExportWhere(visitor) != null;
   }
 }

--- a/packages/freezed/lib/src/tools/recursive_import_locator.dart
+++ b/packages/freezed/lib/src/tools/recursive_import_locator.dart
@@ -1,7 +1,7 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:collection/collection.dart';
 
-extension FindAllAvailableTopLevelElements on LibraryElement {
+extension FindAllAvailableTopLevelElements on LibraryElement2 {
   bool isFromPackage(String packageName) {
     return firstFragment.source.fullName.startsWith('/$packageName/');
   }
@@ -11,7 +11,7 @@ extension FindAllAvailableTopLevelElements on LibraryElement {
   ///
   /// This function does not guarantees that the elements returned are unique.
   /// It is possible for the same object to be present multiple times in the list.
-  Iterable<Element> findAllAvailableTopLevelElements() {
+  Iterable<Element2> findAllAvailableTopLevelElements() {
     return _findAllAvailableTopLevelElements(
       {},
       checkExports: false,
@@ -23,20 +23,20 @@ extension FindAllAvailableTopLevelElements on LibraryElement {
     );
   }
 
-  Iterable<Element> _findAllAvailableTopLevelElements(
+  Iterable<Element2> _findAllAvailableTopLevelElements(
     Set<_LibraryKey> visitedLibraryPaths, {
     required bool checkExports,
     required _LibraryKey key,
   }) sync* {
-    yield* children;
+    yield* children2;
 
     final librariesToCheck = checkExports
         ? fragments
-              .expand((e) => e.libraryExports)
+              .expand((e) => e.libraryExports2)
               .map(_LibraryDirectives.fromExport)
               .nonNulls
         : fragments
-              .expand((e) => e.libraryImports)
+              .expand((e) => e.libraryImports2)
               .map(_LibraryDirectives.fromImport)
               .nonNulls;
 
@@ -55,8 +55,8 @@ extension FindAllAvailableTopLevelElements on LibraryElement {
             return (directive.showStatements.isEmpty &&
                     directive.hideStatements.isEmpty) ||
                 (directive.hideStatements.isNotEmpty &&
-                    !directive.hideStatements.contains(element.name)) ||
-                directive.showStatements.contains(element.name);
+                    !directive.hideStatements.contains(element.name3)) ||
+                directive.showStatements.contains(element.name3);
           });
     }
   }
@@ -70,7 +70,7 @@ class _LibraryDirectives {
   });
 
   static _LibraryDirectives? fromExport(LibraryExport export) {
-    final library = export.exportedLibrary;
+    final library = export.exportedLibrary2;
     if (library == null) return null;
 
     final hideStatements = export.combinators
@@ -91,7 +91,7 @@ class _LibraryDirectives {
   }
 
   static _LibraryDirectives? fromImport(LibraryImport export) {
-    final library = export.importedLibrary;
+    final library = export.importedLibrary2;
     if (library == null) return null;
 
     final hideStatements = export.combinators
@@ -113,7 +113,7 @@ class _LibraryDirectives {
 
   final Set<String> hideStatements;
   final Set<String> showStatements;
-  final LibraryElement library;
+  final LibraryElement2 library;
 
   _LibraryKey get key {
     return _LibraryKey(

--- a/packages/freezed/lib/src/tools/type.dart
+++ b/packages/freezed/lib/src/tools/type.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:collection/collection.dart';
@@ -24,26 +24,26 @@ extension DartTypeX on DartType {
   }
 }
 
-/// Returns the [Element] for a given [DartType]
+/// Returns the [Element2] for a given [DartType]
 ///
 /// this is usually type.element, except if it is a typedef then it is
 /// type.alias.element
-Element? _getElementForType(DartType type) {
+Element2? _getElementForType(DartType type) {
   if (type is InterfaceType) {
-    return type.element;
+    return type.element3;
   }
   if (type is FunctionType) {
-    return type.alias?.element;
+    return type.alias?.element2;
   }
   return null;
 }
 
 /// Renders a type based on its string + potential import alias
-String resolveFullTypeStringFrom(LibraryElement originLibrary, DartType type) {
+String resolveFullTypeStringFrom(LibraryElement2 originLibrary, DartType type) {
   final owner = originLibrary.firstFragment.prefixes.firstWhereOrNull((e) {
     return e.imports.any((l) {
-      return l.importedLibrary!.anyTransitiveExport((library) {
-        return library.id == _getElementForType(type)?.library?.id;
+      return l.importedLibrary2!.anyTransitiveExport((library) {
+        return library.id == _getElementForType(type)?.library2?.id;
       });
     });
   });
@@ -62,8 +62,8 @@ String resolveFullTypeStringFrom(LibraryElement originLibrary, DartType type) {
   // 'dynamic Function(String)'
   //
   // Instead of 'SomeTypedef'
-  if (type is FunctionType && type.alias?.element != null) {
-    displayType = type.alias!.element.name!;
+  if (type is FunctionType && type.alias?.element2 != null) {
+    displayType = type.alias!.element2.name3!;
     if (type.alias!.typeArguments.isNotEmpty) {
       displayType += '<${type.alias!.typeArguments.join(', ')}>';
     }
@@ -84,14 +84,14 @@ String resolveFullTypeStringFrom(LibraryElement originLibrary, DartType type) {
   // This a regression in analyzer 5.13.0
   if (type is InterfaceType &&
       type.typeArguments.any((e) => e is InvalidType)) {
-    final dynamicType = type.element.library.typeProvider.dynamicType;
+    final dynamicType = type.element3.library2.typeProvider.dynamicType;
     var modified = type;
     modified.typeArguments..replaceWhere((t) => t is InvalidType, dynamicType);
     displayType = modified.getDisplayString();
   }
 
   if (owner != null) {
-    return '${owner.name}.$displayType';
+    return '${owner.name3}.$displayType';
   }
 
   return displayType;

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=7.5.9 <8.0.0"
-  build: ^3.0.0
+  analyzer: ">=7.5.9 <9.0.0"
+  build: ">=3.0.0 <5.0.0"
   build_config: ^1.1.0
   collection: ^1.15.0
   meta: ^1.9.1
-  source_gen: ^3.0.0
+  source_gen: ">=3.0.0 <5.0.0"
   freezed_annotation: 3.1.0
   json_annotation: ^4.8.0
   dart_style: ^3.0.0

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  analyzer: ^8.0.0
-  build: ^4.0.0
+  analyzer: ">=7.5.9 <8.0.0"
+  build: ^3.0.0
   build_config: ^1.1.0
   collection: ^1.15.0
   meta: ^1.9.1
-  source_gen: ^4.0.0
+  source_gen: ^3.0.0
   freezed_annotation: 3.1.0
   json_annotation: ^4.8.0
   dart_style: ^3.0.0

--- a/packages/freezed/test/bidirectional_test.dart
+++ b/packages/freezed/test/bidirectional_test.dart
@@ -20,7 +20,7 @@ void main() {
             )
             as ErrorsResult;
 
-    expect(errorResult.diagnostics, isEmpty);
+    expect(errorResult.errors, isEmpty);
   });
 
   test('bidirectional deep_copy', () {

--- a/packages/freezed/test/common.dart
+++ b/packages/freezed/test/common.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/diagnostic/diagnostic.dart';
+import 'package:analyzer/error/error.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
@@ -22,7 +23,7 @@ $src
   final errorResult =
       await main!.session.getErrors('/freezed/test/integration/main.dart')
           as ErrorsResult;
-  final criticalErrors = errorResult.diagnostics
+  final criticalErrors = errorResult.errors
       .where((element) => element.severity == Severity.error)
       .toList();
 
@@ -33,7 +34,7 @@ $src
 
 class CompileError extends Error {
   CompileError(this.errors);
-  final List<Diagnostic> errors;
+  final List<AnalysisError> errors;
 
   @override
   String toString() {

--- a/packages/freezed/test/common_types_test.dart
+++ b/packages/freezed/test/common_types_test.dart
@@ -25,7 +25,7 @@ Future<void> main() async {
             )
             as ErrorsResult;
 
-    expect(errorResult.diagnostics, isEmpty);
+    expect(errorResult.errors, isEmpty);
   });
 
   group('CommonSuperSubtype', () {

--- a/packages/freezed/test/decorator_test.dart
+++ b/packages/freezed/test/decorator_test.dart
@@ -17,7 +17,7 @@ void main() {
               '/freezed/test/integration/decorator.freezed.dart',
             )
             as ErrorsResult;
-    expect(errorResult.diagnostics, isEmpty);
+    expect(errorResult.errors, isEmpty);
     errorResult =
         await main.session.getErrors('/freezed/test/integration/decorator.dart')
             as ErrorsResult;
@@ -33,29 +33,32 @@ import 'decorator.dart';
 ''',
         },
         (r) => r.libraries.firstWhere(
-          (element) => element.library.name == 'decorator',
+          (element) => element.library2.name3 == 'decorator',
         ),
         readAllSourcesFromFilesystem: true,
       );
 
       final concrete = main.classes.firstWhere(
-        (e) => e.name == r'ListDecorator0',
+        (e) => e.name3 == r'ListDecorator0',
       );
 
       expect(
-        concrete.fields
-            .firstWhere((element) => element.name == '_a')
-            .metadata
+        concrete.fields2
+            .firstWhere((element) => element.name3 == '_a')
+            .metadata2
             .annotations,
         isEmpty,
       );
 
-      final unmodifiableGetter = concrete.fields
-          .firstWhere((element) => element.name == 'a')
-          .getter!;
+      final unmodifiableGetter = concrete.fields2
+          .firstWhere((element) => element.name3 == 'a')
+          .getter2!;
 
-      expect(unmodifiableGetter.metadata.annotations.length, 2);
-      expect(unmodifiableGetter.metadata.annotations.last.toSource(), '@Foo()');
+      expect(unmodifiableGetter.metadata2.annotations.length, 2);
+      expect(
+        unmodifiableGetter.metadata2.annotations.last.toSource(),
+        '@Foo()',
+      );
     },
   );
 
@@ -93,7 +96,7 @@ void main() {
         await main.session.getErrors('/freezed/test/integration/main.dart')
             as ErrorsResult;
     expect(
-      errorResult.diagnostics.map((e) => e.diagnosticCode.name),
+      errorResult.errors.map((e) => e.errorCode.name),
       anyOf([
         [
           'UNUSED_RESULT',

--- a/packages/freezed/test/deep_copy_test.dart
+++ b/packages/freezed/test/deep_copy_test.dart
@@ -31,7 +31,7 @@ void main() {
             )
             as ErrorsResult;
 
-    expect(errorResult.diagnostics, isEmpty);
+    expect(errorResult.errors, isEmpty);
   });
 
   test('has no issue #2', () async {
@@ -49,7 +49,7 @@ void main() {
             )
             as ErrorsResult;
 
-    expect(errorResult.diagnostics, isEmpty);
+    expect(errorResult.errors, isEmpty);
   });
 
   test('handles null', () {
@@ -734,7 +734,7 @@ void main() {
         await main.session.getErrors('/freezed/test/integration/main.dart')
             as ErrorsResult;
 
-    expect(errorResult.diagnostics.map((e) => e.diagnosticCode.name), [
+    expect(errorResult.errors.map((e) => e.errorCode.name), [
       'UNUSED_RESULT',
       'UNUSED_RESULT',
     ]);

--- a/packages/freezed/test/generic_test.dart
+++ b/packages/freezed/test/generic_test.dart
@@ -52,7 +52,7 @@ void main() {
             )
             as ErrorsResult;
 
-    expect(errorResult.diagnostics, isEmpty);
+    expect(errorResult.errors, isEmpty);
   });
 
   test('is generic', () {

--- a/packages/freezed/test/generics_refs_test.dart
+++ b/packages/freezed/test/generics_refs_test.dart
@@ -21,7 +21,7 @@ void main() {
             )
             as ErrorsResult;
 
-    expect(errorResult.diagnostics, isEmpty);
+    expect(errorResult.errors, isEmpty);
   });
 
   test('handles lists', () async {

--- a/packages/freezed/test/json_test.dart
+++ b/packages/freezed/test/json_test.dart
@@ -752,7 +752,7 @@ Future<void> main() async {
               '/freezed/test/integration/json.freezed.dart',
             )
             as ErrorsResult;
-    expect(errorResult.diagnostics, isEmpty);
+    expect(errorResult.errors, isEmpty);
   }, skip: true);
 
   test("single constructor fromJson doesn't require type", () {

--- a/packages/freezed/test/map_test.dart
+++ b/packages/freezed/test/map_test.dart
@@ -303,7 +303,7 @@ void main() {
           await main!.session.getErrors('/freezed/test/integration/main.dart')
               as ErrorsResult;
 
-      expect(errorResult.diagnostics, isNotEmpty);
+      expect(errorResult.errors, isNotEmpty);
     });
   });
 
@@ -424,7 +424,7 @@ void main() {
           await main!.session.getErrors('/freezed/test/integration/main.dart')
               as ErrorsResult;
 
-      expect(errorResult.diagnostics, isNotEmpty);
+      expect(errorResult.errors, isNotEmpty);
     });
   });
 

--- a/packages/freezed/test/multiple_constructors_test.dart
+++ b/packages/freezed/test/multiple_constructors_test.dart
@@ -2,7 +2,7 @@
 import 'dart:async';
 
 import 'package:analyzer/dart/analysis/results.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
@@ -23,8 +23,8 @@ Future<void> main() async {
     readAllSourcesFromFilesystem: true,
   );
 
-  ClassElement _getClassElement(String elementName) {
-    return sources.classes.singleWhere((e) => e.name == elementName);
+  ClassElement2 _getClassElement(String elementName) {
+    return sources.classes.singleWhere((e) => e.name3 == elementName);
   }
 
   test('Response', () {
@@ -37,14 +37,14 @@ Future<void> main() async {
   test('recursive class does not generate dynamic', () async {
     final recursiveClass = _getClassElement('_RecursiveNext');
 
-    expect(recursiveClass.getField('value')!.type, isA<InterfaceType>());
+    expect(recursiveClass.getField2('value')!.type, isA<InterfaceType>());
   });
 
   test('recursive class with dollar generates correctly', () async {
     final recursiveClass = _getClassElement('_RecursiveWith\$DollarNext');
 
     expect(
-      recursiveClass.getField('value')!.type.getDisplayString(),
+      recursiveClass.getField2('value')!.type.getDisplayString(),
       'RecursiveWith\$DollarImpl',
     );
   });
@@ -65,53 +65,53 @@ Future<void> main() async {
 
     expect(
       complex.mixins.first.getters.first,
-      isA<PropertyAccessorElement>()
-          .having((e) => e.name, 'name', 'a')
+      isA<PropertyAccessorElement2>()
+          .having((e) => e.name3, 'name', 'a')
           .having((e) => e.documentationComment, 'doc', '/// Hello'),
     );
 
     expect(
-      complex0.fields.where(
-        (e) => e.name != 'copyWith' && e.name != 'hashCode',
+      complex0.fields2.where(
+        (e) => e.name3 != 'copyWith' && e.name3 != 'hashCode',
       ),
       [
-        isA<FieldElement>()
-            .having((e) => e.name, 'name', 'a')
+        isA<FieldElement2>()
+            .having((e) => e.name3, 'name', 'a')
             .having((e) => e.documentationComment, 'doc', '/// Hello'),
       ],
     );
 
     expect(
-      complex1.fields.where(
-        (e) => e.name != 'copyWith' && e.name != 'hashCode',
+      complex1.fields2.where(
+        (e) => e.name3 != 'copyWith' && e.name3 != 'hashCode',
       ),
       [
-        isA<FieldElement>()
-            .having((e) => e.name, 'name', 'a')
+        isA<FieldElement2>()
+            .having((e) => e.name3, 'name', 'a')
             .having((e) => e.documentationComment, 'doc', '/// World'),
-        isA<FieldElement>()
-            .having((e) => e.name, 'name', 'b')
+        isA<FieldElement2>()
+            .having((e) => e.name3, 'name', 'b')
             .having((e) => e.documentationComment, 'doc', '/// B'),
-        isA<FieldElement>()
-            .having((e) => e.name, 'name', 'd')
+        isA<FieldElement2>()
+            .having((e) => e.name3, 'name', 'd')
             .having((e) => e.documentationComment, 'doc', null),
       ],
     );
 
     expect(
-      complex2.fields.where(
-        (e) => e.name != 'copyWith' && e.name != 'hashCode',
+      complex2.fields2.where(
+        (e) => e.name3 != 'copyWith' && e.name3 != 'hashCode',
       ),
       [
-        isA<FieldElement>()
-            .having((e) => e.name, 'name', 'a')
+        isA<FieldElement2>()
+            .having((e) => e.name3, 'name', 'a')
             // The doc is inherited from `Complex`
             .having((e) => e.documentationComment, 'doc', null),
-        isA<FieldElement>()
-            .having((e) => e.name, 'name', 'c')
+        isA<FieldElement2>()
+            .having((e) => e.name3, 'name', 'c')
             .having((e) => e.documentationComment, 'doc', '/// C'),
-        isA<FieldElement>()
-            .having((e) => e.name, 'name', 'd')
+        isA<FieldElement2>()
+            .having((e) => e.name3, 'name', 'd')
             .having((e) => e.documentationComment, 'doc', null),
       ],
     );
@@ -181,7 +181,7 @@ void main() {
               )
               as ErrorsResult;
 
-      expect(errorResult.diagnostics, isEmpty);
+      expect(errorResult.errors, isEmpty);
     });
 
     test('can mutate unfreezed unions', () {
@@ -574,7 +574,7 @@ void main() {
       final nestedListClass = _getClassElement('ShallowNestedList');
 
       expect(
-        nestedListClass.getField('children')!.type.getDisplayString(),
+        nestedListClass.getField2('children')!.type.getDisplayString(),
         'List<LeafNestedListItem>',
       );
     });
@@ -583,14 +583,14 @@ void main() {
       final nestedListClass = _getClassElement('DeepNestedList');
 
       expect(
-        nestedListClass.getField('children')!.type.getDisplayString(),
+        nestedListClass.getField2('children')!.type.getDisplayString(),
         'List<InnerNestedListItem>',
       );
 
       final nestedListItemClass = _getClassElement('InnerNestedListItem');
 
       expect(
-        nestedListItemClass.getField('children')!.type.getDisplayString(),
+        nestedListItemClass.getField2('children')!.type.getDisplayString(),
         'List<LeafNestedListItem>',
       );
     });
@@ -600,7 +600,7 @@ void main() {
       final nestedMapClass = _getClassElement('ShallowNestedMap');
 
       expect(
-        nestedMapClass.getField('children')!.type.getDisplayString(),
+        nestedMapClass.getField2('children')!.type.getDisplayString(),
         'Map<String, LeafNestedMapItem>',
       );
     });
@@ -609,14 +609,14 @@ void main() {
       final nestedMapClass = _getClassElement('DeepNestedMap');
 
       expect(
-        nestedMapClass.getField('children')!.type.getDisplayString(),
+        nestedMapClass.getField2('children')!.type.getDisplayString(),
         'Map<String, InnerNestedMapItem>',
       );
 
       final nestedMapItemClass = _getClassElement('InnerNestedMapItem');
 
       expect(
-        nestedMapItemClass.getField('children')!.type.getDisplayString(),
+        nestedMapItemClass.getField2('children')!.type.getDisplayString(),
         'Map<String, LeafNestedMapItem>',
       );
     });
@@ -627,19 +627,19 @@ void main() {
       final nestedMapClass = _getClassElement('_UsesGenerated');
 
       expect(
-        nestedMapClass.getField('value')!.type.getDisplayString(),
+        nestedMapClass.getField2('value')!.type.getDisplayString(),
         'CodeGenerated',
       );
       expect(
-        nestedMapClass.getField('list')!.type.getDisplayString(),
+        nestedMapClass.getField2('list')!.type.getDisplayString(),
         'List<CodeGenerated>',
       );
       expect(
-        nestedMapClass.getField('nestedList')!.type.getDisplayString(),
+        nestedMapClass.getField2('nestedList')!.type.getDisplayString(),
         'List<List<CodeGenerated>>',
       );
       expect(
-        nestedMapClass.getField('map')!.type.getDisplayString(),
+        nestedMapClass.getField2('map')!.type.getDisplayString(),
         'Map<int, CodeGenerated>',
       );
     });

--- a/packages/freezed/test/optional_maybe_test.dart
+++ b/packages/freezed/test/optional_maybe_test.dart
@@ -21,7 +21,7 @@ void main() {
             )
             as ErrorsResult;
 
-    expect(errorResult.diagnostics, isEmpty);
+    expect(errorResult.errors, isEmpty);
   });
 
   test('does not generates maybeMap', () async {

--- a/packages/freezed/test/single_class_constructor_test.dart
+++ b/packages/freezed/test/single_class_constructor_test.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: prefer_const_constructors, omit_local_variable_types, deprecated_member_use_from_same_package
 import 'package:analyzer/dart/analysis/results.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
@@ -25,7 +25,7 @@ class MyObject {
 }
 
 Future<void> main() async {
-  Future<LibraryElement> analyze() {
+  Future<LibraryElement2> analyze() {
     return resolveSources(
       {
         'freezed|test/integration/single_class_constructor.dart':
@@ -211,28 +211,28 @@ Future<void> main() async {
   test('documentation', () async {
     final singleClassLibrary = await analyze();
 
-    final doc = singleClassLibrary.classes.firstWhere((e) => e.name == 'Doc');
+    final doc = singleClassLibrary.classes.firstWhere((e) => e.name3 == 'Doc');
 
     expect(
       doc.mixins.first.getters.where(
-        (e) => e.name != 'copyWith' && e.name != 'hashCode',
+        (e) => e.name3 != 'copyWith' && e.name3 != 'hashCode',
       ),
       [
-        isA<PropertyAccessorElement>()
-            .having((e) => e.name, 'name', 'positional')
+        isA<PropertyAccessorElement2>()
+            .having((e) => e.name3, 'name', 'positional')
             .having((e) => e.documentationComment, 'doc', '''
 /// Multi
 /// line
 /// positional'''),
-        isA<PropertyAccessorElement>() //
-            .having((e) => e.name, 'name', 'named')
+        isA<PropertyAccessorElement2>() //
+            .having((e) => e.name3, 'name', 'named')
             .having(
               (e) => e.documentationComment,
               'doc',
               '/// Single line named',
             ),
-        isA<PropertyAccessorElement>() //
-            .having((e) => e.name, 'name', 'simple')
+        isA<PropertyAccessorElement2>() //
+            .having((e) => e.name3, 'name', 'simple')
             .having((e) => e.documentationComment, 'doc', null),
       ],
     );
@@ -379,7 +379,7 @@ void main() {
             )
             as ErrorsResult;
 
-    expect(errorResult.diagnostics, isEmpty);
+    expect(errorResult.errors, isEmpty);
   });
 
   test('toString includes the constructor name', () {
@@ -651,7 +651,7 @@ void main() {
               as ErrorsResult;
 
       expect(
-        errorResult.diagnostics.map((e) => e.toString()),
+        errorResult.errors.map((e) => e.toString()),
         anyElement(contains("The named parameter 'a' is required")),
       );
     },

--- a/packages/freezed/test/typedef_parameter_test.dart
+++ b/packages/freezed/test/typedef_parameter_test.dart
@@ -21,7 +21,7 @@ void main() {
             )
             as ErrorsResult;
 
-    expect(errorResult.diagnostics, isEmpty);
+    expect(errorResult.errors, isEmpty);
   });
 
   test('generates correct typedefs', () async {
@@ -36,33 +36,33 @@ void main() {
     );
 
     var freezedClass = main.classes.firstWhere(
-      (element) => element.name == '_ClassWithTypedef',
+      (element) => element.name3 == '_ClassWithTypedef',
     );
 
-    var constructor = freezedClass.constructors.firstWhere(
-      (element) => element.name == 'new',
+    var constructor = freezedClass.constructors2.firstWhere(
+      (element) => element.name3 == 'new',
     );
 
     var a = constructor.formalParameters.first.type;
     expect(a, isA<FunctionType>());
-    expect(a.alias!.element.name, equals('MyTypedef'));
+    expect(a.alias!.element2.name3, equals('MyTypedef'));
 
     var b = constructor.formalParameters[1].type;
     expect(b, isA<FunctionType>());
-    expect(b.alias!.element.name, equals('MyTypedef'));
+    expect(b.alias!.element2.name3, equals('MyTypedef'));
     expect(b.nullabilitySuffix, equals(NullabilitySuffix.question));
 
     var c = constructor.formalParameters[2].type;
     expect(c, isA<FunctionType>());
-    expect(c.alias!.element.name, equals('ExternalTypedef'));
+    expect(c.alias!.element2.name3, equals('ExternalTypedef'));
 
     var d = constructor.formalParameters[3].type;
     expect(d, isA<FunctionType>());
-    expect(d.alias!.element.name, equals('ExternalTypedefTwo'));
+    expect(d.alias!.element2.name3, equals('ExternalTypedefTwo'));
 
     var e = constructor.formalParameters[4].type;
     expect(e, isA<FunctionType>());
-    expect(e.alias!.element.name, equals('GenericTypedef'));
+    expect(e.alias!.element2.name3, equals('GenericTypedef'));
     expect(e.alias!.typeArguments.toString(), equals('[int, bool]'));
   });
 }

--- a/packages/freezed/test/when_test.dart
+++ b/packages/freezed/test/when_test.dart
@@ -302,7 +302,7 @@ void main() {
           await main!.session.getErrors('/freezed/test/integration/main.dart')
               as ErrorsResult;
 
-      expect(errorResult.diagnostics, isNotEmpty);
+      expect(errorResult.errors, isNotEmpty);
     });
   });
 

--- a/packages/freezed_lint/lib/src/missing_mixin.dart
+++ b/packages/freezed_lint/lib/src/missing_mixin.dart
@@ -1,5 +1,5 @@
-import 'package:analyzer/diagnostic/diagnostic.dart';
-import 'package:analyzer/error/listener.dart' show DiagnosticReporter;
+import 'package:analyzer/error/error.dart' hide LintCode;
+import 'package:analyzer/error/listener.dart' show ErrorReporter;
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:freezed_lint/src/tools/freezed_annotation_checker.dart';
 
@@ -14,7 +14,7 @@ class MissingMixin extends DartLintRule {
   @override
   void run(
     CustomLintResolver resolver,
-    DiagnosticReporter reporter,
+    ErrorReporter reporter,
     CustomLintContext context,
   ) {
     context.registry.addClassDeclaration((node) {
@@ -24,7 +24,7 @@ class MissingMixin extends DartLintRule {
       final annotation = freezedAnnotationChecker.hasAnnotationOfExact(element);
       if (!annotation) return;
 
-      final name = '_\$${element.name}';
+      final name = '_\$${element.name3}';
       final withClause = node.withClause;
       if (withClause == null) {
         reporter.atElement2(element, _code, arguments: [name]);
@@ -32,7 +32,7 @@ class MissingMixin extends DartLintRule {
       }
 
       final mixins = withClause.mixinTypes;
-      if (mixins.any((m) => name == m.name.lexeme)) return;
+      if (mixins.any((m) => name == m.name2.lexeme)) return;
       reporter.atElement2(element, _code, arguments: [name]);
     });
   }
@@ -47,8 +47,8 @@ class _AddMixinFreezedClassFix extends DartFix {
     CustomLintResolver resolver,
     ChangeReporter reporter,
     CustomLintContext context,
-    Diagnostic analysisError,
-    List<Diagnostic> others,
+    AnalysisError analysisError,
+    List<AnalysisError> others,
   ) {
     context.registry.addClassDeclaration((node) {
       if (!analysisError.sourceRange.intersects(node.sourceRange)) return;

--- a/packages/freezed_lint/lib/src/missing_private_empty_ctor.dart
+++ b/packages/freezed_lint/lib/src/missing_private_empty_ctor.dart
@@ -1,6 +1,5 @@
-import 'package:analyzer/diagnostic/diagnostic.dart';
 import 'package:analyzer/error/error.dart' hide LintCode;
-import 'package:analyzer/error/listener.dart' show DiagnosticReporter;
+import 'package:analyzer/error/listener.dart' show ErrorReporter;
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:freezed_lint/src/tools/element_extensions.dart';
 import 'package:freezed_lint/src/tools/freezed_annotation_checker.dart';
@@ -14,13 +13,13 @@ class MissingPrivateEmptyCtor extends DartLintRule {
     correctionMessage:
         'Freezed classes containing methods, fields or accessors,'
         'requires a {0}',
-    errorSeverity: DiagnosticSeverity.ERROR,
+    errorSeverity: ErrorSeverity.ERROR,
   );
 
   @override
   void run(
     CustomLintResolver resolver,
-    DiagnosticReporter reporter,
+    ErrorReporter reporter,
     CustomLintContext context,
   ) {
     context.registry.addClassDeclaration((node) {
@@ -30,17 +29,17 @@ class MissingPrivateEmptyCtor extends DartLintRule {
       final annotation = freezedAnnotationChecker.hasAnnotationOfExact(element);
       if (!annotation) return;
 
-      final methods = element.methods.where((method) => !method.isStatic);
-      final fields = element.fields.where((field) => !field.isStatic);
+      final methods = element.methods2.where((method) => !method.isStatic);
+      final fields = element.fields2.where((field) => !field.isStatic);
 
       final accessors = [
-        ...element.getters,
-        ...element.setters,
+        ...element.getters2,
+        ...element.setters2,
       ].where((accessor) => !accessor.isStatic);
       if (methods.isEmpty && fields.isEmpty && accessors.isEmpty) return;
 
-      final ctors = element.constructors.where((ctor) =>
-          ctor.isPrivate && ctor.formalParameters.isEmpty && ctor.name == '_');
+      final ctors = element.constructors2.where((ctor) =>
+          ctor.isPrivate && ctor.formalParameters.isEmpty && ctor.name3 == '_');
       if (ctors.isNotEmpty) return;
 
       final constToken = element.constToken();
@@ -59,8 +58,8 @@ class _AddPrivateEmptyCtorFix extends DartFix {
     CustomLintResolver resolver,
     ChangeReporter reporter,
     CustomLintContext context,
-    Diagnostic analysisError,
-    List<Diagnostic> others,
+    AnalysisError analysisError,
+    List<AnalysisError> others,
   ) {
     context.registry.addClassDeclaration((node) {
       if (!analysisError.sourceRange.intersects(node.sourceRange)) return;

--- a/packages/freezed_lint/lib/src/tools/element_extensions.dart
+++ b/packages/freezed_lint/lib/src/tools/element_extensions.dart
@@ -1,13 +1,13 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 extension DartTypeExt on DartType {
   bool hasName(String name) => getDisplayString() == name;
 }
 
-extension ClassElementExt on ClassElement {
+extension ClassElementExt on ClassElement2 {
   String? constToken() {
-    if (constructors.any((c) => c.isConst)) return 'const ';
+    if (constructors2.any((c) => c.isConst)) return 'const ';
     return null;
   }
 }

--- a/packages/freezed_lint/pubspec.yaml
+++ b/packages/freezed_lint/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: ^7.0.0
+  analyzer: ">=7.5.9 <9.0.0"
   analyzer_plugin: ^0.13.0
   custom_lint_builder: ^0.8.0
   freezed_annotation: 3.1.0

--- a/packages/freezed_lint/pubspec.yaml
+++ b/packages/freezed_lint/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: ^8.0.0
+  analyzer: ^7.0.0
   analyzer_plugin: ^0.13.0
-  custom_lint_builder: ^0.8.1
+  custom_lint_builder: ^0.8.0
   freezed_annotation: 3.1.0
 
 dev_dependencies:
-  custom_lint: ^0.8.1
+  custom_lint: ^0.8.0
   build_verify: ^3.1.0
   test: ^1.22.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Broaden dependency constraints (analyzer, build, source_gen) and add a new dependency to improve compatibility with analyzer 7.5.9–<9.0.0.
  - Update lint package constraints and temporarily ignore a deprecation in analysis settings.

- Refactor
  - Migrate internals to newer analyzer APIs for improved forward compatibility. No functional changes expected for end users.

- Tests
  - Update test suite to align with the analyzer’s new error reporting API, maintaining existing coverage and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->