### PR TITLE
Fix missing `unnecessary_non_null_assertion` (#1270)

### DIFF
--- a/packages/freezed/lib/src/templates/copy_with.dart
+++ b/packages/freezed/lib/src/templates/copy_with.dart
@@ -256,7 +256,10 @@ ${_copyWithDocs(data.name)}
 
   String _ignoreLints(
     String s, [
-    List<String> lints = const ['cast_nullable_to_non_nullable'],
+    List<String> lints = const [
+      'cast_nullable_to_non_nullable',
+      'unnecessary_non_null_assertion',
+    ],
   ]) =>
       '''
 // ignore: ${lints.join(', ')}


### PR DESCRIPTION
Fixes #1270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analyzer lint suppression in generated code to reduce unnecessary warnings related to null assertion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->