### PR TITLE
fix: use `analyzer_buffer` to correctly resolve record types like `(i…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,9 +73,9 @@ jobs:
       - name: Run tests
         run: |
           if grep -q "name: freezed_example" "pubspec.yaml"; then
-            flutter test
+            flutter test --enable-experiment=primary-constructors
           else
-            dart test
+            dart test --enable-experiment=primary-constructors
           fi
         working-directory: ${{ matrix.package }}
 

--- a/packages/freezed/CHANGELOG.md
+++ b/packages/freezed/CHANGELOG.md
@@ -1,8 +1,12 @@
+## Unreleased build
+
+- Fix `(int,)` records incorrectly generated
+
 ## 4.0.0-dev.1 - 2026-06-11
 
 - Support analyzer 13.0
 - Support primary constructors
-- *Breaking*: No-longer support `final` keyword inside constructor parameter. This is due to Dart 3.13 no-longer allowing this syntax.
+- _Breaking_: No-longer support `final` keyword inside constructor parameter. This is due to Dart 3.13 no-longer allowing this syntax.
   This prevents `@unfreezed` from defining immutable fields.
 
 ## 3.2.6-dev.1 - 2026-04-23
@@ -1013,4 +1017,3 @@ Add generic support
 ## 0.0.0
 
 Initial release
-

--- a/packages/freezed/lib/builder.dart
+++ b/packages/freezed/lib/builder.dart
@@ -20,7 +20,8 @@ Builder freezed(BuilderOptions options) {
     header: '''
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // coverage:ignore-file
-// ignore_for_file: type=lint, type=warning
+// ignore_for_file: type=lint, type=warning, deprecated_member_use, deprecated_member_use_from_same_package
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
     ''',
     options: options,
   );

--- a/packages/freezed/lib/src/models.dart
+++ b/packages/freezed/lib/src/models.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer_buffer/analyzer_buffer.dart';
 import 'package:collection/collection.dart';
 import 'package:freezed/src/ast.dart';
 import 'package:freezed/src/freezed_generator.dart';
@@ -912,7 +913,11 @@ To fix, either:
         // Only a single constructor and no field
         case [null, final fieldType?]:
           type = fieldType.type?.type ?? typeProvider.dynamicType;
-          typeString = fieldType.type?.toSource() ?? type.toString();
+          try {
+            typeString = type.toCode();
+          } on InvalidTypeException {
+            typeString = fieldType.type?.toSource() ?? type.toString();
+          }
           doc = fieldType.doc;
           isFinal = fieldType.isFinal;
           decorators = fieldType.decorators;
@@ -933,7 +938,11 @@ To fix, either:
                 .first;
             // All constructors use the exact same type. No need to check lower-bounds,
             // and we can paste the type in the generated source directly.
-            typeString = typeSources.single ?? type.toString();
+            try {
+              typeString = type.toCode();
+            } on InvalidTypeException {
+              typeString = typeSources.single ?? type.toString();
+            }
             isFinal = fields.any((e) => e!.isFinal);
 
             break;

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer_buffer/analyzer_buffer.dart';
 import 'package:freezed/src/freezed_generator.dart';
 import 'package:freezed/src/models.dart';
 import 'package:freezed/src/templates/properties.dart';
@@ -554,12 +555,14 @@ extension DefaultValue on FormalParameterElement {
 }
 
 String parseTypeSource(FormalParameter p) {
-  switch (p) {
-    case FormalParameter(:final type?):
-      return type.toSource();
-    case _:
-      break;
+  try {
+    return p.declaredFragment!.element.type.toCode();
+  } on InvalidTypeException {
+    switch (p) {
+      case FormalParameter(:final type?):
+        return type.toSource();
+      case _:
+        return p.declaredFragment!.element.type.getDisplayString();
+    }
   }
-
-  return p.declaredFragment!.element.type.getDisplayString();
 }

--- a/packages/freezed/lib/src/tools/type.dart
+++ b/packages/freezed/lib/src/tools/type.dart
@@ -1,6 +1,7 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer_buffer/analyzer_buffer.dart';
 import 'package:collection/collection.dart';
 
 import 'imports.dart';
@@ -40,6 +41,12 @@ Element? _getElementForType(DartType type) {
 
 /// Renders a type based on its string + potential import alias
 String resolveFullTypeStringFrom(LibraryElement originLibrary, DartType type) {
+  try {
+    return type.toCode();
+  } on InvalidTypeException {
+    // continue
+  }
+
   final owner = originLibrary.firstFragment.prefixes.firstWhereOrNull((e) {
     return e.imports.any((l) {
       return l.importedLibrary!.anyTransitiveExport((library) {

--- a/packages/freezed/test/integration/single_class_constructor.dart
+++ b/packages/freezed/test/integration/single_class_constructor.dart
@@ -9,6 +9,14 @@ part 'single_class_constructor.freezed.dart';
 
 typedef StringAlias = String;
 
+// https://github.com/rrousselGit/freezed/issues/1356
+@freezed
+abstract class SingleRecordTest with _$SingleRecordTest {
+  factory SingleRecordTest({
+    required (int,) singleRecord,
+  }) = _SingleRecordTest;
+}
+
 // https://github.com/rrousselGit/freezed/issues/1204
 @freezed
 sealed class Regression1204 with _$Regression1204 {

--- a/packages/freezed/test/integration/single_class_constructor.dart
+++ b/packages/freezed/test/integration/single_class_constructor.dart
@@ -12,9 +12,7 @@ typedef StringAlias = String;
 // https://github.com/rrousselGit/freezed/issues/1356
 @freezed
 abstract class SingleRecordTest with _$SingleRecordTest {
-  factory SingleRecordTest({
-    required (int,) singleRecord,
-  }) = _SingleRecordTest;
+  factory SingleRecordTest({required (int,) singleRecord}) = _SingleRecordTest;
 }
 
 // https://github.com/rrousselGit/freezed/issues/1204


### PR DESCRIPTION
…nt,)` during code generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect generation for single-element record types (e.g., (int,)).
* **Tests**
  * Added an integration test covering single-element record handling.
* **Chores**
  * CI updated to enable a language experiment during test runs.
  * Expanded generated-code header to include additional lint ignores.
* **Documentation**
  * Added an “Unreleased” changelog entry noting the record-type fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->