### PR TITLE
Allow analyzer 11.x and 12.x releases

### DIFF
--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  analyzer: '>=9.0.0 <11.0.0'
+  analyzer: '>=9.0.0 <13.0.0'
   build: ">=3.0.0 <5.0.0"
   build_config: ^1.1.0
   collection: ^1.15.0

--- a/packages/freezed_lint/pubspec.yaml
+++ b/packages/freezed_lint/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: '>=9.0.0 <11.0.0'
+  analyzer: '>=9.0.0 <13.0.0'
   analyzer_plugin: ^0.13.0
   custom_lint_builder: ^0.8.0
   freezed_annotation: 3.1.0


### PR DESCRIPTION
Allow analyzer 11.x and 12.x releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated analyzer dependency constraints in freezed and freezed_lint packages to support a broader range of compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->