### PR TITLE
fix: correct immutable collection handling in == and copyWith for non-factory constructors

### DIFF
--- a/packages/freezed/CHANGELOG.md
+++ b/packages/freezed/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased build
+
+- Fix `==`/`copyWith` when immutable collections are enabled yet non-factory constructors are used.
+
 ## 4.0.0-dev.2 - 2026-06-13
 
 - Fix `(int,)` records incorrectly generated
@@ -1017,4 +1021,3 @@ Add generic support
 ## 0.0.0
 
 Initial release
-

--- a/packages/freezed/lib/src/templates/concrete_template.dart
+++ b/packages/freezed/lib/src/templates/concrete_template.dart
@@ -441,6 +441,7 @@ String operatorEqualMethod(
 
       if (data.options.asUnmodifiableCollections &&
           source == Source.syntheticClass &&
+          p.isSynthetic &&
           p.type.isPossiblyDartCollection &&
           (p.type.isDartCoreList ||
               p.type.isDartCoreMap ||
@@ -484,6 +485,7 @@ String hashCodeMethod(
       if (property.type.isPossiblyDartCollection)
         if (data.options.asUnmodifiableCollections &&
             source == Source.syntheticClass &&
+            property.isSynthetic &&
             (property.type.isDartCoreList ||
                 property.type.isDartCoreMap ||
                 property.type.isDartCoreSet))

--- a/packages/freezed/lib/src/templates/copy_with.dart
+++ b/packages/freezed/lib/src/templates/copy_with.dart
@@ -282,6 +282,7 @@ $s''';
     }) {
       var propertyName = to.name;
       if (_canAccessRawCollection &&
+          propertyGetterForCopyWithParameter.isSynthetic &&
           (to.type.isDartCoreList ||
               to.type.isDartCoreMap ||
               to.type.isDartCoreSet) &&

--- a/packages/freezed/test/integration/single_class_constructor.dart
+++ b/packages/freezed/test/integration/single_class_constructor.dart
@@ -12,9 +12,8 @@ typedef StringAlias = String;
 // Regression for https://github.com/rrousselGit/freezed/issues/1358
 @freezed
 abstract class DeviceInfo with _$DeviceInfo {
-  const DeviceInfo._({
-    Map<String, dynamic>? metadata,
-  }) : metadata = metadata ?? const {};
+  const DeviceInfo._({Map<String, dynamic>? metadata})
+    : metadata = metadata ?? const {};
 
   const factory DeviceInfo({
     required String platform,

--- a/packages/freezed/test/integration/single_class_constructor.dart
+++ b/packages/freezed/test/integration/single_class_constructor.dart
@@ -9,6 +9,25 @@ part 'single_class_constructor.freezed.dart';
 
 typedef StringAlias = String;
 
+// Regression for https://github.com/rrousselGit/freezed/issues/1358
+@freezed
+abstract class DeviceInfo with _$DeviceInfo {
+  const DeviceInfo._({
+    Map<String, dynamic>? metadata,
+  }) : metadata = metadata ?? const {};
+
+  const factory DeviceInfo({
+    required String platform,
+    required String version,
+    required int totalRam,
+    Map<String, dynamic>? metadata,
+  }) = _DeviceInfo;
+
+  @override
+  // Raw additional details of the device.
+  final Map<String, dynamic> metadata;
+}
+
 // https://github.com/rrousselGit/freezed/issues/1356
 @freezed
 abstract class SingleRecordTest with _$SingleRecordTest {


### PR DESCRIPTION
fixes #1358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed equality/hashCode and copyWith generation for immutable collections so behavior is correct when non-factory constructors are present.

* **Tests**
  * Added a regression test covering immutable collection handling with mixed constructor scenarios.

* **Documentation**
  * Updated changelog entry noting the fix for equality and copyWith with immutable collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->