### PR TITLE
Initial primary constructor support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,13 +56,13 @@ jobs:
       - name: Check format
         # Check dart format only on stable
         if: matrix.channel == 'master'
-        run: dart format --set-exit-if-changed .
+        run: dart format --set-exit-if-changed . --enable-experiment=primary-constructors
         working-directory: ${{ matrix.package }}
 
       - name: Generate
         run: |
           if grep -q build_runner "pubspec.yaml"; then
-            dart pub run build_runner build --delete-conflicting-outputs
+            dart pub run build_runner build --delete-conflicting-outputs  --enable-experiment=primary-constructors
           fi
         working-directory: ${{ matrix.package }}
 

--- a/packages/freezed/CHANGELOG.md
+++ b/packages/freezed/CHANGELOG.md
@@ -1,6 +1,9 @@
-## Unreleased 3.2.6-dev.2
+## Unreleased major
 
-Support analyzer 13.0
+- Support analyzer 13.0
+- Support primary constructors
+- *Breaking*: No-longer support `final` keyword inside constructor parameter. This is due to Dart 3.13 no-longer allowing this syntax.
+  This prevents `@unfreezed` from defining immutable fields.
 
 ## 3.2.6-dev.1 - 2026-04-23
 

--- a/packages/freezed/README.md
+++ b/packages/freezed/README.md
@@ -363,7 +363,6 @@ abstract class Person with _$Person {
   factory Person({
     required String firstName,
     required String lastName,
-    required final int age,
   }) = _Person;
 
   factory Person.fromJson(Map<String, Object?> json) => _$PersonFromJson(json);
@@ -377,20 +376,19 @@ differences:
 
   ```dart
   void main() {
-    var person = Person(firstName: 'John', lastName: 'Smith', age: 42);
+    var person = Person(firstName: 'John', lastName: 'Smith');
 
     person.firstName = 'Mona';
     person.lastName = 'Lisa';
   }
   ```
 
-- `age` is still immutable, because we explicitly marked the property as `final`.
 - `Person` no-longer has a custom ==/hashCode implementation:
 
   ```dart
   void main() {
-    var john = Person(firstName: 'John', lastName: 'Smith', age: 42);
-    var john2 = Person(firstName: 'John', lastName: 'Smith', age: 42);
+    var john = Person(firstName: 'John', lastName: 'Smith');
+    var john2 = Person(firstName: 'John', lastName: 'Smith');
 
     print(john == john2); // false
   }

--- a/packages/freezed/analysis_options.yaml
+++ b/packages/freezed/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: ../../analysis_options.yaml
+
+analyzer:
+  enable-experiment:
+    - primary-constructors

--- a/packages/freezed/lib/builder.dart
+++ b/packages/freezed/lib/builder.dart
@@ -20,8 +20,7 @@ Builder freezed(BuilderOptions options) {
     header: '''
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // coverage:ignore-file
-// ignore_for_file: type=lint
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+// ignore_for_file: type=lint, type=warning
     ''',
     options: options,
   );

--- a/packages/freezed/lib/src/models.dart
+++ b/packages/freezed/lib/src/models.dart
@@ -87,10 +87,10 @@ class DeepCloneableProperty {
   });
 
   static Iterable<DeepCloneableProperty> parseAll(
-    ConstructorDeclaration constructorNode,
+    AstNode constructorNode,
     Freezed globalConfigs,
   ) sync* {
-    for (final parameterNode in constructorNode.parameters.parameters) {
+    for (final parameterNode in constructorNode.constructorParameters.parameters) {
       final type = parseTypeSource(parameterNode);
 
       final parameter = parameterNode.declaredFragment!.element;
@@ -175,23 +175,23 @@ class ConstructorDetails {
 
   static void _assertValidNormalConstructorUsage(
     ClassDeclaration declaration,
-    ConstructorDeclaration constructor,
+    AstNode constructor,
   ) {
-    final freezedCtors = declaration.constructors.where(
-      (e) => e.factoryKeyword != null && e.redirectedConstructor != null,
-    );
+    final freezedCtors = declaration.allConstructors.where(
+      (e) => e is ConstructorDeclaration && e.factoryKeyword != null && e.redirectedConstructor != null,
+    ).cast<ConstructorDeclaration>();
 
-    if (constructor.factoryKeyword == null &&
+    if (((constructor is ConstructorDeclaration && constructor.factoryKeyword == null) || constructor is PrimaryConstructorDeclaration) &&
         !constructor.isManualCtor &&
         freezedCtors.isNotEmpty) {
       throw InvalidGenerationSourceError(
         'Classes decorated with @freezed can only have a single non-factory constructor.',
-        element: constructor.declaredFragment?.element,
+        element: constructor.constructorElement,
       );
     }
 
     if (constructor.isManualCtor) {
-      for (final param in constructor.parameters.parameters) {
+      for (final param in constructor.constructorParameters.parameters) {
         if (param.isPositional) {
           for (final ctor in freezedCtors) {
             final hasMatchingParam = ctor.parameters.parameters.any(
@@ -206,7 +206,7 @@ but at least one constructor does not have a matching parameter.
 When specifying fields in non-factory constructor then specifying factory constructors, either:
 - the parameter should be named
 - or all constructors in the class should specify that parameter.
-''', element: constructor.declaredFragment?.element);
+''', element: constructor.constructorElement);
           }
         }
       }
@@ -246,34 +246,46 @@ When specifying fields in non-factory constructor then specifying factory constr
 
     final manualConstructor = declaration.manualConstructor;
 
-    for (final constructor in declaration.constructors) {
-      if (constructor.factoryKeyword == null ||
-          constructor.name?.lexeme == 'fromJson') {
-        _assertValidNormalConstructorUsage(declaration, constructor);
+    for (final constructor in declaration.allConstructors) {
+      final String? redirectedName;
+      if (constructor is ConstructorDeclaration) {
+        if (constructor.factoryKeyword == null ||
+            constructor.name?.lexeme == 'fromJson') {
+          _assertValidNormalConstructorUsage(declaration, constructor);
+          continue;
+        }
+
+        redirectedName =
+            constructor.redirectedConstructor?.type.name.lexeme;
+
+        if (redirectedName == null) {
+          _assertValidNormalConstructorUsage(declaration, constructor);
+          continue;
+        }
+
+        _assertValidFreezedConstructorUsage(
+          constructor,
+          className: declaration.namePart.typeName.lexeme,
+        );
+      } else if (constructor is PrimaryConstructorDeclaration) {
+        if (constructor.isManualCtor) {
+          _assertValidNormalConstructorUsage(declaration, constructor);
+          continue;
+        }
+
+        redirectedName = '_${declaration.namePart.typeName.lexeme}';
+      } else {
         continue;
       }
-
-      final redirectedName =
-          constructor.redirectedConstructor?.type.name.lexeme;
-
-      if (redirectedName == null) {
-        _assertValidNormalConstructorUsage(declaration, constructor);
-        continue;
-      }
-
-      _assertValidFreezedConstructorUsage(
-        constructor,
-        className: declaration.namePart.typeName.lexeme,
-      );
 
       final excludedProperties =
-          manualConstructor?.parameters.parameters
-              .map((e) => e.declaredFragment!.element.name!)
+          manualConstructor?.constructorParameters.parameters
+              .map((FormalParameter e) => e.declaredFragment!.element.name!)
               .toSet() ??
           <String>{};
 
       final allProperties = [
-        for (final parameter in constructor.parameters.parameters)
+        for (final parameter in constructor.constructorParameters.parameters)
           Property.fromFormalParameter(
             parameter,
             addImplicitFinal: configs.annotation.addImplicitFinal,
@@ -290,43 +302,47 @@ When specifying fields in non-factory constructor then specifying factory constr
 
       result.add(
         ConstructorDetails(
-          asserts: AssertAnnotation.parseAll(constructor).toList(),
+          asserts: AssertAnnotation.parseAll(constructor.constructorElement).toList(),
           isSynthetic: !isEjected,
-          name: constructor.name?.lexeme ?? '',
-          unionValue: constructor.declaredFragment!.element.unionValue(
+          name: constructor.constructorNamePart ?? '',
+          unionValue: constructor.constructorElement.unionValue(
             configs.annotation.unionValueCase,
           ),
-          isConst: constructor.constKeyword != null,
-          fullName: constructor.fullName,
-          escapedName: constructor.escapedName,
+          isConst: constructor is ConstructorDeclaration
+              ? constructor.constKeyword != null
+              : constructor.constructorElement.isConst,
+          fullName: constructor.constructorFullName,
+          escapedName: constructor.constructorEscapedName,
           properties: allProperties,
-          decorators: constructor.metadata
-              .where((element) {
-                final elementSourceUri =
-                    element.element?.baseElement.library?.uri;
+          decorators: constructor is ConstructorDeclaration
+              ? constructor.metadata
+                  .where((Annotation element) {
+                    final elementSourceUri =
+                        element.element?.baseElement.library?.uri;
 
-                final isFreezedAnnotation =
-                    elementSourceUri != null &&
-                    elementSourceUri.scheme == 'package' &&
-                    elementSourceUri.pathSegments.isNotEmpty &&
-                    elementSourceUri.pathSegments.first == 'freezed_annotation';
+                    final isFreezedAnnotation =
+                        elementSourceUri != null &&
+                        elementSourceUri.scheme == 'package' &&
+                        elementSourceUri.pathSegments.isNotEmpty &&
+                        elementSourceUri.pathSegments.first == 'freezed_annotation';
 
-                return !isFreezedAnnotation;
-              })
-              .map((e) => e.toSource())
-              .toList(),
+                    return !isFreezedAnnotation;
+                  })
+                  .map((Annotation e) => e.toSource())
+                  .toList()
+              : const <String>[],
           withDecorators: WithAnnotation.parseAll(
-            constructor.declaredFragment!.element,
+            constructor.constructorElement,
           ).toSet().toList(),
           implementsDecorators: ImplementsAnnotation.parseAll(
-            constructor.declaredFragment!.element,
+            constructor.constructorElement,
           ).toSet().toList(),
           isDefault: isDefaultConstructor(
-            constructor.declaredFragment!.element,
+            constructor.constructorElement,
           ),
           hasJsonSerializable:
-              constructor.declaredFragment!.element.hasJsonSerializable,
-          isFallback: constructor.declaredFragment!.element.isFallbackUnion(
+              constructor.constructorElement.hasJsonSerializable,
+          isFallback: constructor.constructorElement.isFallbackUnion(
             configs.annotation.fallbackUnion,
           ),
           deepCloneableProperties: DeepCloneableProperty.parseAll(
@@ -334,7 +350,7 @@ When specifying fields in non-factory constructor then specifying factory constr
             globalConfigs,
           ).toList(),
           parameters: ParametersTemplate.fromParameterList(
-            constructor.parameters.parameters,
+            constructor.constructorParameters.parameters,
             addImplicitFinal: configs.annotation.addImplicitFinal,
           ),
           redirectedName: redirectedName,
@@ -463,12 +479,12 @@ class AssertAnnotation {
   AssertAnnotation({required this.code, required this.message});
 
   static Iterable<AssertAnnotation> parseAll(
-    ConstructorDeclaration constructor,
+    ConstructorElement element,
   ) sync* {
     for (final meta in const TypeChecker.typeNamed(
       Assert,
       inPackage: 'freezed_annotation',
-    ).annotationsOf(constructor.declaredFragment!.element)) {
+    ).annotationsOf(element)) {
       yield AssertAnnotation(
         code: meta.getField('eval')!.toStringValue()!,
         message: meta.getField('message')!.toStringValue(),
@@ -595,13 +611,13 @@ class Class {
       ),
     );
 
-    final copyWithTarget = constructors.isNotEmpty
-        ? null
-        : declaration.copyWithTarget;
+    final copyWithTarget = (constructors.length <= 1)
+        ? declaration.copyWithTarget
+        : null;
 
     if (copyWithTarget != null) {
       // Check for missing required parameters on the copyWith target
-      for (final param in copyWithTarget.parameters.parameters) {
+      for (final param in copyWithTarget.constructorParameters.parameters) {
         if (param.isOptional) continue;
 
         final cloneableProperty = properties.cloneableProperties
@@ -626,12 +642,12 @@ To fix, either:
     final copyWithInvocation = copyWithTarget == null
         ? null
         : CopyWithTarget(
-            name: copyWithTarget.name?.lexeme,
+            name: copyWithTarget.constructorNamePart,
             parameters: ParametersTemplate.fromParameterList(
               // Only include parameters that are cloneable
-              copyWithTarget.parameters.parameters.where((e) {
+              copyWithTarget.constructorParameters.parameters.where((FormalParameter e) {
                 return properties.cloneableProperties
-                    .map((e) => e.name)
+                    .map((p) => p.name)
                     .contains(e.name!.lexeme);
               }),
               addImplicitFinal: configs.annotation.addImplicitFinal,
@@ -639,16 +655,28 @@ To fix, either:
           );
 
     final superCall = privateCtor == null
-        ? null
+        ? (declaration.primaryConstructor != null
+            ? ConstructorInvocation(
+                name: declaration.primaryConstructor!.constructorNamePart ?? '',
+                positional: declaration.primaryConstructor!.constructorParameters.parameters
+                    .where((FormalParameter e) => e.isPositional)
+                    .map((FormalParameter e) => e.name!.lexeme)
+                    .toList(),
+                named: declaration.primaryConstructor!.constructorParameters.parameters
+                    .where((FormalParameter e) => e.isNamed)
+                    .map((FormalParameter e) => e.name!.lexeme)
+                    .toList(),
+              )
+            : null)
         : ConstructorInvocation(
-            name: '_',
-            positional: privateCtor.parameters.parameters
-                .where((e) => e.isPositional)
-                .map((e) => e.name!.lexeme)
+            name: privateCtor.constructorNamePart ?? '',
+            positional: privateCtor.constructorParameters.parameters
+                .where((FormalParameter e) => e.isPositional)
+                .map((FormalParameter e) => e.name!.lexeme)
                 .toList(),
-            named: privateCtor.parameters.parameters
-                .where((e) => e.isNamed)
-                .map((e) => e.name!.lexeme)
+            named: privateCtor.constructorParameters.parameters
+                .where((FormalParameter e) => e.isNamed)
+                .map((FormalParameter e) => e.name!.lexeme)
                 .toList(),
           );
 
@@ -759,7 +787,7 @@ To fix, either:
     final targetConstructor = declaration.copyWithTarget;
     if (targetConstructor == null) return;
 
-    for (final parameter in targetConstructor.parameters.parameters) {
+    for (final parameter in targetConstructor.constructorParameters.parameters) {
       yield Property.fromFormalParameter(
         parameter,
         addImplicitFinal: configs.annotation.addImplicitFinal,
@@ -824,11 +852,11 @@ To fix, either:
     }
 
     for (final (index, freezedCtor) in constructorsNeedsGeneration.indexed) {
-      final ctor = declaration.constructors
-          .where((e) => (e.name?.lexeme ?? '') == freezedCtor.name)
+      final ctor = declaration.allConstructors
+          .where((e) => (e.constructorNamePart ?? '') == freezedCtor.name)
           .first;
 
-      for (final parameter in ctor.parameters.parameters) {
+      for (final parameter in ctor.constructorParameters.parameters) {
         final freezedParameter = freezedCtor.parameters.allParameters
             .where((e) => e.name == parameter.name?.lexeme)
             .first;
@@ -1297,22 +1325,121 @@ class ClassConfig {
   final Freezed annotation;
 }
 
-extension on ConstructorDeclaration {
-  bool get isManualCtor => name?.lexeme == '_' && factoryKeyword == null;
+extension AstNodeConstructorX on AstNode {
+  bool get isManualCtor {
+    final self = this;
+    if (self is ConstructorDeclaration) {
+      return self.name?.lexeme == '_' && self.factoryKeyword == null;
+    } else if (self is PrimaryConstructorDeclaration) {
+      return self.constructorName?.name.lexeme == '_';
+    }
+    return false;
+  }
+
+  FormalParameterList get constructorParameters {
+    final self = this;
+    if (self is ConstructorDeclaration) {
+      return self.parameters;
+    } else if (self is PrimaryConstructorDeclaration) {
+      return self.formalParameters;
+    }
+    throw StateError('Unknown node type $runtimeType');
+  }
+
+  String? get constructorNamePart {
+    final self = this;
+    if (self is ConstructorDeclaration) {
+      return self.name?.lexeme;
+    } else if (self is PrimaryConstructorDeclaration) {
+      return self.constructorName?.name.lexeme;
+    }
+    return null;
+  }
+
+  ConstructorElement get constructorElement {
+    final self = this;
+    if (self is ConstructorDeclaration) {
+      return self.declaredFragment!.element;
+    } else if (self is PrimaryConstructorDeclaration) {
+      return (self as dynamic).declaredFragment!.element as ConstructorElement;
+    }
+    throw StateError('Unknown node type $runtimeType');
+  }
+
+  String get constructorFullName {
+    final self = this;
+    final element = self.constructorElement;
+    final classElement = element.enclosingElement;
+
+    var generics = classElement.typeParameters
+        .map((e) => '\$${e.name}')
+        .join(', ');
+    if (generics.isNotEmpty) {
+      generics = '<$generics>';
+    }
+
+    final className = classElement.enclosingElement.name;
+    final constructorName = self.constructorNamePart;
+
+    return constructorName == null ? '$className$generics' : '$className$generics.$constructorName';
+  }
+
+  String get constructorEscapedName {
+    final self = this;
+    final element = self.constructorElement;
+    final classElement = element.enclosingElement;
+
+    var generics = classElement.typeParameters
+        .map((e) => '\$${e.name}')
+        .join(', ');
+    if (generics.isNotEmpty) {
+      generics = '<$generics>';
+    }
+
+    final escapedElementName = classElement.name!.replaceAll(r'$', r'\$');
+    final constructorName = self.constructorNamePart;
+    final escapedConstructorName = constructorName?.replaceAll(r'$', r'\$');
+
+    return escapedConstructorName == null
+        ? '$escapedElementName$generics'
+        : '$escapedElementName$generics.$escapedConstructorName';
+  }
 }
 
 extension ClassDeclarationX on ClassDeclaration {
-  /// Pick either Class(), Class._() or the first constructor found, in that order.
-  ConstructorDeclaration? get copyWithTarget {
-    return constructors.fold<ConstructorDeclaration?>(null, (acc, ctor) {
-          if (ctor.name == null) return ctor;
-          if (ctor.name!.lexeme == '_') return acc ?? ctor;
-          return acc;
-        }) ??
-        constructors.firstOrNull;
+  PrimaryConstructorDeclaration? get primaryConstructor {
+    for (final child in childEntities) {
+      if (child is PrimaryConstructorDeclaration) {
+        return child;
+      }
+    }
+    return null;
   }
 
-  ConstructorDeclaration? get manualConstructor {
+  List<AstNode> get allConstructors {
+    return [
+      if (primaryConstructor case final primary?) primary,
+      ...constructors,
+    ];
+  }
+
+  /// Pick either Class(), Class._() or the first constructor found, in that order.
+  AstNode? get copyWithTarget {
+    final all = allConstructors;
+    return all.fold<AstNode?>(null, (acc, ctor) {
+          final ctorName = ctor.constructorNamePart;
+          if (ctorName == null) return ctor;
+          if (ctorName == '_') return acc ?? ctor;
+          return acc;
+        }) ??
+        all.firstOrNull;
+  }
+
+  AstNode? get manualConstructor {
+    final primary = primaryConstructor;
+    if (primary != null && primary.isManualCtor) {
+      return primary;
+    }
     return constructors.where((e) => e.isManualCtor).firstOrNull;
   }
 

--- a/packages/freezed/lib/src/models.dart
+++ b/packages/freezed/lib/src/models.dart
@@ -90,7 +90,8 @@ class DeepCloneableProperty {
     AstNode constructorNode,
     Freezed globalConfigs,
   ) sync* {
-    for (final parameterNode in constructorNode.constructorParameters.parameters) {
+    for (final parameterNode
+        in constructorNode.constructorParameters.parameters) {
       final type = parseTypeSource(parameterNode);
 
       final parameter = parameterNode.declaredFragment!.element;
@@ -177,11 +178,18 @@ class ConstructorDetails {
     ClassDeclaration declaration,
     AstNode constructor,
   ) {
-    final freezedCtors = declaration.allConstructors.where(
-      (e) => e is ConstructorDeclaration && e.factoryKeyword != null && e.redirectedConstructor != null,
-    ).cast<ConstructorDeclaration>();
+    final freezedCtors = declaration.allConstructors
+        .where(
+          (e) =>
+              e is ConstructorDeclaration &&
+              e.factoryKeyword != null &&
+              e.redirectedConstructor != null,
+        )
+        .cast<ConstructorDeclaration>();
 
-    if (((constructor is ConstructorDeclaration && constructor.factoryKeyword == null) || constructor is PrimaryConstructorDeclaration) &&
+    if (((constructor is ConstructorDeclaration &&
+                constructor.factoryKeyword == null) ||
+            constructor is PrimaryConstructorDeclaration) &&
         !constructor.isManualCtor &&
         freezedCtors.isNotEmpty) {
       throw InvalidGenerationSourceError(
@@ -255,8 +263,7 @@ When specifying fields in non-factory constructor then specifying factory constr
           continue;
         }
 
-        redirectedName =
-            constructor.redirectedConstructor?.type.name.lexeme;
+        redirectedName = constructor.redirectedConstructor?.type.name.lexeme;
 
         if (redirectedName == null) {
           _assertValidNormalConstructorUsage(declaration, constructor);
@@ -302,7 +309,9 @@ When specifying fields in non-factory constructor then specifying factory constr
 
       result.add(
         ConstructorDetails(
-          asserts: AssertAnnotation.parseAll(constructor.constructorElement).toList(),
+          asserts: AssertAnnotation.parseAll(
+            constructor.constructorElement,
+          ).toList(),
           isSynthetic: !isEjected,
           name: constructor.constructorNamePart ?? '',
           unionValue: constructor.constructorElement.unionValue(
@@ -316,20 +325,21 @@ When specifying fields in non-factory constructor then specifying factory constr
           properties: allProperties,
           decorators: constructor is ConstructorDeclaration
               ? constructor.metadata
-                  .where((Annotation element) {
-                    final elementSourceUri =
-                        element.element?.baseElement.library?.uri;
+                    .where((Annotation element) {
+                      final elementSourceUri =
+                          element.element?.baseElement.library?.uri;
 
-                    final isFreezedAnnotation =
-                        elementSourceUri != null &&
-                        elementSourceUri.scheme == 'package' &&
-                        elementSourceUri.pathSegments.isNotEmpty &&
-                        elementSourceUri.pathSegments.first == 'freezed_annotation';
+                      final isFreezedAnnotation =
+                          elementSourceUri != null &&
+                          elementSourceUri.scheme == 'package' &&
+                          elementSourceUri.pathSegments.isNotEmpty &&
+                          elementSourceUri.pathSegments.first ==
+                              'freezed_annotation';
 
-                    return !isFreezedAnnotation;
-                  })
-                  .map((Annotation e) => e.toSource())
-                  .toList()
+                      return !isFreezedAnnotation;
+                    })
+                    .map((Annotation e) => e.toSource())
+                    .toList()
               : const <String>[],
           withDecorators: WithAnnotation.parseAll(
             constructor.constructorElement,
@@ -337,9 +347,7 @@ When specifying fields in non-factory constructor then specifying factory constr
           implementsDecorators: ImplementsAnnotation.parseAll(
             constructor.constructorElement,
           ).toSet().toList(),
-          isDefault: isDefaultConstructor(
-            constructor.constructorElement,
-          ),
+          isDefault: isDefaultConstructor(constructor.constructorElement),
           hasJsonSerializable:
               constructor.constructorElement.hasJsonSerializable,
           isFallback: constructor.constructorElement.isFallbackUnion(
@@ -478,9 +486,7 @@ class WithAnnotation {
 class AssertAnnotation {
   AssertAnnotation({required this.code, required this.message});
 
-  static Iterable<AssertAnnotation> parseAll(
-    ConstructorElement element,
-  ) sync* {
+  static Iterable<AssertAnnotation> parseAll(ConstructorElement element) sync* {
     for (final meta in const TypeChecker.typeNamed(
       Assert,
       inPackage: 'freezed_annotation',
@@ -537,9 +543,8 @@ class Class {
     required this.superCall,
     required this.properties,
     required this.copyWithTarget,
-    required ClassDeclaration node,
-  }) : _node = node,
-       assert(constructors.isNotEmpty);
+    required this._node,
+  }) : assert(constructors.isNotEmpty);
 
   final String name;
   final ClassConfig options;
@@ -645,7 +650,9 @@ To fix, either:
             name: copyWithTarget.constructorNamePart,
             parameters: ParametersTemplate.fromParameterList(
               // Only include parameters that are cloneable
-              copyWithTarget.constructorParameters.parameters.where((FormalParameter e) {
+              copyWithTarget.constructorParameters.parameters.where((
+                FormalParameter e,
+              ) {
                 return properties.cloneableProperties
                     .map((p) => p.name)
                     .contains(e.name!.lexeme);
@@ -656,18 +663,25 @@ To fix, either:
 
     final superCall = privateCtor == null
         ? (declaration.primaryConstructor != null
-            ? ConstructorInvocation(
-                name: declaration.primaryConstructor!.constructorNamePart ?? '',
-                positional: declaration.primaryConstructor!.constructorParameters.parameters
-                    .where((FormalParameter e) => e.isPositional)
-                    .map((FormalParameter e) => e.name!.lexeme)
-                    .toList(),
-                named: declaration.primaryConstructor!.constructorParameters.parameters
-                    .where((FormalParameter e) => e.isNamed)
-                    .map((FormalParameter e) => e.name!.lexeme)
-                    .toList(),
-              )
-            : null)
+              ? ConstructorInvocation(
+                  name:
+                      declaration.primaryConstructor!.constructorNamePart ?? '',
+                  positional: declaration
+                      .primaryConstructor!
+                      .constructorParameters
+                      .parameters
+                      .where((FormalParameter e) => e.isPositional)
+                      .map((FormalParameter e) => e.name!.lexeme)
+                      .toList(),
+                  named: declaration
+                      .primaryConstructor!
+                      .constructorParameters
+                      .parameters
+                      .where((FormalParameter e) => e.isNamed)
+                      .map((FormalParameter e) => e.name!.lexeme)
+                      .toList(),
+                )
+              : null)
         : ConstructorInvocation(
             name: privateCtor.constructorNamePart ?? '',
             positional: privateCtor.constructorParameters.parameters
@@ -787,7 +801,8 @@ To fix, either:
     final targetConstructor = declaration.copyWithTarget;
     if (targetConstructor == null) return;
 
-    for (final parameter in targetConstructor.constructorParameters.parameters) {
+    for (final parameter
+        in targetConstructor.constructorParameters.parameters) {
       yield Property.fromFormalParameter(
         parameter,
         addImplicitFinal: configs.annotation.addImplicitFinal,
@@ -1381,7 +1396,9 @@ extension AstNodeConstructorX on AstNode {
     final className = classElement.enclosingElement.name;
     final constructorName = self.constructorNamePart;
 
-    return constructorName == null ? '$className$generics' : '$className$generics.$constructorName';
+    return constructorName == null
+        ? '$className$generics'
+        : '$className$generics.$constructorName';
   }
 
   String get constructorEscapedName {

--- a/packages/freezed/lib/src/parse_generator.dart
+++ b/packages/freezed/lib/src/parse_generator.dart
@@ -4,6 +4,7 @@ import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer_buffer/analyzer_buffer.dart';
 import 'package:build/build.dart';
 import 'package:collection/collection.dart';
 import 'package:source_gen/source_gen.dart';
@@ -25,7 +26,7 @@ abstract class ParserGenerator<AnnotationT>
       ),
     ).cast<CompilationUnit>().toList();
 
-    final values = StringBuffer();
+    final values = AnalyzerBuffer.part(oldLibrary.element);
     final datas = <AnnotationMeta>[];
 
     for (final unit in units) {
@@ -44,7 +45,7 @@ abstract class ParserGenerator<AnnotationT>
     }
 
     for (final value in generateAll(units, datas)) {
-      values.writeln(value);
+      values.write(value.toString());
     }
 
     return values.toString();

--- a/packages/freezed/lib/src/parse_generator.dart
+++ b/packages/freezed/lib/src/parse_generator.dart
@@ -45,7 +45,9 @@ abstract class ParserGenerator<AnnotationT>
     }
 
     for (final value in generateAll(units, datas)) {
-      values.write(value.toString());
+      values
+        ..write(value.toString())
+        ..write('\n');
     }
 
     return values.toString();

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -203,7 +203,9 @@ ${copyWith?.concreteImpl(constructor.parameters) ?? ''}
           '$p: $p',
     ].join(', ');
 
-    return 'super._($params)';
+    final name = superCall.name;
+    final superCtorName = name == null || name.isEmpty ? '' : '.$name';
+    return 'super$superCtorName($params)';
   }
 
   String get _concreteSuper {

--- a/packages/freezed/lib/src/templates/parameter_template.dart
+++ b/packages/freezed/lib/src/templates/parameter_template.dart
@@ -71,7 +71,7 @@ class ParametersTemplate {
 
       final value = Parameter(
         name: e.name!,
-        defaultValueSource: e.defaultValue,
+        defaultValueSource: p.defaultValueSource ?? e.defaultValue,
         isRequired: e.isRequiredNamed,
         isFinal: addImplicitFinal || e.isFinal,
         type: e.type,
@@ -402,5 +402,24 @@ class CallbackParameter extends Parameter {
     }
 
     return '$res  $name';
+  }
+}
+
+extension FormalParameterDefaultX on FormalParameter {
+  String? get defaultValueSource {
+    final self = this;
+    try {
+      final dynamic d = self;
+      if (d.defaultValue != null) {
+        return d.defaultValue.toSource() as String?;
+      }
+    } catch (_) {}
+    try {
+      final dynamic d = self;
+      if (d.defaultClause != null) {
+        return d.defaultClause.value?.toSource() as String?;
+      }
+    } catch (_) {}
+    return null;
   }
 }

--- a/packages/freezed/lib/src/templates/parameter_template.dart
+++ b/packages/freezed/lib/src/templates/parameter_template.dart
@@ -271,9 +271,6 @@ class Parameter {
   @override
   String toString() {
     var res = ' $typeDisplayString $name';
-    if (isFinal) {
-      res = 'final $res';
-    }
     if (isRequired) {
       res = 'required $res';
     }

--- a/packages/freezed/lib/src/templates/parameter_template.dart
+++ b/packages/freezed/lib/src/templates/parameter_template.dart
@@ -1,6 +1,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer_buffer/analyzer_buffer.dart';
 import 'package:collection/collection.dart';
 import 'package:freezed/src/ast.dart';
 import 'package:freezed/src/templates/concrete_template.dart';
@@ -71,7 +72,9 @@ class ParametersTemplate {
 
       final value = Parameter(
         name: e.name!,
-        defaultValueSource: p.defaultValueSource ?? e.defaultValue,
+        defaultValueSource:
+            p.defaultClause?.value.computeConstantValue()?.value?.toCode() ??
+            e.defaultValue,
         isRequired: e.isRequiredNamed,
         isFinal: addImplicitFinal || e.isFinal,
         type: e.type,
@@ -399,24 +402,5 @@ class CallbackParameter extends Parameter {
     }
 
     return '$res  $name';
-  }
-}
-
-extension FormalParameterDefaultX on FormalParameter {
-  String? get defaultValueSource {
-    final self = this;
-    try {
-      final dynamic d = self;
-      if (d.defaultValue != null) {
-        return d.defaultValue.toSource() as String?;
-      }
-    } catch (_) {}
-    try {
-      final dynamic d = self;
-      if (d.defaultClause != null) {
-        return d.defaultClause.value?.toSource() as String?;
-      }
-    } catch (_) {}
-    return null;
   }
 }

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -7,7 +7,7 @@ repository: https://github.com/rrousselGit/freezed
 issue_tracker: https://github.com/rrousselGit/freezed/issues
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   analyzer: ^13.0.0
@@ -20,6 +20,7 @@ dependencies:
   json_annotation: ^4.8.0
   dart_style: ^3.0.0
   pub_semver: ^2.2.0
+  analyzer_buffer: ^0.3.3
 
 dev_dependencies:
   json_serializable: ^6.10.0

--- a/packages/freezed/test/data_test.dart
+++ b/packages/freezed/test/data_test.dart
@@ -22,21 +22,23 @@ import 'data.dart';
 
 void main() {
   final value = Data(0, 1);
+  value.a = 42;
 }
 '''),
       completes,
     );
 
-    await expectLater(
-      compile(r'''
-import 'data.dart';
+  // TODO no-longer doable since Dart 3.13
+//     await expectLater(
+//       compile(r'''
+// import 'data.dart';
 
-void main() {
-  final value = Data(0, 1);
-  value.b = 42;
-}
-'''),
-      throwsCompileError,
-    );
+// void main() {
+//   final value = Data(0, 1);
+//   value.b = 42;
+// }
+// '''),
+//       throwsCompileError,
+//     );
   });
 }

--- a/packages/freezed/test/data_test.dart
+++ b/packages/freezed/test/data_test.dart
@@ -28,17 +28,17 @@ void main() {
       completes,
     );
 
-  // TODO no-longer doable since Dart 3.13
-//     await expectLater(
-//       compile(r'''
-// import 'data.dart';
+    // TODO no-longer doable since Dart 3.13
+    //     await expectLater(
+    //       compile(r'''
+    // import 'data.dart';
 
-// void main() {
-//   final value = Data(0, 1);
-//   value.b = 42;
-// }
-// '''),
-//       throwsCompileError,
-//     );
+    // void main() {
+    //   final value = Data(0, 1);
+    //   value.b = 42;
+    // }
+    // '''),
+    //       throwsCompileError,
+    //     );
   });
 }

--- a/packages/freezed/test/integration/data.dart
+++ b/packages/freezed/test/integration/data.dart
@@ -4,5 +4,5 @@ part 'data.freezed.dart';
 
 @unfreezed
 abstract class Data with _$Data {
-  factory Data(int a, final int b) = _Data;
+  factory Data(int a, int b) = _Data;
 }

--- a/packages/freezed/test/integration/multiple_constructors.dart
+++ b/packages/freezed/test/integration/multiple_constructors.dart
@@ -67,21 +67,6 @@ abstract class Subclass with _$Subclass {
 }
 
 @unfreezed
-abstract class UnfreezedImmutableUnion with _$UnfreezedImmutableUnion {
-  factory UnfreezedImmutableUnion(final String a) =
-      DirectUnfreezedImmutableUnion;
-  factory UnfreezedImmutableUnion.named(String a) =
-      DirectUnfreezedImmutableUnionNamed;
-}
-
-@unfreezed
-abstract class UnfreezedImmutableUnion2 with _$UnfreezedImmutableUnion2 {
-  factory UnfreezedImmutableUnion2(String a) = DirectUnfreezedImmutableUnion2;
-  factory UnfreezedImmutableUnion2.named(final String a) =
-      DirectUnfreezedImmutableUnionNamed2;
-}
-
-@unfreezed
 abstract class MutableUnion with _$MutableUnion {
   factory MutableUnion(String a, int b) = MutableUnion0;
   factory MutableUnion.named(String a, int c) = MutableUnion1;

--- a/packages/freezed/test/integration/primary_constructor.dart
+++ b/packages/freezed/test/integration/primary_constructor.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'primary_constructor.freezed.dart';
+
+@freezed
+class Example(@override final int field, {@override final int another = 0})
+    with _$Example {}
+
+@freezed
+abstract class ExampleWithPrivate._() with _$ExampleWithPrivate {
+  factory ExampleWithPrivate(int field, {int? another}) = _ExampleWithPrivate;
+
+  int get getter => field * 2;
+}

--- a/packages/freezed/test/multiple_constructors_test.dart
+++ b/packages/freezed/test/multiple_constructors_test.dart
@@ -201,38 +201,6 @@ void main() {
       downcast.a = 'b';
     });
 
-    test(
-      'cannot mutate shared property if one of the union has an immutable variant',
-      () async {
-        DirectUnfreezedImmutableUnionNamed('a').a = '';
-        DirectUnfreezedImmutableUnion2('a').a = '';
-
-        await expectLater(
-          compile(r'''
-import 'multiple_constructors.dart';
-
-void main() {
-  UnfreezedImmutableUnion('').a;
-  UnfreezedImmutableUnion2('').a;
-}
-'''),
-          completes,
-        );
-
-        await expectLater(
-          compile(r'''
-import 'multiple_constructors.dart';
-
-void main() {
-  UnfreezedImmutableUnion('').a = '';
-  UnfreezedImmutableUnion2('').a = '';
-}
-'''),
-          throwsCompileError,
-        );
-      },
-    );
-
     test('when works on unnamed constructors', () {
       expect(RequiredParams(a: 'a').when((a) => 21, second: (_) => 42), 21);
       expect(

--- a/packages/freezed/test/primary_constructor_test.dart
+++ b/packages/freezed/test/primary_constructor_test.dart
@@ -4,33 +4,39 @@ import 'integration/primary_constructor.dart';
 
 void main() {
   group('Primary Constructor support', () {
-    test('standard primary constructor compiles and has copyWith / equality / toString', () {
-      final a = Example(42, another: 10);
-      expect(a.field, 42);
-      expect(a.another, 10);
-      
-      final b = a.copyWith(field: 100);
-      expect(b.field, 100);
-      expect(b.another, 10);
+    test(
+      'standard primary constructor compiles and has copyWith / equality / toString',
+      () {
+        final a = Example(42, another: 10);
+        expect(a.field, 42);
+        expect(a.another, 10);
 
-      expect(a, isNot(equals(b)));
-      expect(a, equals(Example(42, another: 10)));
-      expect(a.toString(), 'Example(field: 42, another: 10)');
-    });
+        final b = a.copyWith(field: 100);
+        expect(b.field, 100);
+        expect(b.another, 10);
 
-    test('private primary constructor with body factory redirects compiles and works', () {
-      final a = ExampleWithPrivate(10, another: 20);
-      expect(a.field, 10);
-      expect(a.another, 20);
-      expect(a.getter, 20);
+        expect(a, isNot(equals(b)));
+        expect(a, equals(Example(42, another: 10)));
+        expect(a.toString(), 'Example(field: 42, another: 10)');
+      },
+    );
 
-      final b = a.copyWith(another: null);
-      expect(b.field, 10);
-      expect(b.another, isNull);
+    test(
+      'private primary constructor with body factory redirects compiles and works',
+      () {
+        final a = ExampleWithPrivate(10, another: 20);
+        expect(a.field, 10);
+        expect(a.another, 20);
+        expect(a.getter, 20);
 
-      expect(a, isNot(equals(b)));
-      expect(a, equals(ExampleWithPrivate(10, another: 20)));
-      expect(a.toString(), 'ExampleWithPrivate(field: 10, another: 20)');
-    });
+        final b = a.copyWith(another: null);
+        expect(b.field, 10);
+        expect(b.another, isNull);
+
+        expect(a, isNot(equals(b)));
+        expect(a, equals(ExampleWithPrivate(10, another: 20)));
+        expect(a.toString(), 'ExampleWithPrivate(field: 10, another: 20)');
+      },
+    );
   });
 }

--- a/packages/freezed/test/primary_constructor_test.dart
+++ b/packages/freezed/test/primary_constructor_test.dart
@@ -1,0 +1,36 @@
+import 'package:test/test.dart';
+
+import 'integration/primary_constructor.dart';
+
+void main() {
+  group('Primary Constructor support', () {
+    test('standard primary constructor compiles and has copyWith / equality / toString', () {
+      final a = Example(42, another: 10);
+      expect(a.field, 42);
+      expect(a.another, 10);
+      
+      final b = a.copyWith(field: 100);
+      expect(b.field, 100);
+      expect(b.another, 10);
+
+      expect(a, isNot(equals(b)));
+      expect(a, equals(Example(42, another: 10)));
+      expect(a.toString(), 'Example(field: 42, another: 10)');
+    });
+
+    test('private primary constructor with body factory redirects compiles and works', () {
+      final a = ExampleWithPrivate(10, another: 20);
+      expect(a.field, 10);
+      expect(a.another, 20);
+      expect(a.getter, 20);
+
+      final b = a.copyWith(another: null);
+      expect(b.field, 10);
+      expect(b.another, isNull);
+
+      expect(a, isNot(equals(b)));
+      expect(a, equals(ExampleWithPrivate(10, another: 20)));
+      expect(a.toString(), 'ExampleWithPrivate(field: 10, another: 20)');
+    });
+  });
+}

--- a/resources/translations/ja_JP/README.md
+++ b/resources/translations/ja_JP/README.md
@@ -201,7 +201,6 @@ abstract class Person with _$Person {
   factory Person({
     required String firstName,
     required String lastName,
-    required final int age,
   }) = _Person;
 
   factory Person.fromJson(Map<String, Object?> json)
@@ -215,20 +214,19 @@ abstract class Person with _$Person {
 
   ```dart
   void main() {
-    var person = Person(firstName: 'John', lastName: 'Smith', age: 42);
+    var person = Person(firstName: 'John', lastName: 'Smith');
 
     person.firstName = 'Mona';
     person.lastName = 'Lisa';
   }
   ```
 
-- `age`はイミュータブルのままです。なぜなら、プロパティを`final`として明記しているからです。
 - `Person`は==とhashCodeの実装がなくなりました。
 
   ```dart
   void main() {
-    var john = Person(firstName: 'John', lastName: 'Smith', age: 42);
-    var john2 = Person(firstName: 'John', lastName: 'Smith', age: 42);
+    var john = Person(firstName: 'John', lastName: 'Smith');
+    var john2 = Person(firstName: 'John', lastName: 'Smith');
 
     print(john == john2); // false
   }

--- a/resources/translations/ko_KR/README.md
+++ b/resources/translations/ko_KR/README.md
@@ -341,7 +341,6 @@ abstract class Person with _$Person {
   factory Person({
     required String firstName,
     required String lastName,
-    required final int age,
   }) = _Person;
 
   factory Person.fromJson(Map<String, Object?> json) => _$PersonFromJson(json);
@@ -354,20 +353,19 @@ abstract class Person with _$Person {
 
   ```dart
   void main() {
-    var person = Person(firstName: 'John', lastName: 'Smith', age: 42);
+    var person = Person(firstName: 'John', lastName: 'Smith');
 
     person.firstName = 'Mona';
     person.lastName = 'Lisa';
   }
   ```
 
-- `age`는 프로퍼티를 명시적으로 `final`로 표시했기 때문에 여전히 불변입니다.
 - `Person`은 더 이상 사용자 정의 ==/hashCode 구현을 가지지 않습니다:
 
   ```dart
   void main() {
-    var john = Person(firstName: 'John', lastName: 'Smith', age: 42);
-    var john2 = Person(firstName: 'John', lastName: 'Smith', age: 42);
+    var john = Person(firstName: 'John', lastName: 'Smith');
+    var john2 = Person(firstName: 'John', lastName: 'Smith');
 
     print(john == john2); // false
   }

--- a/resources/translations/vi_VN/README.md
+++ b/resources/translations/vi_VN/README.md
@@ -200,7 +200,6 @@ class Person with _$Person {
   factory Person({
     required String firstName,
     required String lastName,
-    required final int age,
   }) = _Person;
 
   factory Person.fromJson(Map<String, Object?> json)
@@ -214,20 +213,19 @@ class Person with _$Person {
 
   ```dart
   void main() {
-    var person = Person(firstName: 'John', lastName: 'Smith', age: 42);
+    var person = Person(firstName: 'John', lastName: 'Smith');
 
     person.firstName = 'Mona';
     person.lastName = 'Lisa';
   }
   ```
 
-- `age` vẫn là bất biến vì thuộc tính này được khai báo là `final`.
 - `Person` không còn triển khai `==` và `hashCode`.
 
   ```dart
   void main() {
-    var john = Person(firstName: 'John', lastName: 'Smith', age: 42);
-    var john2 = Person(firstName: 'John', lastName: 'Smith', age: 42);
+    var john = Person(firstName: 'John', lastName: 'Smith');
+    var john2 = Person(firstName: 'John', lastName: 'Smith');
 
     print(john == john2); // false
   }

--- a/resources/translations/zh_CN/README.md
+++ b/resources/translations/zh_CN/README.md
@@ -197,7 +197,6 @@ abstract class Person with _$Person {
   factory Person({
     required String firstName,
     required String lastName,
-    required final int age,
   }) = _Person;
 
   factory Person.fromJson(Map<String, Object?> json)
@@ -211,20 +210,19 @@ abstract class Person with _$Person {
 
   ```dart
   void main() {
-    var person = Person(firstName: 'John', lastName: 'Smith', age: 42);
+    var person = Person(firstName: 'John', lastName: 'Smith');
 
     person.firstName = 'Mona';
     person.lastName = 'Lisa';
   }
   ```
 
-- `age` 仍然是不可变的，因为我们明确地将属性标记为 `final`。
 - `Person` 不再有自定义的 `==` `hashCode` 实现：
 
   ```dart
   void main() {
-    var john = Person(firstName: 'John', lastName: 'Smith', age: 42);
-    var john2 = Person(firstName: 'John', lastName: 'Smith', age: 42);
+    var john = Person(firstName: 'John', lastName: 'Smith');
+    var john2 = Person(firstName: 'John', lastName: 'Smith');
 
     print(john == john2); // false
   }


### PR DESCRIPTION
fixes #1352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for primary constructors.

* **Breaking Changes**
  * `final` is no longer supported in constructor parameters (may require code updates).

* **Documentation**
  * Updated README and translations to reflect constructor parameter changes and mutability examples.

* **Tests**
  * Added tests and integration fixtures verifying primary constructor behavior.

* **Chores**
  * Updated SDK constraint and CI/formatting to enable primary-constructors experiment; added analyzer buffering dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->