### PR TITLE
docs: capitalize bullet points in model definition steps

### DIFF
--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -16,10 +16,10 @@ To migrate from 2.0.0 to 3.0.0, see [changelog](https://github.com/rrousselGit/f
 
 Dart is awesome, but defining a "model" can be tedious. You have to:
 
-- define a constructor + properties
-- override `toString`, `operator ==`, `hashCode`
-- implement a `copyWith` method to clone the object
-- handle (de)serialization
+- Define a constructor + properties
+- Override `toString`, `operator ==`, `hashCode`
+- Implement a `copyWith` method to clone the object
+- Handle (de)serialization
 
 Implementing all of this can take hundreds of lines, which are error-prone
 and affect the readability of your model significantly.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved readability in the README’s Motivation section by standardizing capitalization and phrasing of four bullet points outlining core capabilities (constructor/properties, toString/==/hashCode overrides, copyWith cloning, and (de)serialization).
  * Documentation-only update; no functional changes or API adjustments.
  * Provides clearer guidance for users scanning the rationale and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->