### PR TITLE
fix: updated README.md format from freezed: to freezed:freezed:

### DIFF
--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -825,7 +825,7 @@ If you want to customize key and value for all the classes, you can specify it i
 targets:
   $default:
     builders:
-      freezed:
+      freezed:freezed:
         options:
           union_key: type
           union_value_case: pascal
@@ -912,7 +912,7 @@ Alternatively, you can enable `genericArgumentFactories` for the whole project b
 targets:
   $default:
     builders:
-      freezed:
+      freezed:freezed:
         options:
           generic_argument_factories: true
 ```
@@ -1358,7 +1358,7 @@ by writing:
 targets:
   $default:
     builders:
-      freezed:
+      freezed:freezed:
         options:
           # Tells Freezed to format .freezed.dart files.
           # This can significantly slow down code-generation.

--- a/packages/freezed/example/build.yaml
+++ b/packages/freezed/example/build.yaml
@@ -1,7 +1,7 @@
 targets:
   $default:
     builders:
-      freezed:
+      freezed:freezed:
         options:
           union_key: custom-key
           union_value_case: pascal

--- a/packages/freezed_lint/example/build.yaml
+++ b/packages/freezed_lint/example/build.yaml
@@ -1,7 +1,7 @@
 targets:
   $default:
     builders:
-      freezed:
+      freezed:freezed:
         enabled: true
         generate_for:
           exclude:

--- a/resources/translations/ja_JP/README.md
+++ b/resources/translations/ja_JP/README.md
@@ -721,7 +721,7 @@ sealed class MyResponse with _$MyResponse {
 targets:
   $default:
     builders:
-      freezed:
+      freezed:freezed:
         options:
           union_key: type
           union_value_case: pascal
@@ -805,7 +805,7 @@ sealed class ApiResponse<T> with _$ApiResponse<T> {
 targets:
   $default:
     builders:
-      freezed:
+      freezed:freezed:
         options:
           generic_argument_factories: true
 ```
@@ -1142,7 +1142,7 @@ my_project_folder/
 targets:
   $default:
     builders:
-      freezed:
+      freezed:freezed:
         options:
           # .freezed.dartファイルのフォーマットを無効にします。
           # これによりコード生成の速度が大幅に向上する可能性があります。

--- a/resources/translations/ko_KR/README.md
+++ b/resources/translations/ko_KR/README.md
@@ -717,7 +717,7 @@ class MyResponse with _$MyResponse {
 targets:
   $default:
     builders:
-      freezed:
+      freezed:freezed:
         options:
           union_key: type
           union_value_case: pascal
@@ -802,7 +802,7 @@ class ApiResponse<T> with _$ApiResponse<T> {
 targets:
   $default:
     builders:
-      freezed:
+      freezed:freezed:
         options:
           generic_argument_factories: true
 ```
@@ -1129,7 +1129,7 @@ my_project_folder/
 targets:
   $default:
     builders:
-      freezed:
+      freezed:freezed:
         options:
           # 전체 프로젝트에 대해 copyWith/== 생성 비활성화
           copy_with: false

--- a/resources/translations/vi_VN/README.md
+++ b/resources/translations/vi_VN/README.md
@@ -709,7 +709,7 @@ Nếu bạn muốn tùy chỉnh khóa và giá trị của tất cả các lớp
 targets:
   $default:
     builders:
-      freezed:
+      freezed:freezed:
         options:
           union_key: type
           union_value_case: pascal
@@ -791,7 +791,7 @@ Ngoài ra, bạn cũng có thể thay đổi tệp `build.yaml` để kích ho�
 targets:
   $default:
     builders:
-      freezed:
+      freezed:freezed:
         options:
           generic_argument_factories: true
 ```
@@ -1120,7 +1120,7 @@ Ví dụ như sau:
 targets:
   $default:
     builders:
-      freezed:
+      freezed:freezed:
         options:
           # Vô hiệu hóa định dạng tệp .freezed.dart.
           # Điều này có thể giúp tăng tốc quá trình tạo mã.

--- a/resources/translations/zh_CN/README.md
+++ b/resources/translations/zh_CN/README.md
@@ -710,7 +710,7 @@ sealed class MyResponse with _$MyResponse {
 targets:
   $default:
     builders:
-      freezed:
+      freezed:freezed:
         options:
           union_key: type
           union_value_case: pascal
@@ -794,7 +794,7 @@ sealed class ApiResponse<T> with _$ApiResponse<T> {
 targets:
   $default:
     builders:
-      freezed:
+      freezed:freezed:
         options:
           generic_argument_factories: true
 ```
@@ -1122,7 +1122,7 @@ my_project_folder/
 targets:
   $default:
     builders:
-      freezed:
+      freezed:freezed:
         options:
           # 禁用生成 copyWith / == （整个项目）
           copy_with: false


### PR DESCRIPTION
## Description
Fixes incorrect `build.yaml` configuration format in documentation examples.

## Changes Made
- Updated `build.yaml` configuration from `freezed:` to `freezed:freezed:` in all documentation examples
- Fixed example `build.yaml` files throughout the repository
- Updated `README.md` and translation files to reflect correct configuration format

## Fixes
Closes #1309

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build configuration examples across multiple language READMEs to reflect the correct builder namespace reference format.

* **Chores**
  * Updated example build configurations to use the qualified builder reference.
  * Added file exclusion to generated code configuration in freezed_lint example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->