### PR TITLE
Allow analyzer 14

### DIFF
--- a/packages/freezed/CHANGELOG.md
+++ b/packages/freezed/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased patch
 
 - Removed the need for `@overrides` in class fields and primary constructors.
+- Support analyzer 14.0.0
 
 ## 4.0.0 - 2026-08-22
 

--- a/packages/freezed/pubspec.yaml
+++ b/packages/freezed/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.13.0 <4.0.0"
 
 dependencies:
-  analyzer: ^13.0.0
+  analyzer: ">=13.0.0 <15.0.0"
   build: ">=3.0.0 <5.0.0"
   build_config: ^1.1.0
   collection: ^1.15.0


### PR DESCRIPTION
Widens `freezed`'s `analyzer` constraint to `>=13.0.0 <15.0.0`, keeping the range as permissive as possible (13.x stays supported).

### Blocked on

- rrousselGit/analyzer_buffer#8
- rrousselGit/expect_error#25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for analyzer 14.0.0.
* **Documentation**
  * Updated the changelog to document analyzer compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->