### PR TITLE
docs: fix typo decarator -> decorator in resources/translations/ko_KR…

### DIFF
--- a/resources/translations/ko_KR/README.md
+++ b/resources/translations/ko_KR/README.md
@@ -539,7 +539,7 @@ abstract class Person with _$Person {
 
 ### Union Types에서 Mixin 및 Interface 사용하기
 
-Union Type 클래스는 `@implements` 또는 `@with` decarator를 사용하여 `Mixin` 또는 `Interface`를 구현할 수 있습니다. 아래 예제에서는 `City` 클래스가 `GeographicArea` 추상 클래스를 구현합니다.
+Union Type 클래스는 `@implements` 또는 `@with` decorator를 사용하여 `Mixin` 또는 `Interface`를 구현할 수 있습니다. 아래 예제에서는 `City` 클래스가 `GeographicArea` 추상 클래스를 구현합니다.
 
 ```dart
 abstract class GeographicArea {


### PR DESCRIPTION
- Documentation
   - Fixed a typo(decarator -> decorator) in `resources/translations/ko_KR/README.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected typo in Korean language documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->