### PR TITLE
Fix EqualUnmodifiableListView equality to use content-based comparison

### DIFF
--- a/packages/freezed_annotation/lib/freezed_annotation.dart
+++ b/packages/freezed_annotation/lib/freezed_annotation.dart
@@ -18,11 +18,11 @@ class EqualUnmodifiableListView<T> extends UnmodifiableListView<T> {
   bool operator ==(Object other) {
     return other is EqualUnmodifiableListView<T> &&
         other.runtimeType == runtimeType &&
-        other._source == _source;
+        const DeepCollectionEquality().equals(other._source, _source);
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, _source);
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(_source));
 }
 
 /// An [UnmodifiableSetView] which overrides ==
@@ -36,11 +36,11 @@ class EqualUnmodifiableSetView<T> extends UnmodifiableSetView<T> {
   bool operator ==(Object other) {
     return other is EqualUnmodifiableSetView<T> &&
         other.runtimeType == runtimeType &&
-        other._source == _source;
+        const DeepCollectionEquality().equals(other._source, _source);
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, _source);
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(_source));
 }
 
 /// An [UnmodifiableMapView] which overrides ==
@@ -55,11 +55,11 @@ class EqualUnmodifiableMapView<Key, Value>
   bool operator ==(Object other) {
     return other is EqualUnmodifiableMapView<Key, Value> &&
         other.runtimeType == runtimeType &&
-        other._source == _source;
+        const DeepCollectionEquality().equals(other._source, _source);
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, _source);
+  int get hashCode => Object.hash(runtimeType, const DeepCollectionEquality().hash(_source));
 }
 
 /// Options for enabling/disabling specific `Union.map` features;


### PR DESCRIPTION


This PR fixes the equality comparison for `EqualUnmodifiableListView`, `EqualUnmodifiableSetView`, and `EqualUnmodifiableMapView` to use content-based comparison instead of object reference comparison.

## Changes

- Updated `==` operator to use `DeepCollectionEquality().equals()` for content comparison
- Updated `hashCode` to use `DeepCollectionEquality().hash()` for consistent hashing
- Applied fixes to all three collection wrapper classes

## Fixes

Resolves #1308


## Impact

This fix ensures consistency between freezed `List` equality and freezed objects containing lists, which resolves the Riverpod `ref.watch(Provider).select()` issue mentioned in the GitHub issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced equality comparison for collection-based objects. Collections are now compared using deep equality instead of reference equality, ensuring objects with identical collection contents are correctly recognized as equal. Hash code calculations updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->